### PR TITLE
Auto-enable conneg when mashlib is enabled

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -228,6 +228,11 @@ export async function loadConfig(cliOptions = {}, configFile = null) {
     config.logger = false;
   }
 
+  // Mashlib requires content negotiation for Turtle support
+  if (config.mashlib || config.mashlibCdn) {
+    config.conneg = true;
+  }
+
   // Validate SSL config
   if ((config.sslKey && !config.sslCert) || (!config.sslKey && config.sslCert)) {
     throw new Error('Both --ssl-key and --ssl-cert must be provided together');


### PR DESCRIPTION
## Summary

- When `--mashlib` or `--mashlib-cdn` is enabled, automatically set `conneg: true`
- Mashlib expects `.ttl` files served as Turtle, but without conneg the raw JSON-LD is served, causing parse errors like `Strange: Error parse_error trying to read your preference file`

## Change

One check added to `loadConfig()` in `src/config.js` (5 lines).

## Test plan

- [x] `jss start --mashlib-cdn` now serves Turtle without needing explicit `--conneg`
- [x] Explicit `--conneg` still works independently

Closes #22