### PR TITLE
feat: add --public and --read-only flags for open access mode

### DIFF
--- a/bin/jss.js
+++ b/bin/jss.js
@@ -76,6 +76,8 @@ program
   .option('--single-user-name <name>', 'Username for single-user mode (default: me)')
   .option('--webid-tls', 'Enable WebID-TLS client certificate authentication')
   .option('--no-webid-tls', 'Disable WebID-TLS authentication')
+  .option('--public', 'Allow unauthenticated access (skip WAC, open read/write)')
+  .option('--read-only', 'Disable PUT/DELETE/PATCH methods (read-only mode)')
   .option('-q, --quiet', 'Suppress log output')
   .option('--print-config', 'Print configuration and exit')
   .action(async (options) => {
@@ -131,6 +133,8 @@ program
         webidTls: config.webidTls,
         singleUser: config.singleUser,
         singleUserName: config.singleUserName,
+        public: config.public,
+        readOnly: config.readOnly,
       });
 
       await server.listen({ port: config.port, host: config.host });
@@ -156,6 +160,16 @@ program
         if (config.singleUser) console.log(`  Single-user: ${config.singleUserName || 'me'} (registration disabled)`);
         else if (config.inviteOnly) console.log('  Registration: invite-only');
         if (config.webidTls) console.log('  WebID-TLS: enabled (client certificate auth)');
+        if (config.public) {
+          console.log('');
+          console.log('  ⚠️  WARNING: PUBLIC MODE ENABLED');
+          console.log('     All files are accessible without authentication.');
+          if (!config.readOnly) {
+            console.log('     Anyone can read, write, and delete files.');
+          }
+          console.log('     Do not expose to the internet!');
+        }
+        if (config.readOnly) console.log('  Read-only: enabled (PUT/DELETE/PATCH disabled)');
         console.log('\n  Press Ctrl+C to stop\n');
       }
 

