### PR TITLE
fix: support top-level JSON-LD arrays in ACL parser

### DIFF
--- a/src/wac/parser.js
+++ b/src/wac/parser.js
@@ -55,7 +55,7 @@ export async function parseAcl(content, aclUrl) {
   const authorizations = [];
 
   // Handle @graph array or single object
-  const nodes = doc['@graph'] || [doc];
+  const nodes = Array.isArray(doc) ? doc : (doc['@graph'] || [doc]);
 
   for (const node of nodes) {
     if (isAuthorization(node)) {


### PR DESCRIPTION
## Summary
- Support top-level JSON-LD arrays in the WAC parser

## Changes
The parser now accepts three JSON-LD formats:
1. Object with `@graph` array (existing)
2. Single authorization object (existing)
3. **Top-level array of authorizations (new)**

This allows cleaner ACL documents without the `@graph` wrapper:

```json
[
  { "@context": {...}, "@id": "#owner", "@type": "acl:Authorization", ... },
  { "@context": {...}, "@id": "#public", "@type": "acl:Authorization", ... }
]
```

## Implementation
One-line change in `src/wac/parser.js`:
```javascript
// Before
const nodes = doc['@graph'] || [doc];

// After  
const nodes = Array.isArray(doc) ? doc : (doc['@graph'] || [doc]);
```

Fixes #59

## Test plan
- [x] Tested against live server with array-format ACLs
- [x] Existing `@graph` format continues to work
- [x] Single object format continues to work