### PR TITLE
Fix 401 error page infinite loop by removing non-existent login link

### DIFF
--- a/src/auth/middleware.js
+++ b/src/auth/middleware.js
@@ -315,12 +315,12 @@ function getErrorPage(statusCode, isAuthenticated, request) {
       <p class="subtitle">${subtitle}</p>
 
       <div class="actions">
-        ${is401 ? `<a href="${baseUrl}/.account/login/password" class="btn btn-primary">
-          Sign In
-        </a>` : ''}
-        <a href="${baseUrl}/" class="btn btn-secondary">
+        <a href="${baseUrl}/" class="btn btn-primary">
           Go to Homepage
         </a>
+        ${is401 ? `<a href="${baseUrl}/idp/register" class="btn btn-secondary">
+          Create Account
+        </a>` : ''}
       </div>
 
       <div class="divider"><span>What is this?</span></div>
@@ -330,7 +330,7 @@ function getErrorPage(statusCode, isAuthenticated, request) {
         <p>
           This is a <strong>Solid Pod</strong> — a personal data store where you control your own data.
           Resources can be private, shared with specific people, or public.
-          ${is401 ? 'Sign in with your WebID to access protected content.' : 'Ask the owner to grant you access.'}
+          ${is401 ? 'To access protected content, use a Solid app (like a data browser) that will authenticate with your WebID.' : 'Ask the owner to grant you access.'}
         </p>
       </div>
 

--- a/src/auth/middleware.js
+++ b/src/auth/middleware.js
@@ -330,7 +330,7 @@ function getErrorPage(statusCode, isAuthenticated, request) {
         <p>
           This is a <strong>Solid Pod</strong> — a personal data store where you control your own data.
           Resources can be private, shared with specific people, or public.
-          ${is401 ? 'To access protected content, use a Solid app (like a data browser) that will authenticate with your WebID.' : 'Ask the owner to grant you access.'}
+          ${is401 ? "To access protected content, you'll need to sign in using a Solid app (like a data browser) with your WebID." : 'Ask the owner to grant you access.'}
         </p>
       </div>
 


### PR DESCRIPTION
## Summary

Fixes #52 

The 401 error page was linking to `/.account/login/password` which doesn't exist in this Solid-OIDC implementation, causing an infinite redirect loop when users tried to sign in.

## Problem

When accessing protected resources without authentication:
1. Server returns 401 error page with "Sign In" button
2. Button links to `/.account/login/password` (doesn't exist)
3. Clicking it → another 401 error → infinite loop

## Changes

### 1. Updated button actions (`src/auth/middleware.js:317-324`)

**Before:**
```javascript
<div class="actions">
  ${is401 ? \`<a href="${baseUrl}/.account/login/password" class="btn btn-primary">
    Sign In
  </a>\` : ''}
  <a href="${baseUrl}/" class="btn btn-secondary">
    Go to Homepage
  </a>
</div>
```

**After:**
```javascript
<div class="actions">
  <a href="${baseUrl}/" class="btn btn-primary">
    Go to Homepage
  </a>
  ${is401 ? \`<a href="${baseUrl}/idp/register" class="btn btn-secondary">
    Create Account
  </a>\` : ''}
</div>
```

### 2. Updated explanation text (line 333)

**Before:**
```javascript
${is401 ? 'Sign in with your WebID to access protected content.' : 'Ask the owner to grant you access.'}
```

**After:**
```javascript
${is401 ? 'To access protected content, use a Solid app (like a data browser) that will authenticate with your WebID.' : 'Ask the owner to grant you access.'}
```

## Rationale

- **Homepage link**: Provides orientation without creating a loop
- **Register link**: Links to existing `/idp/register` route (already exempted from auth)
- **Clear explanation**: Tells users they need a Solid app to authenticate
- **Architecturally correct**: Aligns with Solid-OIDC (OAuth/OIDC flows initiated by client apps, not direct browser login)

The `/.account/login/password` pattern is from Node Solid Server (NSS) which used a different authentication architecture. This server uses **Solid-OIDC** where client applications initiate the authentication flow.

## Testing

### Verified the fix

```bash
# After changes - shows working links
curl -H "Accept: text/html" http://localhost:3000/test-protected | grep 'class="btn'
# <a href="http://localhost:3000/" class="btn btn-primary">
#   Go to Homepage
# <a href="http://localhost:3000/idp/register" class="btn btn-secondary">
#   Create Account
```

### Additional tests

```bash
# Verify register page works
curl -I http://localhost:3000/idp/register
# HTTP/1.1 200 OK

# Verify API clients still get JSON (not HTML)
curl -H "Accept: application/json" http://localhost:3000/test-protected
# {"error":"Unauthorized","message":"Authentication required"}
```

## Impact

- ✅ **Fixes**: Infinite loop blocking user access to protected resources
- ✅ **Breaking changes**: None (removing non-functional link)
- ✅ **Security**: No new attack vectors
- ✅ **Users affected**: Anyone accessing protected resources without authentication

## Related

- Introduced in: `ae796d0` (v0.0.68 - Beautiful 401/403 error pages)
- Attempted fix: `32c0db2` (v0.0.69 - Allow .account in dotfile filter) - incomplete

## References

- [Solid-OIDC Specification](https://solid.github.io/solid-oidc/)
- [Node Solid Server Login Docs](https://github.com/nodeSolidServer/node-solid-server/blob/main/docs/login-and-grant-access-to-application.md)