### PR TITLE
feat: add passkey (WebAuthn) authentication support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "javascript-solid-server",
-  "version": "0.0.75",
+  "version": "0.0.76",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "javascript-solid-server",
-      "version": "0.0.75",
+      "version": "0.0.76",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/middie": "^8.3.3",
         "@fastify/rate-limit": "^9.1.0",
         "@fastify/websocket": "^8.3.1",
+        "@simplewebauthn/server": "^13.2.2",
         "bcrypt": "^6.0.0",
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^12.5.0",
@@ -123,6 +124,12 @@
         "ws": "^8.0.0"
       }
     },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
+    },
     "node_modules/@koa/cors": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-5.0.0.tgz",
@@ -157,6 +164,12 @@
           "optional": false
         }
       }
+    },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
     },
     "node_modules/@lukeed/ms": {
       "version": "2.0.2",
@@ -222,6 +235,165 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.6.0.tgz",
+      "integrity": "sha512-cBRCKtYPF7vJGN76/yG8VbxRcHLPF3HnkoHhKOZeHpoVtbMYfY9ROKtH3DtYUY9m8uI1Mh47PRhHf2hSK3xcSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.0.tgz",
+      "integrity": "sha512-2uZqP+ggSncESeUF/9Su8rWqGclEfEiz1SyU02WX5fUONFfkjzS2Z/F1Li0ofSmf4JqYXIOdCAZqIXAIBAT1OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "@peculiar/asn1-x509-attr": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.0.tgz",
+      "integrity": "sha512-BeWIu5VpTIhfRysfEp73SGbwjjoLL/JWXhJ/9mo4vXnz3tRGm+NGm3KNcRzQ9VMVqwYS2RHlolz21svzRXIHPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.0.tgz",
+      "integrity": "sha512-FF3LMGq6SfAOwUG2sKpPXblibn6XnEIKa+SryvUl5Pik+WR9rmRA3OCiwz8R3lVXnYnyRkSZsSLdml8H3UiOcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.0.tgz",
+      "integrity": "sha512-rtUvtf+tyKGgokHHmZzeUojRZJYPxoD/jaN1+VAB4kKR7tXrnDCA/RAWXAIhMJJC+7W27IIRGe9djvxKgsldCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-pkcs8": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.0.tgz",
+      "integrity": "sha512-KyQ4D8G/NrS7Fw3XCJrngxmjwO/3htnA0lL9gDICvEQ+GJ+EPFqldcJQTwPIdvx98Tua+WjkdKHSC0/Km7T+lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.0.tgz",
+      "integrity": "sha512-b78OQ6OciW0aqZxdzliXGYHASeCvvw5caqidbpQRYW2mBtXIX2WhofNXTEe7NyxTb0P6J62kAAWLwn0HuMF1Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-pfx": "^2.6.0",
+        "@peculiar/asn1-pkcs8": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "@peculiar/asn1-x509-attr": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.0.tgz",
+      "integrity": "sha512-Nu4C19tsrTsCp9fDrH+sdcOKoVfdfoQQ7S3VqjJU6vedR7tY3RLkQ5oguOIB3zFW33USDUuYZnPEQYySlgha4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
+      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.0.tgz",
+      "integrity": "sha512-uzYbPEpoQiBoTq0/+jZtpM6Gq6zADBx+JNFP3yqRgziWBxQ/Dt/HcuvRfm9zJTPdRcBqPNdaRHTVwpyiq6iNMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.0.tgz",
+      "integrity": "sha512-MuIAXFX3/dc8gmoZBkwJWxUWOSvG4MMDntXhrOZpJVMkYX+MYc/rUAU2uJOved9iJEoiUx7//3D8oG83a78UJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.2.tgz",
+      "integrity": "sha512-r2w1Hg6pODDs0zfAKHkSS5HLkOLSeburtcgwvlLLWWCixw+MmW3U6kD5ddyvc2Y2YdbGuVwCF2S2ASoU1cFAag==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
     "node_modules/@scure/base": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
@@ -271,6 +443,25 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.2.2.tgz",
+      "integrity": "sha512-HcWLW28yTMGXpwE9VLx9J+N2KEUaELadLrkPEEI9tpI5la70xNEVEsu/C+m3u7uoq4FulLqZQhgBCzR9IZhFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.3.10",
+        "@peculiar/asn1-ecc": "^2.3.8",
+        "@peculiar/asn1-rsa": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-x509": "^2.3.8",
+        "@peculiar/x509": "^1.13.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/abort-controller": {
@@ -373,6 +564,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
+      "integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/asynckit": {
@@ -2053,6 +2258,24 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
@@ -2123,6 +2346,12 @@
       "engines": {
         "node": ">= 12.13.0"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/reinterval": {
       "version": "1.1.0",
@@ -2449,6 +2678,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/tsscmp": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
@@ -2457,6 +2692,24 @@
       "engines": {
         "node": ">=0.6.x"
       }
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -2668,6 +2921,11 @@
         "ws": "^8.0.0"
       }
     },
+    "@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="
+    },
     "@koa/cors": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-5.0.0.tgz",
@@ -2686,6 +2944,11 @@
         "koa-compose": "^4.1.0",
         "path-to-regexp": "^8.3.0"
       }
+    },
+    "@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="
     },
     "@lukeed/ms": {
       "version": "2.0.2",
@@ -2726,6 +2989,150 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
       "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA=="
     },
+    "@peculiar/asn1-android": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.6.0.tgz",
+      "integrity": "sha512-cBRCKtYPF7vJGN76/yG8VbxRcHLPF3HnkoHhKOZeHpoVtbMYfY9ROKtH3DtYUY9m8uI1Mh47PRhHf2hSK3xcSQ==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-cms": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.0.tgz",
+      "integrity": "sha512-2uZqP+ggSncESeUF/9Su8rWqGclEfEiz1SyU02WX5fUONFfkjzS2Z/F1Li0ofSmf4JqYXIOdCAZqIXAIBAT1OA==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "@peculiar/asn1-x509-attr": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-csr": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.0.tgz",
+      "integrity": "sha512-BeWIu5VpTIhfRysfEp73SGbwjjoLL/JWXhJ/9mo4vXnz3tRGm+NGm3KNcRzQ9VMVqwYS2RHlolz21svzRXIHPQ==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-ecc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.0.tgz",
+      "integrity": "sha512-FF3LMGq6SfAOwUG2sKpPXblibn6XnEIKa+SryvUl5Pik+WR9rmRA3OCiwz8R3lVXnYnyRkSZsSLdml8H3UiOcw==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-pfx": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.0.tgz",
+      "integrity": "sha512-rtUvtf+tyKGgokHHmZzeUojRZJYPxoD/jaN1+VAB4kKR7tXrnDCA/RAWXAIhMJJC+7W27IIRGe9djvxKgsldCQ==",
+      "requires": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-pkcs8": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-pkcs8": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.0.tgz",
+      "integrity": "sha512-KyQ4D8G/NrS7Fw3XCJrngxmjwO/3htnA0lL9gDICvEQ+GJ+EPFqldcJQTwPIdvx98Tua+WjkdKHSC0/Km7T+lA==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-pkcs9": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.0.tgz",
+      "integrity": "sha512-b78OQ6OciW0aqZxdzliXGYHASeCvvw5caqidbpQRYW2mBtXIX2WhofNXTEe7NyxTb0P6J62kAAWLwn0HuMF1Fw==",
+      "requires": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-pfx": "^2.6.0",
+        "@peculiar/asn1-pkcs8": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "@peculiar/asn1-x509-attr": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-rsa": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.0.tgz",
+      "integrity": "sha512-Nu4C19tsrTsCp9fDrH+sdcOKoVfdfoQQ7S3VqjJU6vedR7tY3RLkQ5oguOIB3zFW33USDUuYZnPEQYySlgha4w==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-schema": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
+      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+      "requires": {
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-x509": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.0.tgz",
+      "integrity": "sha512-uzYbPEpoQiBoTq0/+jZtpM6Gq6zADBx+JNFP3yqRgziWBxQ/Dt/HcuvRfm9zJTPdRcBqPNdaRHTVwpyiq6iNMA==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-x509-attr": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.0.tgz",
+      "integrity": "sha512-MuIAXFX3/dc8gmoZBkwJWxUWOSvG4MMDntXhrOZpJVMkYX+MYc/rUAU2uJOved9iJEoiUx7//3D8oG83a78UJA==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/x509": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.2.tgz",
+      "integrity": "sha512-r2w1Hg6pODDs0zfAKHkSS5HLkOLSeburtcgwvlLLWWCixw+MmW3U6kD5ddyvc2Y2YdbGuVwCF2S2ASoU1cFAag==",
+      "requires": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      }
+    },
     "@scure/base": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
