### PR TITLE
fix(webid-tls): improve HTML profile parsing

### DIFF
--- a/src/auth/webid-tls.js
+++ b/src/auth/webid-tls.js
@@ -139,7 +139,7 @@ function parseKeyObject(keyObj) {
 async function fetchProfileKeys(webId) {
   const response = await fetchWithTimeout(webId, {
     headers: {
-      'Accept': 'application/ld+json, text/turtle, application/json'
+      'Accept': 'text/html'
     }
   });
 
@@ -157,7 +157,7 @@ async function fetchProfileKeys(webId) {
     jsonLd = await turtleToJsonLd(text, webId);
   } else if (contentType.includes('text/html')) {
     // Try to extract JSON-LD from HTML data island
-    const jsonLdMatch = text.match(/<script\s+type=["']application\/ld\+json["']\s*>([\s\S]*?)<\/script>/i);
+    const jsonLdMatch = text.match(/<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/i);
     if (jsonLdMatch) {
       jsonLd = JSON.parse(jsonLdMatch[1]);
     } else {

--- a/test/webid-tls.test.js
+++ b/test/webid-tls.test.js
@@ -94,6 +94,56 @@ describe('WebID-TLS', () => {
     });
   });
 
+  describe('HTML JSON-LD extraction regex', () => {
+    // Test the regex pattern used to extract JSON-LD from HTML profiles
+    const jsonLdRegex = /<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/i;
+
+    it('should match basic script tag', () => {
+      const html = '<script type="application/ld+json">{"@id": "#me"}</script>';
+      const match = html.match(jsonLdRegex);
+      assert.ok(match, 'Should match basic script tag');
+      assert.strictEqual(match[1], '{"@id": "#me"}');
+    });
+
+    it('should match script tag with additional attributes', () => {
+      const html = '<script type="application/ld+json" id="me">{"@id": "#me"}</script>';
+      const match = html.match(jsonLdRegex);
+      assert.ok(match, 'Should match script tag with id attribute');
+      assert.strictEqual(match[1], '{"@id": "#me"}');
+    });
+
+    it('should match script tag with attributes before type', () => {
+      const html = '<script id="profile" type="application/ld+json">{"@id": "#me"}</script>';
+      const match = html.match(jsonLdRegex);
+      assert.ok(match, 'Should match script tag with id before type');
+      assert.strictEqual(match[1], '{"@id": "#me"}');
+    });
+
+    it('should match script tag with single quotes', () => {
+      const html = "<script type='application/ld+json'>{'@id': '#me'}</script>";
+      const match = html.match(jsonLdRegex);
+      assert.ok(match, 'Should match script tag with single quotes');
+    });
+
+    it('should match script tag with newlines in content', () => {
+      const html = `<script type="application/ld+json">
+{
+  "@id": "#me",
+  "name": "Test"
+}
+</script>`;
+      const match = html.match(jsonLdRegex);
+      assert.ok(match, 'Should match script tag with multiline content');
+      assert.ok(match[1].includes('"@id": "#me"'));
+    });
+
+    it('should not match non-jsonld script tags', () => {
+      const html = '<script type="text/javascript">console.log("test")</script>';
+      const match = html.match(jsonLdRegex);
+      assert.strictEqual(match, null, 'Should not match JavaScript script tag');
+    });
+  });
+
   describe('SAN format variations', () => {
     it('should handle lowercase uri prefix', () => {
       // Some certs might have lowercase


### PR DESCRIPTION
## Summary

Fixes WebID-TLS authentication failures with HTML profiles containing embedded JSON-LD.

## Changes

1. **Accept header** - Request `text/html` instead of mixed types to work around conneg priority issues (#71)

2. **JSON-LD regex** - Use more flexible pattern to handle additional attributes on script tag (e.g., `<script type="application/ld+json" id="me">`)

## Testing

Tested with WebID-TLS client certificate authentication against HTML profile with embedded JSON-LD.

Fixes #70