### PR TITLE
Fix relative URI resolution for acl:agent

### DIFF
--- a/src/wac/parser.js
+++ b/src/wac/parser.js
@@ -144,8 +144,9 @@ function parseAuthorization(node, aclUrl) {
   auth.default = parseUriArray(node['acl:default'] || node['default'])
     .map(uri => resolveUri(uri, baseUrl));
 
-  // Parse agents (WebIDs can be relative too)
-  auth.agents = parseUriArray(node['acl:agent'] || node['agent']);
+  // Parse agents (WebIDs can be relative too) - resolve against ACL URL
+  auth.agents = parseUriArray(node['acl:agent'] || node['agent'])
+    .map(uri => resolveUri(uri, aclUrl));
 
   // Parse agentClass
   auth.agentClasses = parseUriArray(node['acl:agentClass'] || node['agentClass']);

--- a/test/wac.test.js
+++ b/test/wac.test.js
@@ -187,6 +187,23 @@ describe('WAC Parser', () => {
         `Expected accessTo to include 'https://alice.example/other/', got: ${auths[0].accessTo}`);
     });
 
+    it('should resolve relative agent URIs against ACL URL', async () => {
+      const acl = {
+        '@context': { 'acl': 'http://www.w3.org/ns/auth/acl#' },
+        '@id': '#owner',
+        '@type': 'acl:Authorization',
+        'acl:agent': { '@id': './#me' },
+        'acl:accessTo': { '@id': './' },
+        'acl:mode': [{ '@id': 'acl:Read' }]
+      };
+
+      const auths = await parseAcl(JSON.stringify(acl), 'https://alice.example/.acl');
+
+      assert.strictEqual(auths.length, 1);
+      assert.ok(auths[0].agents.includes('https://alice.example/#me'),
+        `Expected agents to include 'https://alice.example/#me', got: ${auths[0].agents}`);
+    });
+
     it('should keep absolute URLs unchanged', async () => {
       const acl = {
         '@context': { 'acl': 'http://www.w3.org/ns/auth/acl#' },


### PR DESCRIPTION
## Summary
- Resolve agent URIs against the ACL URL so that relative references like `./#me` correctly match the authenticated WebID

## Problem
When using a relative URI like `./#me` in an ACL file to reference the owner's WebID, it wasn't matching the authenticated user's WebID during authorization checks, resulting in 403 Forbidden.

The issue was that `accessTo` and `default` URIs were being resolved against the base URL, but `agents` were not:

```javascript
// These were resolved:
auth.accessTo = parseUriArray(...).map(uri => resolveUri(uri, baseUrl));
auth.default = parseUriArray(...).map(uri => resolveUri(uri, baseUrl));

// But agents were NOT resolved:
auth.agents = parseUriArray(node['acl:agent'] || node['agent']);  // Bug!
```

## Fix
One-line change to resolve agent URIs against the ACL URL:

```javascript
auth.agents = parseUriArray(node['acl:agent'] || node['agent'])
  .map(uri => resolveUri(uri, aclUrl));
```

Note: We resolve against `aclUrl` (not `baseUrl`) because `./#me` in `/.acl` should resolve to `https://example.com/#me`.

## Test plan
- [x] Tested on live server (melvincarvalho.com)
- [ ] Verify `./#me` in ACL matches authenticated WebID
- [ ] Verify absolute URIs still work unchanged

Fixes #64