@@ -2758,6 +3165,21 @@
       "requires": {
         "@noble/hashes": "~1.3.0",
         "@scure/base": "~1.1.0"
+      }
+    },
+    "@simplewebauthn/server": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.2.2.tgz",
+      "integrity": "sha512-HcWLW28yTMGXpwE9VLx9J+N2KEUaELadLrkPEEI9tpI5la70xNEVEsu/C+m3u7uoq4FulLqZQhgBCzR9IZhFpA==",
+      "requires": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.3.10",
+        "@peculiar/asn1-ecc": "^2.3.8",
+        "@peculiar/asn1-rsa": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-x509": "^2.3.8",
+        "@peculiar/x509": "^1.13.0"
       }
     },
     "abort-controller": {
@@ -2821,6 +3243,16 @@
       "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
+      }
+    },
+    "asn1js": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
+      "integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
+      "requires": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
       }
     },
     "asynckit": {
@@ -3952,6 +4384,19 @@
         "once": "^1.3.1"
       }
     },
+    "pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "requires": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="
+    },
     "quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
@@ -4000,6 +4445,11 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
+    },
+    "reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
     },
     "reinterval": {
       "version": "1.1.0",
@@ -4215,10 +4665,30 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
+    "tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
     "tsscmp": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
       "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
+    },
+    "tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "requires": {
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@fastify/middie": "^8.3.3",
     "@fastify/rate-limit": "^9.1.0",
     "@fastify/websocket": "^8.3.1",
+    "@simplewebauthn/server": "^13.2.2",
     "bcrypt": "^6.0.0",
     "bcryptjs": "^3.0.3",
     "better-sqlite3": "^12.5.0",

