### PR TITLE
feat: add --solidos-ui flag for modern Nextcloud-style UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ jss --help             # Show help
 | `--mashlib` | Enable Mashlib (local mode) | false |
 | `--mashlib-cdn` | Enable Mashlib (CDN mode) | false |
 | `--mashlib-version <ver>` | Mashlib CDN version | 2.0.0 |
+| `--solidos-ui` | Enable modern SolidOS UI (requires --mashlib) | false |
 | `--git` | Enable Git HTTP backend | false |
 | `--nostr` | Enable Nostr relay | false |
 | `--nostr-path <path>` | Nostr relay WebSocket path | /relay |
@@ -332,6 +333,18 @@ npm install && npm run build
 4. Mashlib renders an interactive, editable view
 
 **Note:** Mashlib works best with `--conneg` enabled for Turtle support.
+
+**Modern UI (SolidOS UI):**
+```bash
+jss start --mashlib --solidos-ui --conneg
+```
+Serves a modern Nextcloud-style UI shell while reusing mashlib's data layer. The `--solidos-ui` flag swaps the classic databrowser interface for a cleaner, mobile-friendly design with:
+- Modern file browser with breadcrumb navigation
+- Profile, Contacts, Sharing, and Settings views
+- Path-based URLs (browser URL reflects current resource)
+- Responsive design for mobile devices
+
+Requires solidos-ui dist files in `src/mashlib-local/dist/solidos-ui/`. See [solidos-ui](https://github.com/solidos/solidos/tree/main/workspaces/solidos-ui) for details.
 
 ### Profile Pages
 

--- a/bin/jss.js
+++ b/bin/jss.js
@@ -57,6 +57,7 @@ program
   .option('--mashlib-cdn', 'Enable Mashlib data browser (CDN mode, no local files needed)')
   .option('--no-mashlib', 'Disable Mashlib data browser')
   .option('--mashlib-version <version>', 'Mashlib version for CDN mode (default: 2.0.0)')
+  .option('--solidos-ui', 'Enable modern Nextcloud-style UI (requires --mashlib)')
   .option('--git', 'Enable Git HTTP backend (clone/push support)')
   .option('--no-git', 'Disable Git HTTP backend')
   .option('--nostr', 'Enable Nostr relay')
@@ -114,6 +115,7 @@ program
         mashlib: config.mashlib || config.mashlibCdn,
         mashlibCdn: config.mashlibCdn,
         mashlibVersion: config.mashlibVersion,
+        solidosUi: config.solidosUi,
         git: config.git,
         nostr: config.nostr,
         nostrPath: config.nostrPath,
@@ -143,6 +145,7 @@ program
         } else if (config.mashlib) {
           console.log(`  Mashlib: local (data browser enabled)`);
         }
