### PR TITLE
fix(mashlib): CDN race condition with script.onload pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ test-nostr-acl.js
 test-dpop-flow.js
 cth-config/
 test-data-idp-accounts/
+
+# Local mashlib build (for development)
+src/mashlib-local/

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npm run benchmark
 
 ## Features
 
-### Implemented (v0.0.17)
+### Implemented (v0.0.23)
 
 - **LDP CRUD Operations** - GET, PUT, POST, DELETE, HEAD
 - **N3 Patch** - Solid's native patch format for RDF updates
@@ -66,11 +66,13 @@ npm run benchmark
 - **Container Management** - Create, list, and manage containers
 - **Multi-user Pods** - Path-based (`/alice/`) or subdomain-based (`alice.example.com`)
 - **Subdomain Mode** - XSS protection via origin isolation
-- **Mashlib Data Browser** - Optional SolidOS UI for browsing RDF resources
+- **Mashlib Data Browser** - Optional SolidOS UI (CDN or local hosting)
 - **WebID Profiles** - JSON-LD structured data in HTML at pod root
 - **Web Access Control (WAC)** - `.acl` file-based authorization
 - **Solid-OIDC Identity Provider** - Built-in IdP with DPoP, dynamic registration
 - **Solid-OIDC Resource Server** - Accept DPoP-bound access tokens from external IdPs
+- **NSS-style Registration** - Username/password auth compatible with Solid apps
+- **Nostr Authentication** - NIP-98 HTTP Auth with Schnorr signatures
 - **Simple Auth Tokens** - Built-in token authentication for development
 - **Content Negotiation** - Optional Turtle <-> JSON-LD conversion
 - **CORS Support** - Full cross-origin resource sharing

--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ jss --help             # Show help
 | `--idp-issuer <url>` | IdP issuer URL | (auto) |
 | `--subdomains` | Enable subdomain-based pods | false |
 | `--base-domain <domain>` | Base domain for subdomains | - |
-| `--mashlib` | Enable Mashlib data browser | false |
-| `--mashlib-version <ver>` | Mashlib version | 2.0.0 |
+| `--mashlib` | Enable Mashlib (local mode) | false |
+| `--mashlib-cdn` | Enable Mashlib (CDN mode) | false |
+| `--mashlib-version <ver>` | Mashlib CDN version | 2.0.0 |
 | `-q, --quiet` | Suppress logs | false |
 
 ### Environment Variables