--- a/src/idp/accounts.js
+++ b/src/idp/accounts.js
@@ -310,6 +310,13 @@ export async function addPasskey(accountId, credential) {
   if (!account) return false;
 
   account.passkeys = account.passkeys || [];
+
+  // Check for duplicate credentialId
+  const existingPasskey = account.passkeys.find(pk => pk.credentialId === credential.credentialId);
+  if (existingPasskey) {
+    return false; // Already registered
+  }
+
   account.passkeys.push({
     credentialId: credential.credentialId,
     publicKey: credential.publicKey,

--- a/src/idp/accounts.js
+++ b/src/idp/accounts.js
@@ -38,6 +38,10 @@ function getWebIdIndexPath() {
   return path.join(getAccountsDir(), '_webid_index.json');
 }
 
+function getCredentialIndexPath() {
+  return path.join(getAccountsDir(), '_credential_index.json');
+}
+
 const SALT_ROUNDS = 10;
 
 /**
@@ -268,6 +272,128 @@ export async function deleteAccount(id) {
   // Delete account file
   const accountPath = path.join(getAccountsDir(), `${id}.json`);
   await fs.remove(accountPath);
+}
+
+/**
+ * Save an account (internal helper)
+ * @param {object} account - Account object
+ */
+async function saveAccount(account) {
+  const accountPath = path.join(getAccountsDir(), `${account.id}.json`);
+  await fs.writeJson(accountPath, account, { spaces: 2 });
+}
+
+/**
+ * Update last login timestamp
+ * @param {string} id - Account ID
+ */
+export async function updateLastLogin(id) {
+  const account = await findById(id);
+  if (!account) return;
+  account.lastLogin = new Date().toISOString();
+  await saveAccount(account);
+}
+
+/**
+ * Add a passkey credential to an account
+ * @param {string} accountId - Account ID
+ * @param {object} credential - Passkey credential
+ * @param {string} credential.credentialId - Base64url encoded credential ID
+ * @param {string} credential.publicKey - Base64url encoded public key
+ * @param {number} credential.counter - Authenticator counter
+ * @param {string[]} [credential.transports] - Supported transports
+ * @param {string} [credential.name] - User-friendly name
+ * @returns {Promise<boolean>} - Success
+ */
+export async function addPasskey(accountId, credential) {
+  const account = await findById(accountId);
+  if (!account) return false;
+
+  account.passkeys = account.passkeys || [];
+  account.passkeys.push({
+    credentialId: credential.credentialId,
+    publicKey: credential.publicKey,
+    counter: credential.counter || 0,
+    transports: credential.transports || [],
+    createdAt: new Date().toISOString(),
+    lastUsed: null,
+    name: credential.name || 'Security Key'
+  });
+
+  await saveAccount(account);
+
+  // Update credential index
+  const credentialIndex = await loadIndex(getCredentialIndexPath());
+  credentialIndex[credential.credentialId] = accountId;
+  await saveIndex(getCredentialIndexPath(), credentialIndex);
+
+  return true;
+}
+
+/**
+ * Find an account by passkey credential ID
+ * @param {string} credentialId - Base64url encoded credential ID
+ * @returns {Promise<object|null>} - Account or null
+ */
+export async function findByCredentialId(credentialId) {
+  const credentialIndex = await loadIndex(getCredentialIndexPath());
+  const id = credentialIndex[credentialId];
+  if (!id) return null;
+  return findById(id);
+}
+
+/**
+ * Update passkey counter after successful authentication
+ * @param {string} accountId - Account ID
+ * @param {string} credentialId - Credential ID
+ * @param {number} newCounter - New counter value
+ */
+export async function updatePasskeyCounter(accountId, credentialId, newCounter) {
+  const account = await findById(accountId);
+  if (!account || !account.passkeys) return;
+
+  const passkey = account.passkeys.find(p => p.credentialId === credentialId);
+  if (passkey) {
+    passkey.counter = newCounter;
+    passkey.lastUsed = new Date().toISOString();
+    await saveAccount(account);
+  }
+}
+
+/**
+ * Remove a passkey from an account
+ * @param {string} accountId - Account ID
+ * @param {string} credentialId - Credential ID to remove
+ * @returns {Promise<boolean>} - Success
+ */
+export async function removePasskey(accountId, credentialId) {
+  const account = await findById(accountId);
+  if (!account || !account.passkeys) return false;
+
+  const index = account.passkeys.findIndex(p => p.credentialId === credentialId);
+  if (index === -1) return false;
+
+  account.passkeys.splice(index, 1);
+  await saveAccount(account);
+
+  // Update credential index
+  const credentialIndex = await loadIndex(getCredentialIndexPath());
+  delete credentialIndex[credentialId];
+  await saveIndex(getCredentialIndexPath(), credentialIndex);
+
+  return true;
+}
+
+/**
+ * Set passkey prompt dismissed flag
+ * @param {string} accountId - Account ID
+ * @param {boolean} dismissed - Whether prompt was dismissed
+ */
+export async function setPasskeyPromptDismissed(accountId, dismissed = true) {
+  const account = await findById(accountId);
+  if (!account) return;
+  account.passkeyPromptDismissed = dismissed;
+  await saveAccount(account);
 }
 
 /**

--- a/src/idp/index.js
+++ b/src/idp/index.js
@@ -13,11 +13,14 @@ import {
   handleAbort,
   handleRegisterGet,
   handleRegisterPost,
+  handlePasskeyComplete,
+  handlePasskeySkip,
 } from './interactions.js';
 import {
   handleCredentials,
   handleCredentialsInfo,
 } from './credentials.js';
+import * as passkey from './passkey.js';
 import { addTrustedIssuer } from '../auth/solid-oidc.js';
 
 /**
@@ -288,6 +291,52 @@ export async function idpPlugin(fastify, options) {
     }
   }, async (request, reply) => {
     return handleRegisterPost(request, reply, issuer, inviteOnly);
+  });
+
+  // Passkey routes
+  // Registration options - requires authenticated session context
+  fastify.post('/idp/passkey/register/options', async (request, reply) => {
+    return passkey.registrationOptions(request, reply);
+  });
+
+  // Registration verify - rate limited
+  fastify.post('/idp/passkey/register/verify', {
+    config: {
+      rateLimit: {
+        max: 10,
+        timeWindow: '1 minute',
+        keyGenerator: (request) => request.ip
+      }
+    }
+  }, async (request, reply) => {
+    return passkey.registrationVerify(request, reply);
+  });
+
+  // Login options
+  fastify.post('/idp/passkey/login/options', async (request, reply) => {
+    return passkey.authenticationOptions(request, reply);
+  });
+
+  // Login verify - rate limited
+  fastify.post('/idp/passkey/login/verify', {
+    config: {
+      rateLimit: {
+        max: 10,
+        timeWindow: '1 minute',
+        keyGenerator: (request) => request.ip
+      }
+    }
+  }, async (request, reply) => {
+    return passkey.authenticationVerify(request, reply);
+  });
+
+  // Passkey interaction handlers
+  fastify.get('/idp/interaction/:uid/passkey-complete', async (request, reply) => {
+    return handlePasskeyComplete(request, reply, provider);
+  });
+
+  fastify.get('/idp/interaction/:uid/passkey-skip', async (request, reply) => {
+    return handlePasskeySkip(request, reply, provider);
   });
 
   fastify.log.info(`IdP initialized with issuer: ${issuer}`);

--- a/src/idp/index.js
+++ b/src/idp/index.js
@@ -294,8 +294,16 @@ export async function idpPlugin(fastify, options) {
   });
 
   // Passkey routes
-  // Registration options - requires authenticated session context
-  fastify.post('/idp/passkey/register/options', async (request, reply) => {
+  // Registration options - rate limited to prevent DoS
+  fastify.post('/idp/passkey/register/options', {
+    config: {
+      rateLimit: {
+        max: 10,
+        timeWindow: '1 minute',
+        keyGenerator: (request) => request.ip
+      }
+    }
+  }, async (request, reply) => {
     return passkey.registrationOptions(request, reply);
   });
 
@@ -312,8 +320,16 @@ export async function idpPlugin(fastify, options) {
     return passkey.registrationVerify(request, reply);
   });
 
-  // Login options
-  fastify.post('/idp/passkey/login/options', async (request, reply) => {
+  // Login options - rate limited to prevent DoS
+  fastify.post('/idp/passkey/login/options', {
+    config: {
+      rateLimit: {
+        max: 10,
+        timeWindow: '1 minute',
+        keyGenerator: (request) => request.ip
+      }
+    }
+  }, async (request, reply) => {
     return passkey.authenticationOptions(request, reply);
   });
 

--- a/src/idp/interactions.js
+++ b/src/idp/interactions.js
@@ -133,8 +133,7 @@ export async function handleLogin(request, reply, provider) {
     const fullAccount = await findById(account.id);
     const shouldPromptPasskey = wantsBrowserRedirect &&
       !fullAccount.passkeys?.length &&
-      !fullAccount.passkeyPromptDismissed &&
-      request.passkeyEnabled !== false;
+      !fullAccount.passkeyPromptDismissed;
 
     if (shouldPromptPasskey) {
       // Show passkey registration prompt before completing login

--- a/src/idp/interactions.js
+++ b/src/idp/interactions.js
@@ -471,6 +471,15 @@ export async function handlePasskeyComplete(request, reply, provider) {
       return reply.code(404).type('text/html').send(errorPage('Session expired', 'Please try logging in again.'));
     }
 
+    // If this is a post-login passkey registration flow, validate accountId matches
+    // the already-authenticated user to prevent account takeover
+    if (interaction.passkeyPromptPending && interaction.result?.login?.accountId) {
+      if (interaction.result.login.accountId !== accountId) {
+        request.log.warn({ expected: interaction.result.login.accountId, provided: accountId }, 'AccountId mismatch in passkey complete');
+        return reply.code(403).type('text/html').send(errorPage('Access denied', 'Account mismatch.'));
+      }
+    }
+
     const account = await findById(accountId);
     if (!account) {
       return reply.code(404).type('text/html').send(errorPage('Account not found', 'The account could not be found.'));
@@ -508,6 +517,11 @@ export async function handlePasskeySkip(request, reply, provider) {
     const interaction = await provider.Interaction.find(uid);
     if (!interaction) {
       return reply.code(404).type('text/html').send(errorPage('Session expired', 'Please try logging in again.'));
+    }
+
+    // Validate the interaction is in the passkey prompt state
+    if (!interaction.passkeyPromptPending) {
+      return reply.code(400).type('text/html').send(errorPage('Invalid state', 'Not in passkey prompt flow.'));
     }
 
     // Get the pending login result

--- a/src/idp/interactions.js
+++ b/src/idp/interactions.js
@@ -3,8 +3,8 @@
  * Handles the user-facing parts of the authentication flow
  */
 
-import { authenticate, findById, createAccount } from './accounts.js';
-import { loginPage, consentPage, errorPage, registerPage } from './views.js';
+import { authenticate, findById, createAccount, updateLastLogin, setPasskeyPromptDismissed } from './accounts.js';
+import { loginPage, consentPage, errorPage, registerPage, passkeyPromptPage } from './views.js';
 import * as storage from '../storage/filesystem.js';
 import { createPodStructure } from '../handlers/container.js';
 import { validateInvite } from './invites.js';
@@ -122,19 +122,38 @@ export async function handleLogin(request, reply, provider) {
       return reply.redirect(`/idp/interaction/${uid}`);
     }
 
-    // Login successful - complete the interaction
+    // Login successful
+    request.log.info({ accountId: account.id, uid }, 'Login successful');
+
+    // Detect if this is a browser (wants HTML/redirect) or programmatic client (wants JSON)
+    const acceptHeader = request.headers.accept || '';
+    const wantsBrowserRedirect = acceptHeader.includes('text/html') && !acceptHeader.includes('application/json');
+
+    // Check if user should see passkey prompt (browser only, no passkeys, not dismissed)
+    const fullAccount = await findById(account.id);
+    const shouldPromptPasskey = wantsBrowserRedirect &&
+      !fullAccount.passkeys?.length &&
+      !fullAccount.passkeyPromptDismissed &&
+      request.passkeyEnabled !== false;
+
+    if (shouldPromptPasskey) {
+      // Show passkey registration prompt before completing login
+      // Store the pending login in the interaction
+      interaction.result = {
+        login: { accountId: account.id, remember: true }
+      };
+      interaction.passkeyPromptPending = true;
+      await interaction.save(interaction.exp - Math.floor(Date.now() / 1000));
+      return reply.type('text/html').send(passkeyPromptPage(uid, account.id));
+    }
+
+    // Complete the interaction
     const result = {
       login: {
         accountId: account.id,
         remember: true,
       },
     };
-
-    request.log.info({ accountId: account.id, uid }, 'Login successful');
-
-    // Detect if this is a browser (wants HTML/redirect) or programmatic client (wants JSON)
-    const acceptHeader = request.headers.accept || '';
-    const wantsBrowserRedirect = acceptHeader.includes('text/html') && !acceptHeader.includes('application/json');
 
     // Save the login result to the interaction
     interaction.result = result;
@@ -431,5 +450,82 @@ export async function handleRegisterPost(request, reply, issuer, inviteOnly = fa
   } catch (err) {
     request.log.error(err, 'Registration error');
     return reply.type('text/html').send(registerPage(uid, err.message, null, inviteOnly));
+  }
+}
+
+/**
+ * Handle GET /idp/interaction/:uid/passkey-complete
+ * Completes OIDC interaction after passkey login or registration
+ */
+export async function handlePasskeyComplete(request, reply, provider) {
+  const { uid } = request.params;
+  const { accountId } = request.query;
+
+  if (!accountId) {
+    return reply.code(400).type('text/html').send(errorPage('Missing account', 'Account ID is required.'));
+  }
+
+  try {
+    const interaction = await provider.Interaction.find(uid);
+    if (!interaction) {
+      return reply.code(404).type('text/html').send(errorPage('Session expired', 'Please try logging in again.'));
+    }
+
+    const account = await findById(accountId);
+    if (!account) {
+      return reply.code(404).type('text/html').send(errorPage('Account not found', 'The account could not be found.'));
+    }
+
+    // Update last login
+    await updateLastLogin(accountId);
+
+    // Complete the OIDC interaction
+    const result = {
+      login: {
+        accountId: account.id,
+        remember: true,
+      },
+    };
+
+    request.log.info({ accountId: account.id, uid }, 'Passkey login completed');
+
+    reply.hijack();
+    return provider.interactionFinished(request.raw, reply.raw, result, { mergeWithLastSubmission: false });
+  } catch (err) {
+    request.log.error(err, 'Passkey complete error');
+    return reply.code(500).type('text/html').send(errorPage('Error', err.message));
+  }
+}
+
+/**
+ * Handle GET /idp/interaction/:uid/passkey-skip
+ * User skipped passkey registration, complete login
+ */
+export async function handlePasskeySkip(request, reply, provider) {
+  const { uid } = request.params;
+
+  try {
+    const interaction = await provider.Interaction.find(uid);
+    if (!interaction) {
+      return reply.code(404).type('text/html').send(errorPage('Session expired', 'Please try logging in again.'));
+    }
+
+    // Get the pending login result
+    const result = interaction.result;
+    if (!result?.login?.accountId) {
+      return reply.code(400).type('text/html').send(errorPage('Invalid state', 'No pending login found.'));
+    }
+
+    // Mark passkey prompt as dismissed so we don't nag again
+    await setPasskeyPromptDismissed(result.login.accountId, true);
+
+    request.log.info({ accountId: result.login.accountId, uid }, 'Passkey prompt skipped');
+
+    // Complete the OIDC interaction
+    reply.hijack();
+    return provider.interactionFinished(request.raw, reply.raw, result, { mergeWithLastSubmission: false });
+  } catch (err) {
+    request.log.error(err, 'Passkey skip error');
+    return reply.code(500).type('text/html').send(errorPage('Error', err.message));
   }
 }

--- a/src/idp/passkey.js
+++ b/src/idp/passkey.js
@@ -30,9 +30,18 @@ cleanupInterval.unref();
 
 /**
  * Get Relying Party configuration from request
+ * Handles both IPv4 (with port) and IPv6 addresses correctly
  */
 function getRP(request) {
-  const hostname = request.hostname.split(':')[0]; // Remove port
+  let hostname;
+  try {
+    // Use URL parsing to correctly extract hostname (handles IPv6)
+    const url = new URL(`${request.protocol}://${request.hostname}`);
+    hostname = url.hostname;
+  } catch {
+    // Fallback: strip port from hostname (IPv4 only)
+    hostname = String(request.hostname || '').split(':')[0];
+  }
   return {
     name: 'Solid Pod',
     id: hostname
@@ -141,7 +150,7 @@ export async function registrationVerify(request, reply) {
 
     return reply.send({ success: true });
   } catch (err) {
-    console.error('Passkey registration error:', err);
+    request.log.error({ err }, 'Passkey registration error');
     return reply.code(400).send({ error: err.message });
   }
 }
@@ -257,7 +266,7 @@ export async function authenticationVerify(request, reply) {
       webId: account.webId
     });
   } catch (err) {
-    console.error('Passkey authentication error:', err);
+    request.log.error({ err }, 'Passkey authentication error');
     return reply.code(400).send({ error: err.message });
   }
 }

