### PR TITLE
feat: add --live-reload flag for auto-refresh on file changes

### DIFF
--- a/bin/jss.js
+++ b/bin/jss.js
@@ -78,6 +78,7 @@ program
   .option('--no-webid-tls', 'Disable WebID-TLS authentication')
   .option('--public', 'Allow unauthenticated access (skip WAC, open read/write)')
   .option('--read-only', 'Disable PUT/DELETE/PATCH methods (read-only mode)')
+  .option('--live-reload', 'Inject live reload script into HTML (auto-refresh on changes)')
   .option('-q, --quiet', 'Suppress log output')
   .option('--print-config', 'Print configuration and exit')
   .action(async (options) => {
@@ -135,6 +136,7 @@ program
         singleUserName: config.singleUserName,
         public: config.public,
         readOnly: config.readOnly,
+        liveReload: config.liveReload,
       });
 
       await server.listen({ port: config.port, host: config.host });

--- a/src/config.js
+++ b/src/config.js
@@ -79,6 +79,9 @@ export const defaults = {
   // Read-only mode - disable PUT/DELETE/PATCH
   readOnly: false,
 
+  // Live reload - inject script to auto-refresh browser on file changes
+  liveReload: false,
+
   // Logging
   logger: true,
   quiet: false,
@@ -125,6 +128,7 @@ const envMap = {
   JSS_DEFAULT_QUOTA: 'defaultQuota',
   JSS_PUBLIC: 'public',
   JSS_READ_ONLY: 'readOnly',
+  JSS_LIVE_RELOAD: 'liveReload',
 };
 
 /**

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -18,6 +18,24 @@ import { checkIfMatch, checkIfNoneMatchForGet, checkIfNoneMatchForWrite } from '
 import { generateDatabrowserHtml, generateSolidosUiHtml, shouldServeMashlib } from '../mashlib/index.js';
 
 /**
+ * Live reload script - injected into HTML when --live-reload is enabled
+ */
+const LIVE_RELOAD_SCRIPT = `<script>(function(){var ws=new WebSocket((location.protocol==='https:'?'wss:':'ws:')+'//' +location.host+'/notifications/');ws.onmessage=function(){location.reload()};ws.onclose=function(){setTimeout(function(){location.reload()},1000)}})();</script>`;
+
+/**
+ * Inject live reload script into HTML content
+ */
+function injectLiveReload(content, enabled) {
+  if (!enabled) return content;
+  const html = content.toString();
+  // Inject before </body> or at end
+  if (html.includes('</body>')) {
+    return Buffer.from(html.replace('</body>', LIVE_RELOAD_SCRIPT + '</body>'));
+  }
+  return Buffer.from(html + LIVE_RELOAD_SCRIPT);
+}
+
+/**
  * Get the storage path and resource URL for a request
  * In subdomain mode, storage path includes pod name, URL uses subdomain
  */
@@ -439,6 +457,11 @@ export async function handleGet(request, reply) {
   headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
 
   Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
+
+  // Inject live reload script into HTML
+  if (actualContentType === 'text/html' && request.liveReloadEnabled) {
+    return reply.send(injectLiveReload(content, true));
+  }
   return reply.send(content);
 }
 

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -218,6 +218,7 @@ export async function handleGet(request, reply) {
       // Inject live reload script for index.html
       if (request.liveReloadEnabled) {
         reply.header('Cache-Control', 'no-store');
+        reply.removeHeader('ETag');
         return reply.send(injectLiveReload(content));
       }
       return reply.send(content);
@@ -465,6 +466,7 @@ export async function handleGet(request, reply) {
   // Inject live reload script into HTML (disable caching since content is modified)
   if (actualContentType === 'text/html' && request.liveReloadEnabled) {
     reply.header('Cache-Control', 'no-store');
+    reply.removeHeader('ETag');
     return reply.send(injectLiveReload(content));
   }
   return reply.send(content);

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -20,13 +20,12 @@ import { generateDatabrowserHtml, generateSolidosUiHtml, shouldServeMashlib } fr
 /**
  * Live reload script - injected into HTML when --live-reload is enabled
  */
-const LIVE_RELOAD_SCRIPT = `<script>(function(){var ws=new WebSocket((location.protocol==='https:'?'wss:':'ws:')+'//' +location.host+'/notifications/');ws.onmessage=function(){location.reload()};ws.onclose=function(){setTimeout(function(){location.reload()},1000)}})();</script>`;
+const LIVE_RELOAD_SCRIPT = `<script>(function(){var ws=new WebSocket((location.protocol==='https:'?'wss:':'ws:')+'//' +location.host+'/.notifications');ws.onopen=function(){ws.send('sub '+location.href)};ws.onmessage=function(e){if(e.data.startsWith('pub '))location.reload()};ws.onclose=function(){setTimeout(function(){location.reload()},1000)}})();</script>`;
 
 /**
  * Inject live reload script into HTML content
  */
-function injectLiveReload(content, enabled) {
-  if (!enabled) return content;
+function injectLiveReload(content) {
   const html = content.toString();
   // Inject before </body> or at end
   if (html.includes('</body>')) {
@@ -216,6 +215,11 @@ export async function handleGet(request, reply) {
       });
 
       Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
+      // Inject live reload script for index.html
+      if (request.liveReloadEnabled) {
+        reply.header('Cache-Control', 'no-store');
+        return reply.send(injectLiveReload(content));
+      }
       return reply.send(content);
     }
 
@@ -458,9 +462,10 @@ export async function handleGet(request, reply) {
 
   Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
 
-  // Inject live reload script into HTML
+  // Inject live reload script into HTML (disable caching since content is modified)
   if (actualContentType === 'text/html' && request.liveReloadEnabled) {
-    return reply.send(injectLiveReload(content, true));
+    reply.header('Cache-Control', 'no-store');
+    return reply.send(injectLiveReload(content));
   }
   return reply.send(content);
 }

--- a/src/server.js
+++ b/src/server.js
@@ -79,6 +79,8 @@ export function createServer(options = {}) {
   const defaultQuota = options.defaultQuota ?? 50 * 1024 * 1024;
   // WebID-TLS client certificate authentication is OFF by default
   const webidTlsEnabled = options.webidTls ?? false;
+  // Live reload - injects script to auto-refresh browser on file changes
+  const liveReloadEnabled = options.liveReload ?? false;
 
   // Set data root via environment variable if provided
   if (options.root) {
@@ -136,6 +138,7 @@ export function createServer(options = {}) {
   fastify.decorateRequest('solidosUiEnabled', null);
   fastify.decorateRequest('defaultQuota', null);
   fastify.decorateRequest('config', null);
+  fastify.decorateRequest('liveReloadEnabled', null);
   fastify.addHook('onRequest', async (request) => {
     request.connegEnabled = connegEnabled;
     request.notificationsEnabled = notificationsEnabled;
@@ -148,6 +151,7 @@ export function createServer(options = {}) {
     request.solidosUiEnabled = solidosUiEnabled;
     request.defaultQuota = defaultQuota;
     request.config = { public: options.public, readOnly: options.readOnly };
+    request.liveReloadEnabled = liveReloadEnabled;
 
     // Extract pod name from subdomain if enabled
     if (subdomainsEnabled && baseDomain) {
@@ -164,8 +168,8 @@ export function createServer(options = {}) {
     }
   });
 
-  // Register WebSocket notifications plugin if enabled
-  if (notificationsEnabled) {
+  // Register WebSocket notifications plugin if enabled (or live reload needs it)
+  if (notificationsEnabled || liveReloadEnabled) {
     fastify.register(notificationsPlugin);
   }
 

--- a/src/server.js
+++ b/src/server.js
@@ -141,7 +141,7 @@ export function createServer(options = {}) {
   fastify.decorateRequest('liveReloadEnabled', null);
   fastify.addHook('onRequest', async (request) => {
     request.connegEnabled = connegEnabled;
-    request.notificationsEnabled = notificationsEnabled;
+    request.notificationsEnabled = notificationsEnabled || liveReloadEnabled;
     request.idpEnabled = idpEnabled;
     request.subdomainsEnabled = subdomainsEnabled;
     request.baseDomain = baseDomain;


### PR DESCRIPTION
## Summary

Adds `--live-reload` flag that auto-refreshes the browser when files change, leveraging existing WebSocket notifications.

## Implementation

~35 lines total:

- Injects small client script into HTML responses
- Auto-enables WebSocket notifications when flag is used
- Script reconnects if connection drops

```javascript
<script>(function(){
  var ws = new WebSocket('ws://' + location.host + '/notifications/');
  ws.onmessage = function() { location.reload() };
  ws.onclose = function() { setTimeout(function(){ location.reload() }, 1000) };
})();</script>
```

## Usage

```bash
jss start --live-reload
```

## Testing

```bash
# Start server
jss start --root /tmp/test --public --live-reload

# Verify script injection
curl http://localhost:3000/index.html | grep 'notifications'
```

Closes #110