@@ -407,24 +408,35 @@ createServer({
   notifications: false, // Enable WebSocket notifications (default: false)
   subdomains: false,   // Enable subdomain-based pods (default: false)
   baseDomain: null,    // Base domain for subdomains (e.g., "example.com")
-  mashlib: false,      // Enable Mashlib data browser (default: false)
-  mashlibVersion: '2.0.0', // Mashlib version to use
+  mashlib: false,      // Enable Mashlib data browser - local mode (default: false)
+  mashlibCdn: false,   // Enable Mashlib data browser - CDN mode (default: false)
+  mashlibVersion: '2.0.0', // Mashlib version for CDN mode
 });
 ```
 
 ### Mashlib Data Browser
 
-Enable the [SolidOS Mashlib](https://github.com/SolidOS/mashlib) data browser for RDF resources:
+Enable the [SolidOS Mashlib](https://github.com/SolidOS/mashlib) data browser for RDF resources. Two modes are available:
 
+**CDN Mode** (recommended for getting started):
+```bash
+jss start --mashlib-cdn --conneg
+```
+Loads mashlib from unpkg.com CDN. Zero footprint - no local files needed.
+
+**Local Mode** (for production/offline):
 ```bash
 jss start --mashlib --conneg
 ```
-
-When enabled, requesting an RDF resource with `Accept: text/html` returns an interactive data browser UI instead of raw data. Mashlib is loaded from the unpkg CDN.
+Serves mashlib from `src/mashlib-local/dist/`. Requires building mashlib locally:
+```bash
+cd src/mashlib-local
+npm install && npm run build
+```
 
 **How it works:**
 1. Browser requests `/alice/public/data.ttl` with `Accept: text/html`
-2. Server returns Mashlib HTML wrapper (loads JS/CSS from CDN)
+2. Server returns Mashlib HTML wrapper
 3. Mashlib fetches the actual data via content negotiation
 4. Mashlib renders an interactive, editable view
 

--- a/bin/jss.js
+++ b/bin/jss.js
@@ -50,9 +50,10 @@ program
   .option('--subdomains', 'Enable subdomain-based pods (XSS protection)')
   .option('--no-subdomains', 'Disable subdomain-based pods')
   .option('--base-domain <domain>', 'Base domain for subdomain pods (e.g., "example.com")')
-  .option('--mashlib', 'Enable Mashlib data browser for RDF resources')
+  .option('--mashlib', 'Enable Mashlib data browser (local mode, requires mashlib in node_modules)')
+  .option('--mashlib-cdn', 'Enable Mashlib data browser (CDN mode, no local files needed)')
   .option('--no-mashlib', 'Disable Mashlib data browser')
-  .option('--mashlib-version <version>', 'Mashlib version to use (default: 2.0.0)')
+  .option('--mashlib-version <version>', 'Mashlib version for CDN mode (default: 2.0.0)')
   .option('-q, --quiet', 'Suppress log output')
   .option('--print-config', 'Print configuration and exit')
   .action(async (options) => {
@@ -91,7 +92,8 @@ program
         root: config.root,
         subdomains: config.subdomains,
         baseDomain: config.baseDomain,
-        mashlib: config.mashlib,
+        mashlib: config.mashlib || config.mashlibCdn,
+        mashlibCdn: config.mashlibCdn,
         mashlibVersion: config.mashlibVersion,
       });
 
@@ -106,7 +108,11 @@ program
         if (config.notifications) console.log('  WebSocket: enabled');
         if (config.idp) console.log(`  IdP: ${idpIssuer}`);
         if (config.subdomains) console.log(`  Subdomains: ${config.baseDomain} (XSS protection enabled)`);
-        if (config.mashlib) console.log(`  Mashlib: v${config.mashlibVersion} (data browser enabled)`);
+        if (config.mashlibCdn) {
+          console.log(`  Mashlib: v${config.mashlibVersion} (CDN mode)`);
+        } else if (config.mashlib) {
+          console.log(`  Mashlib: local (data browser enabled)`);
+        }
         console.log('\n  Press Ctrl+C to stop\n');
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "javascript-solid-server",
-  "version": "0.0.21",
+  "version": "0.0.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "javascript-solid-server",
-      "version": "0.0.21",
+      "version": "0.0.23",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/middie": "^8.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-solid-server",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "A minimal, fast Solid server",
   "main": "src/index.js",
   "type": "module",

--- a/src/config.js
+++ b/src/config.js
@@ -39,6 +39,7 @@ export const defaults = {
 
   // Mashlib data browser
   mashlib: false,
+  mashlibCdn: false,
   mashlibVersion: '2.0.0',
 
   // Logging
@@ -68,6 +69,7 @@ const envMap = {
   JSS_SUBDOMAINS: 'subdomains',
   JSS_BASE_DOMAIN: 'baseDomain',
   JSS_MASHLIB: 'mashlib',
+  JSS_MASHLIB_CDN: 'mashlibCdn',
   JSS_MASHLIB_VERSION: 'mashlibVersion',
 };
 
@@ -201,6 +203,6 @@ export function printConfig(config) {
   console.log(`  Notifications: ${config.notifications}`);
   console.log(`  IdP:           ${config.idp ? (config.idpIssuer || 'enabled') : 'disabled'}`);
   console.log(`  Subdomains:    ${config.subdomains ? (config.baseDomain || 'enabled') : 'disabled'}`);
-  console.log(`  Mashlib:       ${config.mashlib ? `v${config.mashlibVersion}` : 'disabled'}`);
+  console.log(`  Mashlib:       ${config.mashlibCdn ? `CDN v${config.mashlibVersion}` : config.mashlib ? 'local' : 'disabled'}`);
   console.log('─'.repeat(40));
 }

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -145,7 +145,9 @@ export async function handleGet(request, reply) {
   // Check if we should serve Mashlib data browser
   // Only for RDF resources when Accept: text/html is requested
   if (shouldServeMashlib(request, request.mashlibEnabled, storedContentType)) {
-    const html = generateDatabrowserHtml(resourceUrl, request.mashlibVersion);
+    // Pass CDN version if using CDN mode, null for local mode
+    const cdnVersion = request.mashlibCdn ? request.mashlibVersion : null;
+    const html = generateDatabrowserHtml(resourceUrl, cdnVersion);
     const headers = getAllHeaders({
       isContainer: false,
       etag: stats.etag,
@@ -155,6 +157,10 @@ export async function handleGet(request, reply) {
       connegEnabled
     });
     headers['Vary'] = 'Accept';
+    headers['X-Frame-Options'] = 'DENY';
+    headers['Content-Security-Policy'] = "frame-ancestors 'none'";
+    // Don't cache the HTML wrapper - always negotiate fresh
+    headers['Cache-Control'] = 'no-store';
 
     Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
     return reply.type('text/html').send(html);

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -197,7 +197,7 @@ export async function handleGet(request, reply) {
         resourceUrl,
         connegEnabled
       });
-      headers['Vary'] = getVaryHeader(connegEnabled);
+      headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
 
       Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
       return reply.send(outputContent);
@@ -215,7 +215,7 @@ export async function handleGet(request, reply) {
     resourceUrl,
     connegEnabled
   });
-  headers['Vary'] = getVaryHeader(connegEnabled);
+  headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
 
   Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
   return reply.send(content);
@@ -359,7 +359,7 @@ export async function handlePut(request, reply) {
   const origin = request.headers.origin;
   const headers = getAllHeaders({ isContainer: false, origin, resourceUrl, connegEnabled });
   headers['Location'] = resourceUrl;
-  headers['Vary'] = getVaryHeader(connegEnabled);
+  headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
 
   Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
 

--- a/src/mashlib/index.js
+++ b/src/mashlib/index.js
@@ -6,51 +6,38 @@
  * we return this wrapper which then fetches and renders the data.
  */
 
-const CDN_BASE = 'https://unpkg.com/mashlib';
-
 /**
  * Generate Mashlib databrowser HTML
- * @param {string} resourceUrl - The URL of the resource being viewed
- * @param {string} version - Mashlib version (default: '2.0.0')
+ *
+ * @param {string} resourceUrl - The URL of the resource being viewed (unused, kept for API compatibility)
+ * @param {string} cdnVersion - If provided, load mashlib from unpkg CDN (e.g., "2.0.0")
  * @returns {string} HTML content
  */
-export function generateDatabrowserHtml(resourceUrl, version = '2.0.0') {
-  const cdnUrl = `${CDN_BASE}@${version}/dist`;
+export function generateDatabrowserHtml(resourceUrl, cdnVersion = null) {
+  if (cdnVersion) {
+    // CDN mode - use script.onload to ensure mashlib is fully loaded before init
+    // This avoids race conditions with defer + DOMContentLoaded
+    const cdnBase = `https://unpkg.com/mashlib@${cdnVersion}/dist`;
+    return `<!doctype html><html><head><meta charset="utf-8"/><title>SolidOS Web App</title>
+<link href="${cdnBase}/mash.css" rel="stylesheet"></head>
+<body id="PageBody"><header id="PageHeader"></header>
+<div class="TabulatorOutline" id="DummyUUID" role="main"><table id="outline"></table><div id="GlobalDashboard"></div></div>
+<footer id="PageFooter"></footer>
+<script>
+(function() {
+  var s = document.createElement('script');
+  s.src = '${cdnBase}/mashlib.min.js';
+  s.onload = function() { panes.runDataBrowser(); };
+  s.onerror = function() { document.body.innerHTML = '<p>Failed to load Mashlib from CDN</p>'; };
+  document.head.appendChild(s);
+})();
+</script></body></html>`;
+  }
 