--- a/src/idp/passkey.js
+++ b/src/idp/passkey.js
@@ -1,0 +1,261 @@
+/**
+ * Passkey (WebAuthn) authentication endpoints
+ * Handles registration and authentication of passkey credentials
+ */
+
+import {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse
+} from '@simplewebauthn/server';
+import crypto from 'crypto';
+import * as accounts from './accounts.js';
+
+// Temporary challenge storage (in-memory, cleared on restart)
+// For production clusters, use Redis or session storage
+const challenges = new Map();
+
+// Clean up expired challenges periodically
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, value] of challenges.entries()) {
+    if (now > value.expires) {
+      challenges.delete(key);
+    }
+  }
+}, 60000); // Clean every minute
+
+/**
+ * Get Relying Party configuration from request
+ */
+function getRP(request) {
+  const hostname = request.hostname.split(':')[0]; // Remove port
+  return {
+    name: 'Solid Pod',
+    id: hostname
+  };
+}
+
+/**
+ * Get origin from request
+ */
+function getOrigin(request) {
+  return `${request.protocol}://${request.hostname}`;
+}
+
+/**
+ * POST /idp/passkey/register/options
+ * Generate registration options for a logged-in user
+ */
+export async function registrationOptions(request, reply) {
+  const { accountId } = request.body || {};
+
+  if (!accountId) {
+    return reply.code(401).send({ error: 'Must provide accountId' });
+  }
+
+  const account = await accounts.findById(accountId);
+  if (!account) {
+    return reply.code(404).send({ error: 'Account not found' });
+  }
+
+  const rp = getRP(request);
+
+  const options = await generateRegistrationOptions({
+    rpName: rp.name,
+    rpID: rp.id,
+    userID: new TextEncoder().encode(account.id),
+    userName: account.username,
+    userDisplayName: account.username,
+    attestationType: 'none', // Don't require attestation for privacy
+    excludeCredentials: (account.passkeys || []).map(pk => ({
+      id: Buffer.from(pk.credentialId, 'base64url'),
+      type: 'public-key',
+      transports: pk.transports
+    })),
+    authenticatorSelection: {
+      residentKey: 'preferred',
+      userVerification: 'preferred'
+    }
+  });
+
+  // Store challenge for verification
+  challenges.set(account.id, {
+    challenge: options.challenge,
+    type: 'registration',
+    expires: Date.now() + 60000 // 1 minute
+  });
+
+  return reply.send(options);
+}
+
+/**
+ * POST /idp/passkey/register/verify
+ * Verify and store the registration response
+ */
+export async function registrationVerify(request, reply) {
+  const { accountId, credential, name } = request.body || {};
+
+  if (!accountId || !credential) {
+    return reply.code(400).send({ error: 'Missing accountId or credential' });
+  }
+
+  const account = await accounts.findById(accountId);
+  if (!account) {
+    return reply.code(404).send({ error: 'Account not found' });
+  }
+
+  const stored = challenges.get(account.id);
+  if (!stored || stored.type !== 'registration' || Date.now() > stored.expires) {
+    return reply.code(400).send({ error: 'Challenge expired or invalid' });
+  }
+
+  const rp = getRP(request);
+
+  try {
+    const verification = await verifyRegistrationResponse({
+      response: credential,
+      expectedChallenge: stored.challenge,
+      expectedOrigin: getOrigin(request),
+      expectedRPID: rp.id
+    });
+
+    if (!verification.verified || !verification.registrationInfo) {
+      return reply.code(400).send({ error: 'Verification failed' });
+    }
+
+    const { credential: regCredential, credentialPublicKey, counter } = verification.registrationInfo;
+
+    await accounts.addPasskey(accountId, {
+      credentialId: Buffer.from(regCredential.id).toString('base64url'),
+      publicKey: Buffer.from(credentialPublicKey).toString('base64url'),
+      counter,
+      transports: credential.response?.transports || [],
+      name: name || 'Security Key'
+    });
+
+    challenges.delete(account.id);
+
+    return reply.send({ success: true });
+  } catch (err) {
+    console.error('Passkey registration error:', err);
+    return reply.code(400).send({ error: err.message });
+  }
+}
+
+/**
+ * POST /idp/passkey/login/options
+ * Generate authentication options
+ */
+export async function authenticationOptions(request, reply) {
+  const { username } = request.body || {};
+  const rp = getRP(request);
+
+  let allowCredentials = [];
+  let accountId = null;
+
+  // If username provided, limit to that user's credentials
+  if (username) {
+    const account = await accounts.findByUsername(username);
+    if (account && account.passkeys?.length) {
+      accountId = account.id;
+      allowCredentials = account.passkeys.map(pk => ({
+        id: Buffer.from(pk.credentialId, 'base64url'),
+        type: 'public-key',
+        transports: pk.transports
+      }));
+    }
+  }
+
+  const options = await generateAuthenticationOptions({
+    rpID: rp.id,
+    allowCredentials,
+    userVerification: 'preferred'
+  });
+
+  // Store challenge - use visitorId for anonymous requests
+  const challengeKey = accountId || request.body?.visitorId || crypto.randomUUID();
+  challenges.set(challengeKey, {
+    challenge: options.challenge,
+    type: 'authentication',
+    accountId,
+    expires: Date.now() + 60000 // 1 minute
+  });
+
+  return reply.send({ ...options, challengeKey });
+}
+
+/**
+ * POST /idp/passkey/login/verify
+ * Verify authentication and return account info
+ */
+export async function authenticationVerify(request, reply) {
+  const { challengeKey, credential } = request.body || {};
+
+  if (!challengeKey || !credential) {
+    return reply.code(400).send({ error: 'Missing challengeKey or credential' });
+  }
+
+  const stored = challenges.get(challengeKey);
+  if (!stored || stored.type !== 'authentication' || Date.now() > stored.expires) {
+    return reply.code(400).send({ error: 'Challenge expired or invalid' });
+  }
+
+  // Find account by credential ID
+  const credentialId = credential.id;
+  const account = stored.accountId
+    ? await accounts.findById(stored.accountId)
+    : await accounts.findByCredentialId(credentialId);
+
+  if (!account) {
+    return reply.code(400).send({ error: 'Unknown credential' });
+  }
+
+  const passkey = account.passkeys?.find(pk => pk.credentialId === credentialId);
+  if (!passkey) {
+    return reply.code(400).send({ error: 'Credential not found' });
+  }
+
+  const rp = getRP(request);
+
+  try {
+    const verification = await verifyAuthenticationResponse({
+      response: credential,
+      expectedChallenge: stored.challenge,
+      expectedOrigin: getOrigin(request),
+      expectedRPID: rp.id,
+      credential: {
+        id: Buffer.from(passkey.credentialId, 'base64url'),
+        publicKey: Buffer.from(passkey.publicKey, 'base64url'),
+        counter: passkey.counter
+      }
+    });
+
+    if (!verification.verified) {
+      return reply.code(400).send({ error: 'Verification failed' });
+    }
+
+    // Update counter to prevent replay attacks
+    await accounts.updatePasskeyCounter(
+      account.id,
+      credentialId,
+      verification.authenticationInfo.newCounter
+    );
+
+    // Update last login
+    await accounts.updateLastLogin(account.id);
+
+    challenges.delete(challengeKey);
+
+    // Return account info for session creation
+    return reply.send({
+      success: true,
+      accountId: account.id,
+      webId: account.webId
+    });
+  } catch (err) {
+    console.error('Passkey authentication error:', err);
+    return reply.code(400).send({ error: err.message });
+  }
+}