--- a/src/auth/middleware.js
+++ b/src/auth/middleware.js
@@ -30,7 +30,8 @@ export async function authorize(request, reply, options = {}) {
 
   // Public mode - skip all WAC checks, allow unauthenticated access
   if (request.config?.public) {
-    return { authorized: true, webId: null, wacAllow: 'public="read write append"', authError: null };
+    const modes = request.config?.readOnly ? 'read' : 'read write append';
+    return { authorized: true, webId: null, wacAllow: `public="${modes}"`, authError: null };
   }
 
   // Get WebID from token (supports both simple and Solid-OIDC tokens)

--- a/src/auth/middleware.js
+++ b/src/auth/middleware.js
@@ -28,6 +28,11 @@ export async function authorize(request, reply, options = {}) {
     return { authorized: true, webId: null, wacAllow: 'user="read write append control", public="read write append"', authError: null };
   }
 
+  // Public mode - skip all WAC checks, allow unauthenticated access
+  if (request.config?.public) {
+    return { authorized: true, webId: null, wacAllow: 'public="read write append"', authError: null };
+  }
+
   // Get WebID from token (supports both simple and Solid-OIDC tokens)
   const { webId, error: authError } = await getWebIdFromRequestAsync(request);
 

--- a/src/config.js
+++ b/src/config.js
@@ -73,6 +73,12 @@ export const defaults = {
   // Storage quota (bytes) - 50MB default
   defaultQuota: 50 * 1024 * 1024,
 
+  // Public mode - skip WAC, allow unauthenticated access
+  public: false,
+
+  // Read-only mode - disable PUT/DELETE/PATCH
+  readOnly: false,
+
   // Logging
   logger: true,
   quiet: false,
@@ -117,6 +123,8 @@ const envMap = {
   JSS_SINGLE_USER_NAME: 'singleUserName',
   JSS_WEBID_TLS: 'webidTls',
   JSS_DEFAULT_QUOTA: 'defaultQuota',
+  JSS_PUBLIC: 'public',
+  JSS_READ_ONLY: 'readOnly',
 };
 
 /**

--- a/src/handlers/container.js
+++ b/src/handlers/container.js
@@ -25,6 +25,11 @@ function getRequestPaths(request) {
  * Handle POST request to container (create new resource)
  */
 export async function handlePost(request, reply) {
+  // Read-only mode - block all writes
+  if (request.config?.readOnly) {
+    return reply.code(405).send({ error: 'Method Not Allowed', message: 'Server is in read-only mode' });
+  }
+
   const { urlPath, storagePath } = getRequestPaths(request);
 
   // Ensure target is a container
@@ -233,6 +238,11 @@ export async function createPodStructure(name, webId, podUri, issuer, defaultQuo
  *   /{name}/settings/privateTypeIndex
  */
 export async function handleCreatePod(request, reply) {
+  // Read-only mode - block pod creation
+  if (request.config?.readOnly) {
+    return reply.code(405).send({ error: 'Method Not Allowed', message: 'Server is in read-only mode' });
+  }
+
   const { name, email, password } = request.body || {};
   const idpEnabled = request.idpEnabled;
 

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -511,6 +511,11 @@ export async function handleHead(request, reply) {
  * Handle PUT request
  */
 export async function handlePut(request, reply) {
+  // Read-only mode - block all writes
+  if (request.config?.readOnly) {
+    return reply.code(405).send({ error: 'Method Not Allowed', message: 'Server is in read-only mode' });
+  }
+
   const { urlPath, storagePath, resourceUrl } = getRequestPaths(request);
   const connegEnabled = request.connegEnabled || false;
 
@@ -644,6 +649,11 @@ export async function handlePut(request, reply) {
  * Handle DELETE request
  */
 export async function handleDelete(request, reply) {
+  // Read-only mode - block all writes
+  if (request.config?.readOnly) {
+    return reply.code(405).send({ error: 'Method Not Allowed', message: 'Server is in read-only mode' });
+  }
+
   const { storagePath, resourceUrl } = getRequestPaths(request);
 
   // Check if resource exists and get current ETag
@@ -716,6 +726,11 @@ export async function handleOptions(request, reply) {
  * Supports N3 Patch format (text/n3) and SPARQL Update for updating RDF resources
  */
 export async function handlePatch(request, reply) {
+  // Read-only mode - block all writes
+  if (request.config?.readOnly) {
+    return reply.code(405).send({ error: 'Method Not Allowed', message: 'Server is in read-only mode' });
+  }
+
   const { urlPath, storagePath, resourceUrl } = getRequestPaths(request);
 
   // Don't allow PATCH to containers

--- a/src/server.js
+++ b/src/server.js
@@ -135,6 +135,7 @@ export function createServer(options = {}) {
   fastify.decorateRequest('mashlibVersion', null);
   fastify.decorateRequest('solidosUiEnabled', null);
   fastify.decorateRequest('defaultQuota', null);
+  fastify.decorateRequest('config', null);
   fastify.addHook('onRequest', async (request) => {
     request.connegEnabled = connegEnabled;
     request.notificationsEnabled = notificationsEnabled;
@@ -146,6 +147,7 @@ export function createServer(options = {}) {
     request.mashlibVersion = mashlibVersion;
     request.solidosUiEnabled = solidosUiEnabled;
     request.defaultQuota = defaultQuota;
+    request.config = { public: options.public, readOnly: options.readOnly };
 
     // Extract pod name from subdomain if enabled
     if (subdomainsEnabled && baseDomain) {


### PR DESCRIPTION
## Summary

Implements #107 - adds `--public` and `--read-only` flags to allow JSS to be used as a simple file server similar to `npx serve`, but with write support.

## Changes

### New CLI Flags
- `--public` - Skip WAC checks, allow unauthenticated read/write access
- `--read-only` - Disable PUT/DELETE/PATCH methods

### Environment Variables
- `JSS_PUBLIC=true`
- `JSS_READ_ONLY=true`

### Config File
```json
{
  "public": true,
  "readOnly": true
}
```

## Usage

```bash
# Open read/write access (like a writable npx serve)
jss start --public

# Open read-only access (exactly like npx serve)
jss start --public --read-only

# Just read-only (still requires auth for reads)
jss start --read-only
```

## Startup Warning

When public mode is enabled, a warning is displayed:

```
⚠️  WARNING: PUBLIC MODE ENABLED
   All files are accessible without authentication.
   Anyone can read, write, and delete files.
   Do not expose to the internet!
```

## Files Changed

| File | Change |
|------|--------|
| `bin/jss.js` | Add CLI options, startup warning |
| `src/config.js` | Add defaults and env var mapping |
| `src/server.js` | Pass config to request object |
| `src/auth/middleware.js` | Skip WAC in public mode |
| `src/handlers/resource.js` | Block writes in read-only mode |
| `src/handlers/container.js` | Block writes in read-only mode |

## Test Plan

- [x] `--public` flag shows in help
- [x] Server starts with `--public` flag
- [x] Server starts with `--public --read-only` flags
- [x] Warning message displayed on startup
- [ ] Unauthenticated GET works in public mode
- [ ] Unauthenticated PUT works in public mode
- [ ] PUT returns 405 in read-only mode

Closes #107