-  return `<!doctype html>
-<html>
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>SolidOS - ${escapeHtml(resourceUrl)}</title>
-  <script defer src="${cdnUrl}/mashlib.min.js"></script>
-  <link href="${cdnUrl}/mash.css" rel="stylesheet">
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      // runDataBrowser uses window.location to determine what to fetch
-      panes.runDataBrowser();
-    });
-  </script>
-  <style>
-    /* Loading indicator */
-    body:not(.loaded) #PageBody::before {
-      content: 'Loading SolidOS...';
-      display: block;
-      padding: 2em;
-      text-align: center;
-      color: #666;
-    }
-  </style>
-</head>
-<body id="PageBody">
-  <header id="PageHeader"></header>
-  <div class="TabulatorOutline" id="DummyUUID" role="main">
-    <table id="outline"></table>
-    <div id="GlobalDashboard"></div>
-  </div>
-  <footer id="PageFooter"></footer>
-</body>
-</html>`;
+  // Local mode - use defer (reliable when served locally)
+  return `<!doctype html><html><head><meta charset="utf-8"/><title>SolidOS Web App</title><script>document.addEventListener('DOMContentLoaded', function() {
+        panes.runDataBrowser()
+      })</script><script defer="defer" src="/mashlib.min.js"></script><link href="/mash.css" rel="stylesheet"></head><body id="PageBody"><header id="PageHeader"></header><div class="TabulatorOutline" id="DummyUUID" role="main"><table id="outline"></table><div id="GlobalDashboard"></div></div><footer id="PageFooter"></footer></body></html>`;
 }
 
 /**
@@ -61,11 +48,17 @@ export function generateDatabrowserHtml(resourceUrl, version = '2.0.0') {
  * @returns {boolean}
  */
 export function shouldServeMashlib(request, mashlibEnabled, contentType) {
+  const accept = request.headers.accept || '';
+  const secFetchDest = request.headers['sec-fetch-dest'] || '';
+
   if (!mashlibEnabled) {
     return false;
   }
 
-  const accept = request.headers.accept || '';
+  // Don't serve mashlib for iframe/embed requests (prevents recursive loop)
+  if (secFetchDest === 'iframe' || secFetchDest === 'embed' || secFetchDest === 'object') {
+    return false;
+  }
 
   // Must explicitly accept HTML
   if (!accept.includes('text/html')) {

--- a/src/rdf/conneg.js
+++ b/src/rdf/conneg.js
@@ -188,9 +188,10 @@ export async function fromJsonLd(jsonLd, targetType, baseUri, connegEnabled = fa
 
 /**
  * Get Vary header value for content negotiation
+ * Include Accept when conneg or mashlib is enabled (response varies by Accept header)
  */
-export function getVaryHeader(connegEnabled) {
-  return connegEnabled ? 'Accept, Origin' : 'Origin';
+export function getVaryHeader(connegEnabled, mashlibEnabled = false) {
+  return (connegEnabled || mashlibEnabled) ? 'Accept, Origin' : 'Origin';
 }
 
 /**

--- a/src/server.js
+++ b/src/server.js
@@ -1,10 +1,15 @@
 import Fastify from 'fastify';
+import { readFile } from 'fs/promises';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import { handleGet, handleHead, handlePut, handleDelete, handleOptions, handlePatch } from './handlers/resource.js';
 import { handlePost, handleCreatePod } from './handlers/container.js';
 import { getCorsHeaders } from './ldp/headers.js';
 import { authorize, handleUnauthorized } from './auth/middleware.js';
 import { notificationsPlugin } from './notifications/index.js';
 import { idpPlugin } from './idp/index.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Create and configure Fastify server
@@ -31,7 +36,9 @@ export function createServer(options = {}) {
   const subdomainsEnabled = options.subdomains ?? false;
   const baseDomain = options.baseDomain || null;
   // Mashlib data browser is OFF by default
+  // mashlibCdn: if true, load from CDN; if false, serve locally
   const mashlibEnabled = options.mashlib ?? false;
+  const mashlibCdn = options.mashlibCdn ?? false;
   const mashlibVersion = options.mashlibVersion ?? '2.0.0';
 
   // Set data root via environment variable if provided
@@ -70,6 +77,7 @@ export function createServer(options = {}) {
   fastify.decorateRequest('baseDomain', null);
   fastify.decorateRequest('podName', null);
   fastify.decorateRequest('mashlibEnabled', null);
+  fastify.decorateRequest('mashlibCdn', null);
   fastify.decorateRequest('mashlibVersion', null);
   fastify.addHook('onRequest', async (request) => {
     request.connegEnabled = connegEnabled;
@@ -78,6 +86,7 @@ export function createServer(options = {}) {
     request.subdomainsEnabled = subdomainsEnabled;
     request.baseDomain = baseDomain;
     request.mashlibEnabled = mashlibEnabled;
+    request.mashlibCdn = mashlibCdn;
     request.mashlibVersion = mashlibVersion;
 
     // Extract pod name from subdomain if enabled
@@ -122,11 +131,13 @@ export function createServer(options = {}) {
   // Authorization hook - check WAC permissions
   // Skip for pod creation endpoint (needs special handling)
   fastify.addHook('preHandler', async (request, reply) => {
-    // Skip auth for pod creation, OPTIONS, IdP routes, and well-known endpoints
+    // Skip auth for pod creation, OPTIONS, IdP routes, mashlib, and well-known endpoints
+    const mashlibPaths = ['/mashlib.min.js', '/mash.css', '/841.mashlib.min.js'];
     if (request.url === '/.pods' ||
         request.method === 'OPTIONS' ||
         request.url.startsWith('/idp/') ||
-        request.url.startsWith('/.well-known/')) {
+        request.url.startsWith('/.well-known/') ||
+        mashlibPaths.some(p => request.url === p || request.url.startsWith(p + '.'))) {
       return;
     }
 
@@ -143,6 +154,30 @@ export function createServer(options = {}) {
 
   // Pod creation endpoint
   fastify.post('/.pods', handleCreatePod);
+
+  // Mashlib static files (served from root like NSS does)
+  if (mashlibEnabled) {
+    const mashlibDir = join(__dirname, 'mashlib-local', 'dist');
+    const mashlibFiles = {
+      '/mashlib.min.js': { file: 'mashlib.min.js', type: 'application/javascript' },
+      '/mashlib.min.js.map': { file: 'mashlib.min.js.map', type: 'application/json' },
+      '/mash.css': { file: 'mash.css', type: 'text/css' },
+      '/mash.css.map': { file: 'mash.css.map', type: 'application/json' },
+      '/841.mashlib.min.js': { file: '841.mashlib.min.js', type: 'application/javascript' },
+      '/841.mashlib.min.js.map': { file: '841.mashlib.min.js.map', type: 'application/json' }
+    };
+
+    for (const [path, config] of Object.entries(mashlibFiles)) {
+      fastify.get(path, async (request, reply) => {
+        try {
+          const content = await readFile(join(mashlibDir, config.file));
+          return reply.type(config.type).send(content);
+        } catch {
+          return reply.code(404).send({ error: 'Not Found' });
+        }
+      });
+    }
+  }
 
   // LDP routes - using wildcard routing
   fastify.get('/*', handleGet);


### PR DESCRIPTION
## Summary

Fixes the race condition when loading mashlib from CDN by using `script.onload` instead of `defer` + `DOMContentLoaded`.

## Problem

When mashlib is loaded from a CDN (e.g., unpkg.com), the `defer` attribute doesn't reliably wait for the script to finish downloading before `DOMContentLoaded` fires. This causes:
- First load: blank content or recursive UI nesting
- Hard refresh: works fine

## Solution

**CDN mode (`--mashlib-cdn`):** Use dynamic script injection with `onload` callback:
```javascript
var s = document.createElement('script');
s.src = 'https://unpkg.com/mashlib@2.0.0/dist/mashlib.min.js';
s.onload = function() { panes.runDataBrowser(); };
document.head.appendChild(s);
```

**Local mode (`--mashlib`):** Unchanged - uses official databrowser.html pattern (reliable with local hosting).

## Changes

| File | Change |
|------|--------|
| `src/mashlib/index.js` | CDN mode with `script.onload`, local mode unchanged |
| `src/server.js` | Add `mashlibCdn` config option |
| `src/handlers/resource.js` | Pass CDN version, add `Cache-Control: no-store` |
| `src/config.js` | Add `mashlibCdn` default and env var |
| `bin/jss.js` | Add `--mashlib-cdn` CLI flag |

## Usage

```bash
# CDN mode (zero footprint, loads from unpkg.com)
jss start --mashlib-cdn --mashlib-version 2.0.0

# Local mode (requires mashlib files in src/mashlib-local/dist/)
jss start --mashlib
```

## Test Plan

- [x] CDN mode: first load works in fresh incognito window
- [x] Local mode: still works as before
- [x] `curl -H "Accept: text/html"` returns correct HTML for each mode
- [x] Cache headers prevent HTML wrapper caching

## Related

- Fixes #8
- Upstream issue: https://github.com/SolidOS/mashlib/issues/260