### PR TITLE
Add Schnorr SSO login button

### DIFF
--- a/src/idp/index.js
+++ b/src/idp/index.js
@@ -358,7 +358,14 @@ export async function idpPlugin(fastify, options) {
   });
 
   // Schnorr (NIP-98) interaction handlers
-  fastify.post('/idp/interaction/:uid/schnorr-login', async (request, reply) => {
+  fastify.post('/idp/interaction/:uid/schnorr-login', {
+    config: {
+      rateLimit: {
+        max: 10,
+        timeWindow: '1 minute'
+      }
+    }
+  }, async (request, reply) => {
     return handleSchnorrLogin(request, reply, provider);
   });
 

--- a/src/idp/index.js
+++ b/src/idp/index.js
@@ -15,6 +15,8 @@ import {
   handleRegisterPost,
   handlePasskeyComplete,
   handlePasskeySkip,
+  handleSchnorrLogin,
+  handleSchnorrComplete,
 } from './interactions.js';
 import {
   handleCredentials,
@@ -353,6 +355,15 @@ export async function idpPlugin(fastify, options) {
 
   fastify.get('/idp/interaction/:uid/passkey-skip', async (request, reply) => {
     return handlePasskeySkip(request, reply, provider);
+  });
+
+  // Schnorr (NIP-98) interaction handlers
+  fastify.post('/idp/interaction/:uid/schnorr-login', async (request, reply) => {
+    return handleSchnorrLogin(request, reply, provider);
+  });
+
+  fastify.get('/idp/interaction/:uid/schnorr-complete', async (request, reply) => {
+    return handleSchnorrComplete(request, reply, provider);
   });
 
   fastify.log.info(`IdP initialized with issuer: ${issuer}`);

--- a/src/idp/interactions.js
+++ b/src/idp/interactions.js
@@ -3,11 +3,12 @@
  * Handles the user-facing parts of the authentication flow
  */
 
-import { authenticate, findById, createAccount, updateLastLogin, setPasskeyPromptDismissed } from './accounts.js';
+import { authenticate, findById, findByWebId, createAccount, updateLastLogin, setPasskeyPromptDismissed } from './accounts.js';
 import { loginPage, consentPage, errorPage, registerPage, passkeyPromptPage } from './views.js';
 import * as storage from '../storage/filesystem.js';
 import { createPodStructure } from '../handlers/container.js';
 import { validateInvite } from './invites.js';
+import { verifyNostrAuth, pubkeyToDidNostr } from '../auth/nostr.js';
 
 // Security: Maximum body size for IdP form submissions (1MB)
 const MAX_BODY_SIZE = 1024 * 1024;
@@ -539,6 +540,123 @@ export async function handlePasskeySkip(request, reply, provider) {
     return provider.interactionFinished(request.raw, reply.raw, result, { mergeWithLastSubmission: false });
   } catch (err) {
     request.log.error(err, 'Passkey skip error');
+    return reply.code(500).type('text/html').send(errorPage('Error', err.message));
+  }
+}
+
+/**
+ * Handle POST /idp/interaction/:uid/schnorr-login
+ * Authenticates user via Schnorr signature (NIP-98)
+ */
+export async function handleSchnorrLogin(request, reply, provider) {
+  const { uid } = request.params;
+
+  try {
+    const interaction = await provider.Interaction.find(uid);
+    if (!interaction) {
+      return reply.code(404).type('application/json').send({
+        success: false,
+        error: 'Session expired. Please try again.'
+      });
+    }
+
+    // Verify the Schnorr signature
+    const authResult = await verifyNostrAuth(request);
+
+    if (authResult.error) {
+      request.log.warn({ error: authResult.error }, 'Schnorr auth failed');
+      return reply.code(401).type('application/json').send({
+        success: false,
+        error: authResult.error
+      });
+    }
+
+    // authResult.webId is either a resolved WebID or did:nostr:pubkey
+    const identity = authResult.webId;
+    request.log.info({ identity, uid }, 'Schnorr auth verified');
+
+    // Try to find an existing account linked to this identity
+    let account = await findByWebId(identity);
+
+    if (!account) {
+      // No account linked to this did:nostr
+      // For now, return error - user needs to link their did:nostr to an account
+      // Future: could auto-create account or prompt for linking
+      return reply.code(403).type('application/json').send({
+        success: false,
+        error: 'No account linked to this identity. Please register or link your Schnorr key to an existing account.'
+      });
+    }
+
+    // Update last login
+    await updateLastLogin(account.id);
+
+    // Complete the OIDC interaction
+    const result = {
+      login: {
+        accountId: account.id,
+        remember: true,
+      },
+    };
+
+    // Save the login result
+    interaction.result = result;
+    await interaction.save(interaction.exp - Math.floor(Date.now() / 1000));
+
+    request.log.info({ accountId: account.id, identity, uid }, 'Schnorr login successful');
+
+    // Return success with redirect URL
+    // The client will follow this redirect
+    const redirectUrl = `/idp/interaction/${uid}/schnorr-complete?accountId=${encodeURIComponent(account.id)}`;
+
+    return reply.type('application/json').send({
+      success: true,
+      redirectUrl
+    });
+  } catch (err) {
+    request.log.error(err, 'Schnorr login error');
+    return reply.code(500).type('application/json').send({
+      success: false,
+      error: err.message
+    });
+  }
+}
+
+/**
+ * Handle GET /idp/interaction/:uid/schnorr-complete
+ * Completes OIDC interaction after Schnorr login
+ */
+export async function handleSchnorrComplete(request, reply, provider) {
+  const { uid } = request.params;
+  const { accountId } = request.query;
+
+  if (!accountId) {
+    return reply.code(400).type('text/html').send(errorPage('Missing account', 'Account ID is required.'));
+  }
+
+  try {
+    const interaction = await provider.Interaction.find(uid);
+    if (!interaction) {
+      return reply.code(404).type('text/html').send(errorPage('Session expired', 'Please try logging in again.'));
+    }
+
+    // Validate accountId matches the interaction result
+    if (interaction.result?.login?.accountId !== accountId) {
+      request.log.warn({ expected: interaction.result?.login?.accountId, provided: accountId }, 'AccountId mismatch in schnorr complete');
+      return reply.code(403).type('text/html').send(errorPage('Access denied', 'Account mismatch.'));
+    }
+
+    const account = await findById(accountId);
+    if (!account) {
+      return reply.code(404).type('text/html').send(errorPage('Account not found', 'The account could not be found.'));
+    }
+
+    request.log.info({ accountId: account.id, uid }, 'Schnorr login completed');
+
+    reply.hijack();
+    return provider.interactionFinished(request.raw, reply.raw, interaction.result, { mergeWithLastSubmission: false });
+  } catch (err) {
+    request.log.error(err, 'Schnorr complete error');
     return reply.code(500).type('text/html').send(errorPage('Error', err.message));
   }
 }

--- a/src/idp/interactions.js
+++ b/src/idp/interactions.js
@@ -8,7 +8,7 @@ import { loginPage, consentPage, errorPage, registerPage, passkeyPromptPage } fr
 import * as storage from '../storage/filesystem.js';
 import { createPodStructure } from '../handlers/container.js';
 import { validateInvite } from './invites.js';
-import { verifyNostrAuth, pubkeyToDidNostr } from '../auth/nostr.js';
+import { verifyNostrAuth } from '../auth/nostr.js';
 
 // Security: Maximum body size for IdP form submissions (1MB)
 const MAX_BODY_SIZE = 1024 * 1024;

--- a/src/idp/views.js
+++ b/src/idp/views.js
@@ -121,6 +121,23 @@ const styles = `
     width: 20px;
     height: 20px;
   }
+  .btn-schnorr {
+    background: #7b1fa2;
+    color: white;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin-top: 12px;
+  }
+  .btn-schnorr:hover {
+    background: #6a1b9a;
+  }
+  .btn-schnorr svg {
+    width: 20px;
+    height: 20px;
+  }
   .divider {
     display: flex;
     align-items: center;
@@ -187,6 +204,12 @@ const passkeyIcon = `
 </svg>
 `;
 
+const schnorrIcon = `
+<svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+  <path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"/>
+</svg>
+`;
+
 const scopeDescriptions = {
   openid: 'Access your identity',
   webid: 'Access your WebID',
@@ -213,7 +236,7 @@ function escapeJs(text) {
 /**
  * Login page HTML
  */
-export function loginPage(uid, clientId, error = null, passkeyEnabled = true) {
+export function loginPage(uid, clientId, error = null, passkeyEnabled = true, schnorrEnabled = true) {
   const appName = clientId || 'An application';
   const safeUid = escapeJs(uid);
 
@@ -222,7 +245,18 @@ export function loginPage(uid, clientId, error = null, passkeyEnabled = true) {
       ${passkeyIcon}
       Sign in with Passkey
     </button>
+  ` : '';
 
+  const schnorrSection = schnorrEnabled ? `
+    <button type="button" class="btn btn-schnorr" onclick="loginWithSchnorr()" id="schnorrBtn">
+      ${schnorrIcon}
+      Sign in with Schnorr
+    </button>
+  ` : '';
+
+  const ssoSection = (passkeyEnabled || schnorrEnabled) ? `
+    ${passkeySection}
+    ${schnorrSection}
     <div class="divider"><span>or</span></div>
   ` : '';
 
@@ -315,6 +349,75 @@ export function loginPage(uid, clientId, error = null, passkeyEnabled = true) {
   </script>
   ` : '';
 
+  const schnorrScript = schnorrEnabled ? `
+  <script>
+    async function loginWithSchnorr() {
+      const btn = document.getElementById('schnorrBtn');
+
+      // Check for NIP-07 extension (window.nostr)
+      if (typeof window.nostr === 'undefined') {
+        alert('No Schnorr signer found. Please install a NIP-07 compatible extension like Podkey, nos2x, or Alby.');
+        return;
+      }
+
+      btn.disabled = true;
+      btn.textContent = 'Signing...';
+
+      try {
+        // Get the current URL for the auth event
+        const authUrl = window.location.origin + '/idp/interaction/${safeUid}/schnorr-login';
+
+        // Create NIP-98 event (kind 27235)
+        const event = {
+          kind: 27235,
+          created_at: Math.floor(Date.now() / 1000),
+          tags: [
+            ['u', authUrl],
+            ['method', 'POST']
+          ],
+          content: ''
+        };
+
+        // Sign with NIP-07 extension
+        const signedEvent = await window.nostr.signEvent(event);
+
+        // Send to server
+        const response = await fetch(authUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Nostr ' + btoa(JSON.stringify(signedEvent))
+          },
+          body: JSON.stringify({ event: signedEvent })
+        });
+
+        const result = await response.json();
+
+        if (result.success && result.redirectUrl) {
+          window.location.href = result.redirectUrl;
+        } else if (result.error) {
+          alert('Schnorr login failed: ' + result.error);
+          btn.disabled = false;
+          btn.innerHTML = '${schnorrIcon.replace(/'/g, "\\'")}' + ' Sign in with Schnorr';
+        } else {
+          alert('Schnorr login failed: Unknown error');
+          btn.disabled = false;
+          btn.innerHTML = '${schnorrIcon.replace(/'/g, "\\'")}' + ' Sign in with Schnorr';
+        }
+      } catch (err) {
+        console.error('Schnorr login error:', err);
+        if (err.message && err.message.includes('User rejected')) {
+          // User cancelled signing - do nothing
+        } else {
+          alert('Schnorr login failed: ' + err.message);
+        }
+        btn.disabled = false;
+        btn.innerHTML = '${schnorrIcon.replace(/'/g, "\\'")}' + ' Sign in with Schnorr';
+      }
+    }
+  </script>
+  ` : '';
+
   return `
 <!DOCTYPE html>
 <html lang="en">