--- a/src/idp/passkey.js
+++ b/src/idp/passkey.js
@@ -15,6 +15,7 @@ import * as accounts from './accounts.js';
 // Temporary challenge storage (in-memory, cleared on restart)
 // For production clusters, use Redis or session storage
 const challenges = new Map();
+const MAX_CHALLENGES = 10000; // Prevent unbounded growth
 
 // Clean up expired challenges periodically
 // Use unref() so this timer doesn't prevent process exit (important for tests)
@@ -27,6 +28,28 @@ const cleanupInterval = setInterval(() => {
   }
 }, 60000);
 cleanupInterval.unref();
+
+/**
+ * Store a challenge with size limit enforcement
+ */
+function storeChallenge(key, value) {
+  // If at capacity, remove oldest expired entries first
+  if (challenges.size >= MAX_CHALLENGES) {
+    const now = Date.now();
+    for (const [k, v] of challenges.entries()) {
+      if (now > v.expires) {
+        challenges.delete(k);
+      }
+      if (challenges.size < MAX_CHALLENGES) break;
+    }
+  }
+  // If still at capacity, reject (DoS protection)
+  if (challenges.size >= MAX_CHALLENGES) {
+    return false;
+  }
+  challenges.set(key, value);
+  return true;
+}
 
 /**
  * Get Relying Party configuration from request
@@ -92,11 +115,15 @@ export async function registrationOptions(request, reply) {
   });
 
   // Store challenge for verification
-  challenges.set(account.id, {
+  const stored = storeChallenge(account.id, {
     challenge: options.challenge,
     type: 'registration',
     expires: Date.now() + 60000 // 1 minute
   });
+
+  if (!stored) {
+    return reply.code(503).send({ error: 'Server busy, try again later' });
+  }
 
   return reply.send(options);
 }
@@ -151,7 +178,7 @@ export async function registrationVerify(request, reply) {
     return reply.send({ success: true });
   } catch (err) {
     request.log.error({ err }, 'Passkey registration error');
-    return reply.code(400).send({ error: err.message });
+    return reply.code(400).send({ error: 'Passkey registration failed' });
   }
 }
 
@@ -187,12 +214,16 @@ export async function authenticationOptions(request, reply) {
 
   // Store challenge - use visitorId for anonymous requests
   const challengeKey = accountId || request.body?.visitorId || crypto.randomUUID();
-  challenges.set(challengeKey, {
+  const stored = storeChallenge(challengeKey, {
     challenge: options.challenge,
     type: 'authentication',
     accountId,
     expires: Date.now() + 60000 // 1 minute
   });
+
+  if (!stored) {
+    return reply.code(503).send({ error: 'Server busy, try again later' });
+  }
 
   return reply.send({ ...options, challengeKey });
 }
@@ -267,6 +298,6 @@ export async function authenticationVerify(request, reply) {
     });
   } catch (err) {
     request.log.error({ err }, 'Passkey authentication error');
-    return reply.code(400).send({ error: err.message });
+    return reply.code(400).send({ error: 'Authentication failed' });
   }
 }

--- a/src/idp/passkey.js
+++ b/src/idp/passkey.js
@@ -17,14 +17,16 @@ import * as accounts from './accounts.js';
 const challenges = new Map();
 
 // Clean up expired challenges periodically
-setInterval(() => {
+// Use unref() so this timer doesn't prevent process exit (important for tests)
+const cleanupInterval = setInterval(() => {
   const now = Date.now();
   for (const [key, value] of challenges.entries()) {
     if (now > value.expires) {
       challenges.delete(key);
     }
   }
-}, 60000); // Clean every minute
+}, 60000);
+cleanupInterval.unref();
 
 /**
  * Get Relying Party configuration from request

--- a/src/idp/passkey.js
+++ b/src/idp/passkey.js
@@ -114,10 +114,12 @@ export async function registrationOptions(request, reply) {
     }
   });
 
-  // Store challenge for verification
-  const stored = storeChallenge(account.id, {
+  // Store challenge for verification with unique key (prevents race conditions from multiple tabs)
+  const challengeKey = crypto.randomUUID();
+  const stored = storeChallenge(challengeKey, {
     challenge: options.challenge,
     type: 'registration',
+    accountId: account.id,
     expires: Date.now() + 60000 // 1 minute
   });
 
@@ -125,7 +127,7 @@ export async function registrationOptions(request, reply) {
     return reply.code(503).send({ error: 'Server busy, try again later' });
   }
 
-  return reply.send(options);
+  return reply.send({ ...options, challengeKey });
 }
 
 /**
@@ -133,20 +135,25 @@ export async function registrationOptions(request, reply) {
  * Verify and store the registration response
  */
 export async function registrationVerify(request, reply) {
-  const { accountId, credential, name } = request.body || {};
+  const { accountId, credential, name, challengeKey } = request.body || {};
 
-  if (!accountId || !credential) {
-    return reply.code(400).send({ error: 'Missing accountId or credential' });
+  if (!accountId || !credential || !challengeKey) {
+    return reply.code(400).send({ error: 'Missing required fields' });
+  }
+
+  const stored = challenges.get(challengeKey);
+  if (!stored || stored.type !== 'registration' || Date.now() > stored.expires) {
+    return reply.code(400).send({ error: 'Challenge expired or invalid' });
+  }
+
+  // Verify the accountId matches the challenge
+  if (stored.accountId !== accountId) {
+    return reply.code(403).send({ error: 'Account mismatch' });
   }
 
   const account = await accounts.findById(accountId);
   if (!account) {
     return reply.code(404).send({ error: 'Account not found' });
-  }
-
-  const stored = challenges.get(account.id);
-  if (!stored || stored.type !== 'registration' || Date.now() > stored.expires) {
-    return reply.code(400).send({ error: 'Challenge expired or invalid' });
   }
 
   const rp = getRP(request);
@@ -160,6 +167,7 @@ export async function registrationVerify(request, reply) {
     });
 
     if (!verification.verified || !verification.registrationInfo) {
+      request.log.warn({ verified: verification.verified, hasInfo: !!verification.registrationInfo }, 'Passkey registration verification failed');
       return reply.code(400).send({ error: 'Verification failed' });
     }
 
@@ -173,7 +181,7 @@ export async function registrationVerify(request, reply) {
       name: name || 'Security Key'
     });
 