+        if (config.solidosUi) console.log('  SolidOS UI: enabled (modern interface)');
         if (config.git) console.log('  Git: enabled (clone/push support)');
         if (config.nostr) console.log(`  Nostr: enabled (${config.nostrPath})`);
         if (config.activitypub) console.log(`  ActivityPub: enabled (@${config.apUsername || 'me'})`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-solid-server",
-  "version": "0.0.75",
+  "version": "0.0.76",
   "description": "A minimal, fast Solid server",
   "main": "src/index.js",
   "type": "module",

--- a/src/auth/middleware.js
+++ b/src/auth/middleware.js
@@ -9,7 +9,7 @@ import { checkAccess, getRequiredMode } from '../wac/checker.js';
 import { AccessMode } from '../wac/parser.js';
 import * as storage from '../storage/filesystem.js';
 import { getEffectiveUrlPath } from '../utils/url.js';
-import { generateDatabrowserHtml } from '../mashlib/index.js';
+import { generateDatabrowserHtml, generateSolidosUiHtml } from '../mashlib/index.js';
 
 /**
  * Check if request is authorized
@@ -117,8 +117,11 @@ export function handleUnauthorized(request, reply, isAuthenticated, wacAllow, au
     // If mashlib is enabled, serve mashlib instead of static error page
     // Mashlib has built-in login functionality via panes.runDataBrowser()
     if (request.mashlibEnabled) {
-      const cdnVersion = request.mashlibCdn ? request.mashlibVersion : null;
-      return reply.code(statusCode).type('text/html').send(generateDatabrowserHtml(request.url, cdnVersion));
+      // Use SolidOS UI if enabled, otherwise fallback to classic mashlib
+      const html = request.solidosUiEnabled
+        ? generateSolidosUiHtml()
+        : generateDatabrowserHtml(request.url, request.mashlibCdn ? request.mashlibVersion : null);
+      return reply.code(statusCode).type('text/html').send(html);
     }
     return reply.code(statusCode).type('text/html').send(getErrorPage(statusCode, isAuthenticated, request));
   }

--- a/src/config.js
+++ b/src/config.js
@@ -42,6 +42,9 @@ export const defaults = {
   mashlibCdn: false,
   mashlibVersion: '2.0.0',
 
+  // SolidOS UI (modern Nextcloud-style interface)
+  solidosUi: false,
+
   // Git HTTP backend
   git: false,
 
@@ -95,6 +98,7 @@ const envMap = {
   JSS_MASHLIB: 'mashlib',
   JSS_MASHLIB_CDN: 'mashlibCdn',
   JSS_MASHLIB_VERSION: 'mashlibVersion',
+  JSS_SOLIDOS_UI: 'solidosUi',
   JSS_GIT: 'git',
   JSS_NOSTR: 'nostr',
   JSS_NOSTR_PATH: 'nostrPath',
@@ -258,5 +262,6 @@ export function printConfig(config) {
   console.log(`  IdP:           ${config.idp ? (config.idpIssuer || 'enabled') : 'disabled'}`);
   console.log(`  Subdomains:    ${config.subdomains ? (config.baseDomain || 'enabled') : 'disabled'}`);
   console.log(`  Mashlib:       ${config.mashlibCdn ? `CDN v${config.mashlibVersion}` : config.mashlib ? 'local' : 'disabled'}`);
+  console.log(`  SolidOS UI:    ${config.solidosUi ? 'enabled' : 'disabled'}`);
   console.log('─'.repeat(40));
 }

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -15,7 +15,7 @@ import {
 } from '../rdf/conneg.js';
 import { emitChange } from '../notifications/events.js';
 import { checkIfMatch, checkIfNoneMatchForGet, checkIfNoneMatchForWrite } from '../utils/conditional.js';
-import { generateDatabrowserHtml, shouldServeMashlib } from '../mashlib/index.js';
+import { generateDatabrowserHtml, generateSolidosUiHtml, shouldServeMashlib } from '../mashlib/index.js';
 
 /**
  * Get the storage path and resource URL for a request
@@ -207,8 +207,10 @@ export async function handleGet(request, reply) {
 
     // Check if we should serve Mashlib data browser for containers
     if (shouldServeMashlib(request, request.mashlibEnabled, 'application/ld+json')) {
-      const cdnVersion = request.mashlibCdn ? request.mashlibVersion : null;
-      const html = generateDatabrowserHtml(resourceUrl, cdnVersion);
+      // Use SolidOS UI if enabled, otherwise fallback to classic mashlib
+      const html = request.solidosUiEnabled
+        ? generateSolidosUiHtml()
+        : generateDatabrowserHtml(resourceUrl, request.mashlibCdn ? request.mashlibVersion : null);
       const headers = getAllHeaders({
         isContainer: true,
         etag: stats.etag,
@@ -282,9 +284,10 @@ export async function handleGet(request, reply) {
   // Check if we should serve Mashlib data browser
   // Only for RDF resources when Accept: text/html is requested
   if (shouldServeMashlib(request, request.mashlibEnabled, storedContentType)) {
-    // Pass CDN version if using CDN mode, null for local mode
-    const cdnVersion = request.mashlibCdn ? request.mashlibVersion : null;
-    const html = generateDatabrowserHtml(resourceUrl, cdnVersion);
+    // Use SolidOS UI if enabled, otherwise fallback to classic mashlib
+    const html = request.solidosUiEnabled
+      ? generateSolidosUiHtml()
+      : generateDatabrowserHtml(resourceUrl, request.mashlibCdn ? request.mashlibVersion : null);
     const headers = getAllHeaders({
       isContainer: false,
       etag: stats.etag,

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -1,4 +1,5 @@
 import * as storage from '../storage/filesystem.js';
+import { createReadStream } from '../storage/filesystem.js';
 import { checkQuota, updateQuotaUsage } from '../storage/quota.js';
 import { getAllHeaders, getNotFoundHeaders } from '../ldp/headers.js';
 import { generateContainerJsonLd, serializeJsonLd } from '../ldp/container.js';
@@ -28,6 +29,57 @@ function getRequestPaths(request) {
   // Resource URL - uses the actual request hostname (subdomain in subdomain mode)
   const resourceUrl = `${request.protocol}://${request.hostname}${urlPath}`;
   return { urlPath, storagePath, resourceUrl };
+}
+
+/**
+ * Parse HTTP Range header
+ * @param {string} rangeHeader - The Range header value (e.g., "bytes=0-1023")
+ * @param {number} fileSize - Total file size in bytes
+ * @returns {{ start: number, end: number } | null}
+ */
+function parseRangeHeader(rangeHeader, fileSize) {
+  if (!rangeHeader || !rangeHeader.startsWith('bytes=')) {
+    return null;
+  }
+
+  const range = rangeHeader.slice(6); // Remove 'bytes='
+  const parts = range.split('-');
+
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  let start, end;
+
+  if (parts[0] === '') {
+    // Suffix range: bytes=-500 (last 500 bytes)
+    const suffix = parseInt(parts[1], 10);
+    if (isNaN(suffix) || suffix <= 0) return null;
+    start = Math.max(0, fileSize - suffix);
+    end = fileSize - 1;
+  } else if (parts[1] === '') {
+    // Open-ended range: bytes=1024- (from 1024 to end)
+    start = parseInt(parts[0], 10);
+    if (isNaN(start) || start < 0) return null;
+    end = fileSize - 1;
+  } else {
+    // Normal range: bytes=0-1023
+    start = parseInt(parts[0], 10);
+    end = parseInt(parts[1], 10);
+    if (isNaN(start) || isNaN(end) || start < 0 || end < start) return null;
+  }
+
+  // Clamp end to file size
+  if (end >= fileSize) {
+    end = fileSize - 1;
+  }
+
+  // Check if range is satisfiable
+  if (start > end || start >= fileSize) {
+    return null;
+  }
+
+  return { start, end };
 }
 
 /**
@@ -243,6 +295,42 @@ export async function handleGet(request, reply) {
 
     Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
     return reply.type('text/html').send(html);
+  }
+
+  // Handle Range requests for media files (video, audio, etc.)
+  const rangeHeader = request.headers.range;
+  if (rangeHeader && !isRdfContentType(storedContentType)) {
+    const range = parseRangeHeader(rangeHeader, stats.size);
+
+    if (range) {
+      const { start, end } = range;
+      const chunkSize = end - start + 1;
+
+      const headers = getAllHeaders({
+        isContainer: false,
+        etag: stats.etag,
+        contentType: storedContentType,
+        origin,
+        resourceUrl,
+        connegEnabled
+      });
+      headers['Content-Range'] = `bytes ${start}-${end}/${stats.size}`;
+      headers['Content-Length'] = chunkSize;
+      headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
+
+      Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
+
+      const streamResult = createReadStream(storagePath, { start, end });
+      if (!streamResult) {
+        return reply.code(500).send({ error: 'Stream error' });
+      }
+
+      return reply.code(206).send(streamResult.stream);
+    } else {
+      // Range not satisfiable
+      reply.header('Content-Range', `bytes */${stats.size}`);
+      return reply.code(416).send({ error: 'Range Not Satisfiable' });
+    }
   }
 
   const content = await storage.read(storagePath);

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -1,5 +1,4 @@
 import * as storage from '../storage/filesystem.js';
-import { createReadStream } from '../storage/filesystem.js';
 import { checkQuota, updateQuotaUsage } from '../storage/quota.js';
 import { getAllHeaders, getNotFoundHeaders } from '../ldp/headers.js';
 import { generateContainerJsonLd, serializeJsonLd } from '../ldp/container.js';
@@ -43,6 +42,13 @@ function parseRangeHeader(rangeHeader, fileSize) {
   }
 
   const range = rangeHeader.slice(6); // Remove 'bytes='
+
+  // Multi-range requests (e.g., "0-100,200-300") are not supported
+  // Per RFC 7233, ignore Range header and serve full content instead of 416
+  if (range.includes(',')) {
+    return null;
+  }
+
   const parts = range.split('-');
 
   if (parts.length !== 2) {
@@ -316,21 +322,22 @@ export async function handleGet(request, reply) {
       });
       headers['Content-Range'] = `bytes ${start}-${end}/${stats.size}`;
       headers['Content-Length'] = chunkSize;
-      headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
 
       Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
 
-      const streamResult = createReadStream(storagePath, { start, end });
+      const streamResult = storage.createReadStream(storagePath, { start, end });
       if (!streamResult) {
         return reply.code(500).send({ error: 'Stream error' });
       }
 
+      // Handle stream errors that occur during response
+      streamResult.stream.on('error', (err) => {
+        console.error('Stream error during range response:', err.message);
+      });
+
       return reply.code(206).send(streamResult.stream);
-    } else {
-      // Range not satisfiable
-      reply.header('Content-Range', `bytes */${stats.size}`);
-      return reply.code(416).send({ error: 'Range Not Satisfiable' });
     }
+    // If range is null (unsupported format or multi-range), fall through to serve full content
   }
 
   const content = await storage.read(storagePath);

--- a/src/ldp/headers.js
+++ b/src/ldp/headers.js
@@ -56,6 +56,7 @@ export function getResponseHeaders({ isContainer = false, etag = null, contentTy
   const headers = {
     'Link': getLinkHeader(isContainer, aclUrl),
     'Accept-Patch': 'text/n3, application/sparql-update',
+    'Accept-Ranges': isContainer ? 'none' : 'bytes',
     'Allow': 'GET, HEAD, PUT, DELETE, PATCH, OPTIONS' + (isContainer ? ', POST' : ''),
     'Vary': connegEnabled ? 'Accept, Authorization, Origin' : 'Authorization, Origin'
   };
@@ -94,8 +95,8 @@ export function getCorsHeaders(origin) {
   return {
     'Access-Control-Allow-Origin': origin || '*',
     'Access-Control-Allow-Methods': 'GET, HEAD, POST, PUT, DELETE, PATCH, OPTIONS',
-    'Access-Control-Allow-Headers': 'Accept, Authorization, Content-Type, DPoP, If-Match, If-None-Match, Link, Slug, Origin',
-    'Access-Control-Expose-Headers': 'Accept-Patch, Accept-Post, Allow, Content-Type, ETag, Link, Location, Updates-Via, WAC-Allow',
+    'Access-Control-Allow-Headers': 'Accept, Authorization, Content-Type, DPoP, If-Match, If-None-Match, Link, Range, Slug, Origin',
+    'Access-Control-Expose-Headers': 'Accept-Patch, Accept-Post, Accept-Ranges, Allow, Content-Length, Content-Range, Content-Type, ETag, Link, Location, Updates-Via, WAC-Allow',
     'Access-Control-Allow-Credentials': 'true',
     'Access-Control-Max-Age': '86400'
   };

--- a/src/mashlib/index.js
+++ b/src/mashlib/index.js
@@ -95,6 +95,113 @@ export function shouldServeMashlib(request, mashlibEnabled, contentType) {
 }
 
 /**
+ * Generate SolidOS UI HTML (modern Nextcloud-style interface)
+ * Uses mashlib for data layer but solidos-ui for the UI shell
+ *
+ * @returns {string} HTML content
+ */
+export function generateSolidosUiHtml() {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SolidOS - Modern UI</title>
+  <!-- SolidOS UI Styles -->
+  <link rel="stylesheet" href="/solidos-ui/styles/variables.css">
+  <link rel="stylesheet" href="/solidos-ui/styles/shell.css">
+  <link rel="stylesheet" href="/solidos-ui/styles/components.css">
+  <link rel="stylesheet" href="/solidos-ui/styles/responsive.css">
+  <!-- View-specific styles -->
+  <link rel="stylesheet" href="/solidos-ui/views/profile/profile.css">
+  <link rel="stylesheet" href="/solidos-ui/views/contacts/contacts.css">
+  <link rel="stylesheet" href="/solidos-ui/views/sharing/sharing.css">
+  <link rel="stylesheet" href="/solidos-ui/views/settings/settings.css">
+  <!-- Bundled styles (contains all component styles) -->
+  <link rel="stylesheet" href="/solidos-ui/style.css">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { height: 100%; }
+    #app { height: 100%; }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+
+  <script>
+    // Load mashlib first, then solidos-ui
+    (function() {
+      var mashScript = document.createElement('script');
+      mashScript.src = '/mashlib.min.js';
+      mashScript.onload = function() {
+        // Now load solidos-ui
+        import('/solidos-ui/solidos-ui.js').then(function(module) {
+          var initSolidOSSkin = module.initSolidOSSkin;
+          var SolidLogic = window.SolidLogic;
+          var panes = window.panes;
+          var store = SolidLogic.store;
+
+          initSolidOSSkin('#app', {
+            store: store,
+            fetcher: store.fetcher,
+            paneRegistry: panes,
+            authn: SolidLogic.authn,
+            logic: SolidLogic.solidLogicSingleton,
+          }, {
+            onNavigate: function(uri) {
+              if (uri) {
+                // Use path-based navigation - update URL to match resource
+                try {
+                  var url = new URL(uri);
+                  // Always use the path from the URI, regardless of origin
+                  // (URIs may use internal hostname like jss:4000 vs localhost:4000)
+                  var newPath = url.pathname;
+                  if (newPath !== window.location.pathname) {
+                    window.history.pushState({ uri: uri }, '', newPath);
+                  }
+                } catch (e) {
+                  console.warn('Invalid URI for navigation:', uri);
+                }
+              }
+            },
+            onLogout: function() {
+              window.location.reload();
+            },
+          }).then(function(skin) {
+            // Handle browser back/forward
+            window.addEventListener('popstate', function(event) {
+              // Use the current URL as the resource (not hash-based)
+              var resourceUrl = window.location.origin + window.location.pathname;
+              skin.goto(resourceUrl);
+            });
+
+            // Navigate to the current URL's resource
+            // The URL path IS the resource in JSS (not hash-based routing)
+            var currentPath = window.location.pathname;
+            if (currentPath && currentPath !== '/') {
+              var resourceUrl = window.location.origin + currentPath;
+              skin.goto(resourceUrl);
+            }
+
+            // Expose for debugging
+            window.solidosSkin = skin;
+          });
+        }).catch(function(err) {
+          console.error('Failed to load solidos-ui:', err);
+          document.body.innerHTML = '<p>Failed to load SolidOS UI</p>';
+        });
+      };
+      mashScript.onerror = function() {
+        document.body.innerHTML = '<p>Failed to load Mashlib</p>';
+      };
+      document.head.appendChild(mashScript);
+    })();
+  </script>
+</body>
+</html>`;
+}
+
+/**
  * Escape HTML special characters
  */
 function escapeHtml(str) {

--- a/src/server.js
+++ b/src/server.js
@@ -55,6 +55,8 @@ export function createServer(options = {}) {
   const mashlibEnabled = options.mashlib ?? false;
   const mashlibCdn = options.mashlibCdn ?? false;
   const mashlibVersion = options.mashlibVersion ?? '2.0.0';
+  // SolidOS UI (modern Nextcloud-style interface) - requires mashlib
+  const solidosUiEnabled = options.solidosUi ?? false;
   // Git HTTP backend is OFF by default - enables clone/push via git protocol
   const gitEnabled = options.git ?? false;
   // Nostr relay is OFF by default
@@ -127,6 +129,7 @@ export function createServer(options = {}) {
   fastify.decorateRequest('mashlibEnabled', null);
   fastify.decorateRequest('mashlibCdn', null);
   fastify.decorateRequest('mashlibVersion', null);
+  fastify.decorateRequest('solidosUiEnabled', null);
   fastify.decorateRequest('defaultQuota', null);
   fastify.addHook('onRequest', async (request) => {
     request.connegEnabled = connegEnabled;
@@ -137,6 +140,7 @@ export function createServer(options = {}) {
     request.mashlibEnabled = mashlibEnabled;
     request.mashlibCdn = mashlibCdn;
     request.mashlibVersion = mashlibVersion;
+    request.solidosUiEnabled = solidosUiEnabled;
     request.defaultQuota = defaultQuota;
 
     // Extract pod name from subdomain if enabled
@@ -296,7 +300,7 @@ export function createServer(options = {}) {
   // Authorization hook - check WAC permissions
   // Skip for pod creation endpoint (needs special handling)
   fastify.addHook('preHandler', async (request, reply) => {
-    // Skip auth for pod creation, OPTIONS, IdP routes, mashlib, well-known, notifications, nostr, git, and AP
+    // Skip auth for pod creation, OPTIONS, IdP routes, mashlib, solidos-ui, well-known, notifications, nostr, git, and AP
     const mashlibPaths = ['/mashlib.min.js', '/mash.css', '/841.mashlib.min.js'];
     const apPaths = ['/inbox', '/profile/card/inbox', '/profile/card/outbox', '/profile/card/followers', '/profile/card/following'];
     // Check if request wants ActivityPub content for profile
@@ -308,6 +312,7 @@ export function createServer(options = {}) {
         request.method === 'OPTIONS' ||
         request.url.startsWith('/idp/') ||
         request.url.startsWith('/.well-known/') ||
+        request.url.startsWith('/solidos-ui/') ||
         (nostrEnabled && request.url.startsWith(nostrPath)) ||
         (gitEnabled && isGitRequest(request.url)) ||
         (activitypubEnabled && apPaths.some(p => request.url === p || request.url.startsWith(p + '?'))) ||
@@ -379,6 +384,37 @@ export function createServer(options = {}) {
         });
       }
     }
+  }
+
+  // SolidOS UI static files (modern Nextcloud-style interface)
+  // Serves from /solidos-ui/* - requires mashlib to be enabled as well
+  if (solidosUiEnabled && mashlibEnabled) {
+    const solidosUiDir = join(__dirname, 'mashlib-local', 'dist', 'solidos-ui');
+
+    // Serve all files under /solidos-ui/* path
+    fastify.get('/solidos-ui/*', async (request, reply) => {
+      try {
+        // Get the path after /solidos-ui/
+        const filePath = request.url.replace('/solidos-ui/', '').split('?')[0];
+        const fullPath = join(solidosUiDir, filePath);
+
+        // Determine content type based on extension
+        const ext = filePath.split('.').pop()?.toLowerCase();
+        const contentTypes = {
+          'js': 'application/javascript',
+          'css': 'text/css',
+          'map': 'application/json',
+          'html': 'text/html'
+        };
+        const contentType = contentTypes[ext] || 'application/octet-stream';
+
+        const content = await readFile(fullPath);
+        return reply.type(contentType).send(content);
+      } catch (err) {
+        request.log.error(err, 'Failed to serve solidos-ui file');
+        return reply.code(404).send({ error: 'Not Found' });
+      }
+    });
   }
 
   // Rate limit configuration for write operations

--- a/src/storage/filesystem.js
+++ b/src/storage/filesystem.js
@@ -60,6 +60,11 @@ export async function read(urlPath) {
 export function createReadStream(urlPath, options = {}) {
   const filePath = urlToPath(urlPath);
 
+  // Check file exists before creating stream (createReadStream doesn't throw sync)
+  if (!fs.pathExistsSync(filePath)) {
+    return null;
+  }
+
   try {
     const stream = fs.createReadStream(filePath, options);
     return { stream, filePath };

--- a/src/storage/filesystem.js
+++ b/src/storage/filesystem.js
@@ -52,6 +52,23 @@ export async function read(urlPath) {
 }
 
 /**
+ * Create a readable stream for a resource (supports range requests)
+ * @param {string} urlPath
+ * @param {object} options - { start, end } byte range options
+ * @returns {{ stream: ReadStream, filePath: string } | null}
+ */
+export function createReadStream(urlPath, options = {}) {
+  const filePath = urlToPath(urlPath);
+
+  try {
+    const stream = fs.createReadStream(filePath, options);
+    return { stream, filePath };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Write resource content
  * @param {string} urlPath
  * @param {Buffer | string} content

--- a/test/range.test.js
+++ b/test/range.test.js
@@ -1,0 +1,145 @@
+/**
+ * Range Request Tests
+ *
+ * Tests HTTP Range header support for partial content delivery.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import {
+  startTestServer,
+  stopTestServer,
+  request,
+  createTestPod,
+  assertStatus
+} from './helpers.js';
+
+describe('Range Requests', () => {
+  const testContent = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'; // 36 bytes
+
+  before(async () => {
+    await startTestServer();
+    await createTestPod('rangetest');
+
+    // Create a test file with known content
+    await request('/rangetest/public/test.txt', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'text/plain' },
+      body: testContent,
+      auth: 'rangetest'
+    });
+  });
+
+  after(async () => {
+    await stopTestServer();
+  });
+
+  describe('Accept-Ranges header', () => {
+    it('should include Accept-Ranges: bytes for files', async () => {
+      const res = await request('/rangetest/public/test.txt');
+      assertStatus(res, 200);
+      assert.strictEqual(res.headers.get('Accept-Ranges'), 'bytes');
+    });
+
+    it('should include Accept-Ranges: none for containers', async () => {
+      const res = await request('/rangetest/public/');
+      assertStatus(res, 200);
+      assert.strictEqual(res.headers.get('Accept-Ranges'), 'none');
+    });
+  });
+
+  describe('Range header parsing', () => {
+    it('should return 206 for valid range bytes=0-9', async () => {
+      const res = await request('/rangetest/public/test.txt', {
+        headers: { 'Range': 'bytes=0-9' }
+      });
+      assertStatus(res, 206);
+
+      const body = await res.text();
+      assert.strictEqual(body, 'ABCDEFGHIJ');
+      assert.strictEqual(res.headers.get('Content-Range'), 'bytes 0-9/36');
+      assert.strictEqual(res.headers.get('Content-Length'), '10');
+    });
+
+    it('should return 206 for open-ended range bytes=30-', async () => {
+      const res = await request('/rangetest/public/test.txt', {
+        headers: { 'Range': 'bytes=30-' }
+      });
+      assertStatus(res, 206);
+
+      const body = await res.text();
+      assert.strictEqual(body, '456789');
+      assert.strictEqual(res.headers.get('Content-Range'), 'bytes 30-35/36');
+    });
+
+    it('should return 206 for suffix range bytes=-6', async () => {
+      const res = await request('/rangetest/public/test.txt', {
+        headers: { 'Range': 'bytes=-6' }
+      });
+      assertStatus(res, 206);
+
+      const body = await res.text();
+      assert.strictEqual(body, '456789');
+      assert.strictEqual(res.headers.get('Content-Range'), 'bytes 30-35/36');
+    });
+
+    it('should clamp end to file size for range exceeding file', async () => {
+      const res = await request('/rangetest/public/test.txt', {
+        headers: { 'Range': 'bytes=30-1000' }
+      });
+      assertStatus(res, 206);
+
+      const body = await res.text();
+      assert.strictEqual(body, '456789');
+      assert.strictEqual(res.headers.get('Content-Range'), 'bytes 30-35/36');
+    });
+  });
+
+  describe('Multi-range requests', () => {
+    it('should ignore multi-range and return 200 with full content', async () => {
+      const res = await request('/rangetest/public/test.txt', {
+        headers: { 'Range': 'bytes=0-5,10-15' }
+      });
+      // Multi-range is not supported, should fall back to 200
+      assertStatus(res, 200);
+
+      const body = await res.text();
+      assert.strictEqual(body, testContent);
+    });
+  });
+
+  describe('Invalid ranges', () => {
+    it('should return 200 for invalid range format', async () => {
+      const res = await request('/rangetest/public/test.txt', {
+        headers: { 'Range': 'invalid' }
+      });
+      // Invalid format, ignore Range header
+      assertStatus(res, 200);
+    });
+
+    it('should return 200 for non-bytes range unit', async () => {
+      const res = await request('/rangetest/public/test.txt', {
+        headers: { 'Range': 'chars=0-10' }
+      });
+      assertStatus(res, 200);
+    });
+  });
+
+  describe('RDF resources', () => {
+    it('should ignore Range header for RDF resources', async () => {
+      // Create an RDF resource
+      await request('/rangetest/public/data.jsonld', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/ld+json' },
+        body: JSON.stringify({ '@id': '#test', 'http://example.org/name': 'Test' }),
+        auth: 'rangetest'
+      });
+
+      const res = await request('/rangetest/public/data.jsonld', {
+        headers: { 'Range': 'bytes=0-10' }
+      });
+      // RDF resources don't support range requests
+      assertStatus(res, 200);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add `--solidos-ui` flag that serves a modern Nextcloud-style UI shell while reusing mashlib's data layer.

## Changes

| File | Change |
|------|--------|
| `bin/jss.js` | Add `--solidos-ui` CLI option |
| `src/config.js` | Add config + env var |
| `src/server.js` | Add `/solidos-ui/*` route + auth bypass |
| `src/mashlib/index.js` | Add `generateSolidosUiHtml()` |
| `src/handlers/resource.js` | Use solidos-ui HTML when enabled |
| `src/auth/middleware.js` | Use solidos-ui HTML when enabled |

## Usage

```bash
jss start --port 8080 --root ./data --mashlib --solidos-ui
```

## Architecture

```
┌─────────────────────────────────────┐
│         UI Layer (swappable)        │
│  --mashlib only    │  --solidos-ui  │
│  ┌───────────────┐ │ ┌────────────┐ │
│  │ Classic       │ │ │ Modern     │ │
│  │ Databrowser   │ │ │ Shell      │ │
│  └───────────────┘ │ └────────────┘ │
├─────────────────────────────────────┤
│      Data Layer (--mashlib)         │
│  rdflib.js + solid-logic + panes    │
└─────────────────────────────────────┘
```

## Test Plan

- [x] Tested on localhost:4000
- [x] Tested on melvincarvalho.com (production)
- [x] Folder navigation works
- [x] Browser back/forward works
- [x] Login/logout works

Closes #73