@@ -337,7 +440,7 @@ export function loginPage(uid, clientId, error = null, passkeyEnabled = true) {
 
     ${error ? `<div class="error">${escapeHtml(error)}</div>` : ''}
 
-    ${passkeySection}
+    ${ssoSection}
 
     <form method="POST" action="/idp/interaction/${uid}/login">
       <label for="username">Username</label>
@@ -358,6 +461,7 @@ export function loginPage(uid, clientId, error = null, passkeyEnabled = true) {
     </p>
   </div>
   ${passkeyScript}
+  ${schnorrScript}
 </body>
 </html>
   `;

--- a/src/idp/views.js
+++ b/src/idp/views.js
@@ -385,10 +385,8 @@ export function loginPage(uid, clientId, error = null, passkeyEnabled = true, sc
         const response = await fetch(authUrl, {
           method: 'POST',
           headers: {
-            'Content-Type': 'application/json',
             'Authorization': 'Nostr ' + btoa(JSON.stringify(signedEvent))
-          },
-          body: JSON.stringify({ event: signedEvent })
+          }
         });
 
         const result = await response.json();
@@ -398,11 +396,11 @@ export function loginPage(uid, clientId, error = null, passkeyEnabled = true, sc
         } else if (result.error) {
           alert('Schnorr login failed: ' + result.error);
           btn.disabled = false;
-          btn.innerHTML = '${schnorrIcon.replace(/'/g, "\\'")}' + ' Sign in with Schnorr';
+          btn.textContent = 'Sign in with Schnorr';
         } else {
           alert('Schnorr login failed: Unknown error');
           btn.disabled = false;
-          btn.innerHTML = '${schnorrIcon.replace(/'/g, "\\'")}' + ' Sign in with Schnorr';
+          btn.textContent = 'Sign in with Schnorr';
         }
       } catch (err) {
         console.error('Schnorr login error:', err);
@@ -412,7 +410,7 @@ export function loginPage(uid, clientId, error = null, passkeyEnabled = true, sc
           alert('Schnorr login failed: ' + err.message);
         }
         btn.disabled = false;
-        btn.innerHTML = '${schnorrIcon.replace(/'/g, "\\'")}' + ' Sign in with Schnorr';
+        btn.textContent = 'Sign in with Schnorr';
       }
     }
   </script>


### PR DESCRIPTION
## Summary

Adds a "Sign in with Schnorr" button to the IdP login page, enabling passwordless authentication via BIP-340 Schnorr signatures.

## Changes

- **views.js**: Add Schnorr button UI and NIP-07 signing flow
- **interactions.js**: Add `handleSchnorrLogin` and `handleSchnorrComplete` handlers
- **index.js**: Wire up `/idp/interaction/:uid/schnorr-login` and `/schnorr-complete` routes

## How it works

1. User clicks "Sign in with Schnorr"
2. Frontend checks for `window.nostr` (NIP-07 extension)
3. Creates kind 27235 event and signs via extension
4. Sends `Authorization: Nostr <base64>` to server
5. Server verifies signature (existing `verifyNostrAuth`)
6. Finds account linked to did:nostr identity
7. Completes OIDC interaction

## Requirements

- User needs NIP-07 compatible extension (Podkey, nos2x, Alby)
- Account must be linked to the did:nostr identity

## Screenshot

The button appears below "Sign in with Passkey" with a purple theme.

## References

- HTTP Schnorr Auth: https://nostrcg.github.io/http-schnorr-auth/
- NIP-07: https://nips.nostr.com/7
- NIP-98: https://nips.nostr.com/98

Closes #81