-    challenges.delete(account.id);
+    challenges.delete(challengeKey);
 
     return reply.send({ success: true });
   } catch (err) {

--- a/src/idp/views.js
+++ b/src/idp/views.js
@@ -105,6 +105,38 @@ const styles = `
   .btn-secondary:hover {
     background: #e0e0e0;
   }
+  .btn-passkey {
+    background: #1a73e8;
+    color: white;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+  }
+  .btn-passkey:hover {
+    background: #1557b0;
+  }
+  .btn-passkey svg {
+    width: 20px;
+    height: 20px;
+  }
+  .divider {
+    display: flex;
+    align-items: center;
+    margin: 20px 0;
+    color: #666;
+    font-size: 14px;
+  }
+  .divider::before,
+  .divider::after {
+    content: '';
+    flex: 1;
+    border-bottom: 1px solid #ddd;
+  }
+  .divider span {
+    padding: 0 12px;
+  }
   .scopes {
     margin: 20px 0;
   }
@@ -149,6 +181,12 @@ const solidLogo = `
 </svg>
 `;
 
+const passkeyIcon = `
+<svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12.65 10C11.83 7.67 9.61 6 7 6c-3.31 0-6 2.69-6 6s2.69 6 6 6c2.61 0 4.83-1.67 5.65-4H17v4h4v-4h2v-4H12.65zM7 14c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2z"/>
+</svg>
+`;
+
 const scopeDescriptions = {
   openid: 'Access your identity',
   webid: 'Access your WebID',
@@ -160,8 +198,103 @@ const scopeDescriptions = {
 /**
  * Login page HTML
  */
-export function loginPage(uid, clientId, error = null) {
+export function loginPage(uid, clientId, error = null, passkeyEnabled = true) {
   const appName = clientId || 'An application';
+
+  const passkeySection = passkeyEnabled ? `
+    <button type="button" class="btn btn-passkey" onclick="loginWithPasskey()">
+      ${passkeyIcon}
+      Sign in with Passkey
+    </button>
+
+    <div class="divider"><span>or</span></div>
+  ` : '';
+
+  const passkeyScript = passkeyEnabled ? `
+  <script>
+    async function loginWithPasskey() {
+      try {
+        // Get authentication options
+        const optionsRes = await fetch('/idp/passkey/login/options', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ visitorId: crypto.randomUUID() })
+        });
+        const options = await optionsRes.json();
+        if (options.error) {
+          alert('Error: ' + options.error);
+          return;
+        }
+
+        // Convert base64url to ArrayBuffer
+        options.challenge = base64urlToBuffer(options.challenge);
+        if (options.allowCredentials) {
+          options.allowCredentials = options.allowCredentials.map(c => ({
+            ...c,
+            id: base64urlToBuffer(c.id)
+          }));
+        }
+
+        // Prompt user for passkey
+        const credential = await navigator.credentials.get({ publicKey: options });
+
+        // Send response to server
+        const verifyRes = await fetch('/idp/passkey/login/verify', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            challengeKey: options.challengeKey,
+            credential: {
+              id: credential.id,
+              rawId: bufferToBase64url(credential.rawId),
+              type: credential.type,
+              response: {
+                clientDataJSON: bufferToBase64url(credential.response.clientDataJSON),
+                authenticatorData: bufferToBase64url(credential.response.authenticatorData),
+                signature: bufferToBase64url(credential.response.signature),
+                userHandle: credential.response.userHandle
+                  ? bufferToBase64url(credential.response.userHandle)
+                  : null
+              }
+            }
+          })
+        });
+
+        const result = await verifyRes.json();
+        if (result.success) {
+          // Complete the OIDC interaction
+          window.location.href = '/idp/interaction/${uid}/passkey-complete?accountId=' + result.accountId;
+        } else {
+          alert('Passkey authentication failed: ' + (result.error || 'Unknown error'));
+        }
+      } catch (err) {
+        if (err.name === 'NotAllowedError') {
+          // User cancelled - do nothing
+        } else {
+          console.error('Passkey error:', err);
+          alert('Passkey authentication failed: ' + err.message);
+        }
+      }
+    }
+
+    function base64urlToBuffer(base64url) {
+      const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+      const padLen = (4 - base64.length % 4) % 4;
+      const padded = base64 + '='.repeat(padLen);
+      const binary = atob(padded);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      return bytes.buffer;
+    }
+
+    function bufferToBase64url(buffer) {
+      const bytes = new Uint8Array(buffer);
+      let binary = '';
+      for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+      return btoa(binary).replace(/\\+/g, '-').replace(/\\//g, '_').replace(/=/g, '');
+    }
+  </script>
+  ` : '';
 
   return `
 <!DOCTYPE html>
@@ -185,6 +318,8 @@ export function loginPage(uid, clientId, error = null) {
 
     ${error ? `<div class="error">${escapeHtml(error)}</div>` : ''}
 
+    ${passkeySection}
+
     <form method="POST" action="/idp/interaction/${uid}/login">
       <label for="username">Username</label>
       <input type="text" id="username" name="username" required autofocus placeholder="Your username">
@@ -203,6 +338,7 @@ export function loginPage(uid, clientId, error = null) {
       Don't have an account? <a href="/idp/register?uid=${uid}" style="color: #0066cc;">Register</a>
     </p>
   </div>
+  ${passkeyScript}
 </body>
 </html>
   `;
@@ -344,6 +480,148 @@ export function registerPage(uid = null, error = null, success = null, inviteOnl
       Already have an account? <a href="${uid ? `/idp/interaction/${uid}` : '/idp/auth'}" style="color: #0066cc;">Sign In</a>
     </p>
   </div>
+</body>
+</html>
+  `;
+}
+
+/**
+ * Passkey prompt page - shown after password login to encourage passkey setup
+ */
+export function passkeyPromptPage(uid, accountId) {
+  return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Add a Passkey - Solid IdP</title>
+  <style>${styles}</style>
+</head>
+<body>
+  <div class="container">
+    <div class="logo">${solidLogo}</div>
+    <h1>Add a Passkey?</h1>
+    <p class="subtitle">Sign in faster next time</p>
+
+    <div class="client-info">
+      <div class="client-name">Passkeys are more secure</div>
+      <div class="client-uri">Use Touch ID, Face ID, or a security key instead of your password</div>
+    </div>
+
+    <button type="button" class="btn btn-passkey" onclick="registerPasskey()" id="addBtn">
+      ${passkeyIcon}
+      Add Passkey
+    </button>
+
+    <form method="GET" action="/idp/interaction/${uid}/passkey-skip">
+      <button type="submit" class="btn btn-secondary">Skip for now</button>
+    </form>
+  </div>
+
+  <script>
+    async function registerPasskey() {
+      const btn = document.getElementById('addBtn');
+      btn.disabled = true;
+      btn.textContent = 'Setting up...';
+
+      try {
+        // Get registration options
+        const optionsRes = await fetch('/idp/passkey/register/options', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ accountId: '${accountId}' })
+        });
+        const options = await optionsRes.json();
+        if (options.error) {
+          alert('Error: ' + options.error);
+          btn.disabled = false;
+          btn.innerHTML = '${passkeyIcon} Add Passkey';
+          return;
+        }
+
+        // Convert base64url to ArrayBuffer
+        options.challenge = base64urlToBuffer(options.challenge);
+        options.user.id = base64urlToBuffer(options.user.id);
+        if (options.excludeCredentials) {
+          options.excludeCredentials = options.excludeCredentials.map(c => ({
+            ...c,
+            id: base64urlToBuffer(c.id)
+          }));
+        }
+
+        // Prompt user to create passkey
+        const credential = await navigator.credentials.create({ publicKey: options });
+
+        // Send response to server
+        const verifyRes = await fetch('/idp/passkey/register/verify', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            accountId: '${accountId}',
+            credential: {
+              id: credential.id,
+              rawId: bufferToBase64url(credential.rawId),
+              type: credential.type,
+              response: {
+                clientDataJSON: bufferToBase64url(credential.response.clientDataJSON),
+                attestationObject: bufferToBase64url(credential.response.attestationObject),
+                transports: credential.response.getTransports ? credential.response.getTransports() : []
+              }
+            },
+            name: detectDeviceName()
+          })
+        });
+
+        const result = await verifyRes.json();
+        if (result.success) {
+          // Passkey added, continue to app
+          window.location.href = '/idp/interaction/${uid}/passkey-complete?accountId=${accountId}';
+        } else {
+          alert('Failed to add passkey: ' + (result.error || 'Unknown error'));
+          btn.disabled = false;
+          btn.innerHTML = '${passkeyIcon} Add Passkey';
+        }
+      } catch (err) {
+        if (err.name === 'NotAllowedError') {
+          // User cancelled
+        } else {
+          console.error('Passkey error:', err);
+          alert('Failed to add passkey: ' + err.message);
+        }
+        btn.disabled = false;
+        btn.innerHTML = '${passkeyIcon} Add Passkey';
+      }
+    }
+
+    function detectDeviceName() {
+      const ua = navigator.userAgent;
+      if (/iPhone/.test(ua)) return 'iPhone';
+      if (/iPad/.test(ua)) return 'iPad';
+      if (/Mac/.test(ua)) return 'Mac';
+      if (/Android/.test(ua)) return 'Android';
+      if (/Windows/.test(ua)) return 'Windows';
+      if (/Linux/.test(ua)) return 'Linux';
+      return 'Security Key';
+    }
+
+    function base64urlToBuffer(base64url) {
+      const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+      const padLen = (4 - base64.length % 4) % 4;
+      const padded = base64 + '='.repeat(padLen);
+      const binary = atob(padded);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      return bytes.buffer;
+    }
+
+    function bufferToBase64url(buffer) {
+      const bytes = new Uint8Array(buffer);
+      let binary = '';
+      for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+      return btoa(binary).replace(/\\+/g, '-').replace(/\\//g, '_').replace(/=/g, '');
+    }
+  </script>
 </body>
 </html>
   `;

--- a/src/idp/views.js
+++ b/src/idp/views.js
@@ -568,6 +568,9 @@ export function passkeyPromptPage(uid, accountId) {
           return;
         }
 
+        // Save challengeKey for verification
+        const challengeKey = options.challengeKey;
+
         // Convert base64url to ArrayBuffer
         options.challenge = base64urlToBuffer(options.challenge);
         options.user.id = base64urlToBuffer(options.user.id);
@@ -587,6 +590,7 @@ export function passkeyPromptPage(uid, accountId) {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             accountId: ACCOUNT_ID,
+            challengeKey: challengeKey,
             credential: {
               id: credential.id,
               rawId: bufferToBase64url(credential.rawId),

--- a/src/idp/views.js
+++ b/src/idp/views.js
@@ -196,10 +196,26 @@ const scopeDescriptions = {
 };
 
 /**
+ * Escape string for safe use in JavaScript
+ */
+function escapeJs(text) {
+  if (!text) return '';
+  return String(text)
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+    .replace(/"/g, '\\"')
+    .replace(/</g, '\\x3c')
+    .replace(/>/g, '\\x3e')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r');
+}
+
+/**
  * Login page HTML
  */
 export function loginPage(uid, clientId, error = null, passkeyEnabled = true) {
   const appName = clientId || 'An application';
+  const safeUid = escapeJs(uid);
 
   const passkeySection = passkeyEnabled ? `
     <button type="button" class="btn btn-passkey" onclick="loginWithPasskey()">
@@ -212,6 +228,8 @@ export function loginPage(uid, clientId, error = null, passkeyEnabled = true) {
 
   const passkeyScript = passkeyEnabled ? `
   <script>
+    var INTERACTION_UID = '${safeUid}';
+
     async function loginWithPasskey() {
       try {
         // Get authentication options
@@ -262,8 +280,9 @@ export function loginPage(uid, clientId, error = null, passkeyEnabled = true) {
 
         const result = await verifyRes.json();
         if (result.success) {
-          // Complete the OIDC interaction
-          window.location.href = '/idp/interaction/${uid}/passkey-complete?accountId=' + result.accountId;
+          // Complete the OIDC interaction - build URL safely
+          const redirectUrl = '/idp/interaction/' + encodeURIComponent(INTERACTION_UID) + '/passkey-complete?accountId=' + encodeURIComponent(result.accountId);
+          window.location.href = redirectUrl;
         } else {
           alert('Passkey authentication failed: ' + (result.error || 'Unknown error'));
         }
@@ -291,7 +310,7 @@ export function loginPage(uid, clientId, error = null, passkeyEnabled = true) {
       const bytes = new Uint8Array(buffer);
       let binary = '';
       for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
-      return btoa(binary).replace(/\\+/g, '-').replace(/\\//g, '_').replace(/=/g, '');
+      return btoa(binary).replace(/[+]/g, '-').replace(/[/]/g, '_').replace(/=/g, '');
     }
   </script>
   ` : '';
@@ -489,6 +508,11 @@ export function registerPage(uid = null, error = null, success = null, inviteOnl
  * Passkey prompt page - shown after password login to encourage passkey setup
  */
 export function passkeyPromptPage(uid, accountId) {
+  const safeUid = escapeJs(uid);
+  const safeAccountId = escapeJs(accountId);
+  // Pre-escape the SVG for innerHTML assignment (no user data, just static SVG)
+  const passkeyIconEscaped = passkeyIcon.replace(/'/g, "\\'").replace(/\n/g, '');
+
   return `
 <!DOCTYPE html>
 <html lang="en">
@@ -514,12 +538,16 @@ export function passkeyPromptPage(uid, accountId) {
       Add Passkey
     </button>
 
-    <form method="GET" action="/idp/interaction/${uid}/passkey-skip">
+    <form method="GET" action="/idp/interaction/${escapeHtml(uid)}/passkey-skip">
       <button type="submit" class="btn btn-secondary">Skip for now</button>
     </form>
   </div>
 
   <script>
+    var INTERACTION_UID = '${safeUid}';
+    var ACCOUNT_ID = '${safeAccountId}';
+    var PASSKEY_ICON = '${passkeyIconEscaped}';
+
     async function registerPasskey() {
       const btn = document.getElementById('addBtn');
       btn.disabled = true;
@@ -530,13 +558,13 @@ export function passkeyPromptPage(uid, accountId) {
         const optionsRes = await fetch('/idp/passkey/register/options', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ accountId: '${accountId}' })
+          body: JSON.stringify({ accountId: ACCOUNT_ID })
         });
         const options = await optionsRes.json();
         if (options.error) {
           alert('Error: ' + options.error);
           btn.disabled = false;
-          btn.innerHTML = '${passkeyIcon} Add Passkey';
+          btn.innerHTML = PASSKEY_ICON + ' Add Passkey';
           return;
         }
 
@@ -558,7 +586,7 @@ export function passkeyPromptPage(uid, accountId) {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            accountId: '${accountId}',
+            accountId: ACCOUNT_ID,
             credential: {
               id: credential.id,
               rawId: bufferToBase64url(credential.rawId),
@@ -575,12 +603,13 @@ export function passkeyPromptPage(uid, accountId) {
 
         const result = await verifyRes.json();
         if (result.success) {
-          // Passkey added, continue to app
-          window.location.href = '/idp/interaction/${uid}/passkey-complete?accountId=${accountId}';
+          // Passkey added, continue to app - build URL safely
+          const redirectUrl = '/idp/interaction/' + encodeURIComponent(INTERACTION_UID) + '/passkey-complete?accountId=' + encodeURIComponent(ACCOUNT_ID);
+          window.location.href = redirectUrl;
         } else {
           alert('Failed to add passkey: ' + (result.error || 'Unknown error'));
           btn.disabled = false;
-          btn.innerHTML = '${passkeyIcon} Add Passkey';
+          btn.innerHTML = PASSKEY_ICON + ' Add Passkey';
         }
       } catch (err) {
         if (err.name === 'NotAllowedError') {
@@ -590,7 +619,7 @@ export function passkeyPromptPage(uid, accountId) {
           alert('Failed to add passkey: ' + err.message);
         }
         btn.disabled = false;
-        btn.innerHTML = '${passkeyIcon} Add Passkey';
+        btn.innerHTML = PASSKEY_ICON + ' Add Passkey';
       }
     }
 
@@ -619,7 +648,7 @@ export function passkeyPromptPage(uid, accountId) {
       const bytes = new Uint8Array(buffer);
       let binary = '';
       for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
-      return btoa(binary).replace(/\\+/g, '-').replace(/\\//g, '_').replace(/=/g, '');
+      return btoa(binary).replace(/[+]/g, '-').replace(/[/]/g, '_').replace(/=/g, '');
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary

Implements passwordless authentication using passkeys (WebAuthn/FIDO2):

- Login page now shows "Sign in with Passkey" button
- After password login, users see a prompt to add a passkey
- Passkeys use Touch ID, Face ID, or security keys

## Changes

| File | Change |
|------|--------|
| `package.json` | Add `@simplewebauthn/server` dependency |
| `src/idp/accounts.js` | Add passkey storage methods and credential index |
| `src/idp/passkey.js` | New WebAuthn registration/authentication endpoints |
| `src/idp/views.js` | Add passkey button to login, add passkey prompt page |
| `src/idp/interactions.js` | Add passkey-complete and passkey-skip handlers |
| `src/idp/index.js` | Register passkey routes |

## User Flow

### First Login (with password)
```
Login page -> Enter password -> "Add a Passkey?" prompt -> Touch ID -> Done
```

### Subsequent Logins (with passkey)
```
Login page -> Click "Sign in with Passkey" -> Touch ID -> Done
```

## Screenshots

Login page with passkey button:
```
┌────────────────────────────────┐
│  [🔑 Sign in with Passkey]     │
│  ─────────── or ───────────   │
│  Username: [____________]      │
│  Password: [____________]      │
│  [        Sign In         ]    │
└────────────────────────────────┘
```

Post-login passkey prompt:
```
┌────────────────────────────────┐
│  Add a Passkey?                │
│  Sign in faster next time      │
│  [  Add Passkey  ]  [  Skip  ] │
└────────────────────────────────┘
```

## Test Plan

- [x] All existing IdP tests pass
- [x] All auth tests pass
- [ ] Manual test: login with password, add passkey
- [ ] Manual test: login with passkey
- [ ] Manual test: skip passkey prompt

## Phase

This implements **Phase 1** (post-login prompt + passkey login) of #78.

Future phases:
- Phase 2: Account settings page for passkey management
- Phase 3: Passkey option during registration
- Phase 4: Passwordless accounts