### PR TITLE
test: add coverage for acl:AuthenticatedAgent

### DIFF
--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -149,6 +149,54 @@ describe('Authentication', () => {
       const res = await request('/inboxread/inbox/');
       assertStatus(res, 401);
     });
+
+    it('should allow any authenticated user with acl:AuthenticatedAgent', async () => {
+      await createTestPod('authuser1');
+      await createTestPod('authuser2');
+
+      // Create a test resource with acl:AuthenticatedAgent ACL
+      const baseUrl = getBaseUrl();
+
+      // First, create a resource (this will create parent containers)
+      await request('/authuser1/authenticated-only/test.txt', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'text/plain' },
+        body: 'authenticated content',
+        auth: 'authuser1'
+      });
+
+      // Now create a custom ACL for the container with acl:AuthenticatedAgent
+      const acl = {
+        '@context': { 'acl': 'http://www.w3.org/ns/auth/acl#' },
+        '@graph': [{
+          '@id': '#authenticated',
+          '@type': 'acl:Authorization',
+          'acl:agentClass': { '@id': 'acl:AuthenticatedAgent' },
+          'acl:accessTo': { '@id': `${baseUrl}/authuser1/authenticated-only/` },
+          'acl:default': { '@id': `${baseUrl}/authuser1/authenticated-only/` },
+          'acl:mode': [{ '@id': 'acl:Read' }]
+        }]
+      };
+
+      await request('/authuser1/authenticated-only/.acl', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(acl),
+        auth: 'authuser1'
+      });
+
+      // Test 1: Anonymous access should be denied
+      const res1 = await request('/authuser1/authenticated-only/test.txt');
+      assertStatus(res1, 401);
+
+      // Test 2: Owner should have access
+      const res2 = await request('/authuser1/authenticated-only/test.txt', { auth: 'authuser1' });
+      assertStatus(res2, 200);
+
+      // Test 3: Different authenticated user should also have access (key test!)
+      const res3 = await request('/authuser1/authenticated-only/test.txt', { auth: 'authuser2' });
+      assertStatus(res3, 200);
+    });
   });
 
   describe('WAC-Allow Header', () => {

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -166,16 +166,31 @@ describe('Authentication', () => {
       });
 
       // Now create a custom ACL for the container with acl:AuthenticatedAgent
+      // Include owner with Control so they can manage the ACL
       const acl = {
         '@context': { 'acl': 'http://www.w3.org/ns/auth/acl#' },
-        '@graph': [{
-          '@id': '#authenticated',
-          '@type': 'acl:Authorization',
-          'acl:agentClass': { '@id': 'acl:AuthenticatedAgent' },
-          'acl:accessTo': { '@id': `${baseUrl}/authuser1/authenticated-only/` },
-          'acl:default': { '@id': `${baseUrl}/authuser1/authenticated-only/` },
-          'acl:mode': [{ '@id': 'acl:Read' }]
-        }]
+        '@graph': [
+          {
+            '@id': '#owner',
+            '@type': 'acl:Authorization',
+            'acl:agent': { '@id': `${baseUrl}/authuser1/profile/card#me` },
+            'acl:accessTo': { '@id': `${baseUrl}/authuser1/authenticated-only/` },
+            'acl:default': { '@id': `${baseUrl}/authuser1/authenticated-only/` },
+            'acl:mode': [
+              { '@id': 'acl:Read' },
+              { '@id': 'acl:Write' },
+              { '@id': 'acl:Control' }
+            ]
+          },
+          {
+            '@id': '#authenticated',
+            '@type': 'acl:Authorization',
+            'acl:agentClass': { '@id': 'acl:AuthenticatedAgent' },
+            'acl:accessTo': { '@id': `${baseUrl}/authuser1/authenticated-only/` },
+            'acl:default': { '@id': `${baseUrl}/authuser1/authenticated-only/` },
+            'acl:mode': [{ '@id': 'acl:Read' }]
+          }
+        ]
       };
 
       await request('/authuser1/authenticated-only/.acl', {


### PR DESCRIPTION
## Summary

Adds test coverage for `acl:AuthenticatedAgent` functionality, addressing issue #58.

## Changes

- Added integration test in `test/auth.test.js` that validates `acl:AuthenticatedAgent` behavior
- Test creates a resource with a custom ACL using `acl:AuthenticatedAgent`
- Verifies three critical scenarios:
  1. ❌ Anonymous/unauthenticated users are denied access (401)
  2. ✅ Resource owner has access (200)
  3. ✅ **Any authenticated user** has access (200) - **key distinction**

## Test Approach

The test:
1. Creates two test pods (`authuser1` and `authuser2`)
2. Creates a resource under `authuser1/authenticated-only/test.txt`
3. Applies a custom ACL with `acl:AuthenticatedAgent` to the parent container
4. Validates access control for all three user types

## Why This Matters

This test validates the key semantic difference between:

| Access Type | Anonymous | Owner | Other Authenticated |
|------------|-----------|-------|---------------------|
| `foaf:Agent` (public) | ✅ | ✅ | ✅ |
| Specific agent (private) | ❌ | ✅ | ❌ |
| **`acl:AuthenticatedAgent`** | ❌ | ✅ | ✅ |

The implementation already works correctly (exists in `src/wac/parser.js` and `src/wac/checker.js`), but this test ensures the behavior is validated and won't regress.

## Related

- Fixes #58
- [W3C ACL Ontology](http://www.w3.org/ns/auth/acl) - Official spec
- [Web Access Control Spec](https://solid.github.io/web-access-control-spec/)
- [AuthenticatedAgent Discussion](https://github.com/solid/web-access-control-spec/issues/88)