### PR TITLE
Add --log-level flag and single structured access log line

### DIFF
--- a/bin/jss.js
+++ b/bin/jss.js
@@ -80,6 +80,7 @@ program
   .option('--read-only', 'Disable PUT/DELETE/PATCH methods (read-only mode)')
   .option('--live-reload', 'Inject live reload script into HTML (auto-refresh on changes)')
   .option('-q, --quiet', 'Suppress log output')
+  .option('--log-level <level>', 'Log level: error, warn, info, debug (default: info)')
   .option('--print-config', 'Print configuration and exit')
   .action(async (options) => {
     try {

--- a/src/auth/did-nostr.js
+++ b/src/auth/did-nostr.js
@@ -14,6 +14,23 @@ const DEFAULT_DID_RESOLVER = 'https://nostr.social/.well-known/did/nostr';
 const cache = new Map();
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
+// Rate-limit repeated error logs (key -> { count, lastLogged })
+const errorLogTracker = new Map();
+const ERROR_LOG_INTERVAL = 60_000;
+
+function rateLimitedError(key, message) {
+  const now = Date.now();
+  const entry = errorLogTracker.get(key);
+  if (entry && now - entry.lastLogged < ERROR_LOG_INTERVAL) {
+    entry.count++;
+    return;
+  }
+  const suppressed = entry ? entry.count : 0;
+  const suffix = suppressed > 0 ? ` (${suppressed} similar suppressed)` : '';
+  console.error(`${message}${suffix}`);
+  errorLogTracker.set(key, { count: 0, lastLogged: now });
+}
+
 /**
  * Fetch with timeout
  */
@@ -94,7 +111,7 @@ export async function resolveDidNostrToWebId(pubkey, resolverUrl = DEFAULT_DID_R
 
   } catch (err) {
     // Network error or timeout - don't cache failures
-    console.error(`DID resolution error for ${pubkey}:`, err.message);
+    rateLimitedError(`did:${pubkey.substring(0, 8)}`, `DID resolution error for ${pubkey}: ${err.message}`);
     return null;
   }
 }
@@ -148,7 +165,7 @@ async function verifyWebIdBacklink(webId, pubkey) {
     return false;
 
   } catch (err) {
-    console.error(`WebID backlink verification error for ${webId}:`, err.message);
+    rateLimitedError(`backlink:${webId}`, `WebID backlink verification error for ${webId}: ${err.message}`);
     return false;
   }
 }

--- a/src/auth/did-nostr.js
+++ b/src/auth/did-nostr.js
@@ -26,6 +26,10 @@ function rateLimitedError(key, message) {
     entry.count++;
     return;
   }
+  // Clean up stale entries while we're here
+  for (const [k, v] of errorLogTracker) {
+    if (now - v.lastLogged > ERROR_LOG_INTERVAL) errorLogTracker.delete(k);
+  }
   const suppressed = entry ? entry.count : 0;
   const suffix = suppressed > 0 ? ` (${suppressed} similar suppressed)` : '';
   console.error(`${message}${suffix}`);
@@ -59,12 +63,15 @@ export async function resolveDidNostrToWebId(pubkey, resolverUrl = DEFAULT_DID_R
     return null;
   }
 
-  // Check cache
+  // Check cache (lazy eviction of expired entries)
   const cacheKey = pubkey.toLowerCase();
   const cached = cache.get(cacheKey);
-  const ttl = cached?.failureTtl ? FAILURE_CACHE_TTL : CACHE_TTL;
-  if (cached && Date.now() - cached.timestamp < ttl) {
-    return cached.webId;
+  if (cached) {
+    const ttl = cached.failureTtl ? FAILURE_CACHE_TTL : CACHE_TTL;
+    if (Date.now() - cached.timestamp < ttl) {
+      return cached.webId;
+    }
+    cache.delete(cacheKey);
   }
 
   try {

--- a/src/auth/did-nostr.js
+++ b/src/auth/did-nostr.js
@@ -13,6 +13,7 @@ const DEFAULT_DID_RESOLVER = 'https://nostr.social/.well-known/did/nostr';
 // Cache for resolved DIDs (pubkey -> webId or null)
 const cache = new Map();
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+const FAILURE_CACHE_TTL = 60 * 1000; // 1 minute for failed lookups
 
 // Rate-limit repeated error logs (key -> { count, lastLogged })
 const errorLogTracker = new Map();
@@ -61,7 +62,8 @@ export async function resolveDidNostrToWebId(pubkey, resolverUrl = DEFAULT_DID_R
   // Check cache
   const cacheKey = pubkey.toLowerCase();
   const cached = cache.get(cacheKey);
-  if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+  const ttl = cached?.failureTtl ? FAILURE_CACHE_TTL : CACHE_TTL;
+  if (cached && Date.now() - cached.timestamp < ttl) {
     return cached.webId;
   }
 
@@ -110,7 +112,8 @@ export async function resolveDidNostrToWebId(pubkey, resolverUrl = DEFAULT_DID_R
     return null;
 
   } catch (err) {
-    // Network error or timeout - don't cache failures
+    // Cache failures with short TTL to avoid hammering a down service
+    cache.set(cacheKey, { webId: null, timestamp: Date.now(), failureTtl: true });
     rateLimitedError(`did:${pubkey.substring(0, 8)}`, `DID resolution error for ${pubkey}: ${err.message}`);
     return null;
   }

--- a/src/config.js
+++ b/src/config.js
@@ -85,6 +85,7 @@ export const defaults = {
   // Logging
   logger: true,
   quiet: false,
+  logLevel: 'info',
 
   // Paths
   configPath: './.jss',
@@ -103,6 +104,7 @@ const envMap = {
   JSS_CONNEG: 'conneg',
   JSS_NOTIFICATIONS: 'notifications',
   JSS_QUIET: 'quiet',
+  JSS_LOG_LEVEL: 'logLevel',
   JSS_CONFIG_PATH: 'configPath',
   JSS_IDP: 'idp',
   JSS_IDP_ISSUER: 'idpIssuer',
@@ -226,6 +228,12 @@ export async function loadConfig(cliOptions = {}, configFile = null) {
   // Derive additional settings
   if (config.quiet) {
     config.logger = false;
+  }
+
+  // Validate log level
+  const validLevels = ['fatal', 'error', 'warn', 'info', 'debug', 'trace'];
+  if (!validLevels.includes(config.logLevel)) {
+    config.logLevel = 'info';
   }
 
   // Mashlib requires content negotiation for Turtle support

--- a/src/config.js
+++ b/src/config.js
@@ -233,6 +233,7 @@ export async function loadConfig(cliOptions = {}, configFile = null) {
   // Validate log level
   const validLevels = ['fatal', 'error', 'warn', 'info', 'debug', 'trace'];
   if (!validLevels.includes(config.logLevel)) {
+    console.warn(`Invalid log level '${config.logLevel}', falling back to 'info'. Valid levels: ${validLevels.join(', ')}`);
     config.logLevel = 'info';
   }
 

--- a/src/server.js
+++ b/src/server.js
@@ -173,6 +173,7 @@ export function createServer(options = {}) {
 
   // Unified access log — one line per request
   fastify.addHook('onResponse', async (request, reply) => {
+    if (!request.log.isLevelEnabled('info')) return;
     request.log.info({
       req: { method: request.method, url: request.url, remoteAddress: request.ip },
       res: { statusCode: reply.statusCode },

--- a/src/server.js
+++ b/src/server.js
@@ -89,8 +89,10 @@ export function createServer(options = {}) {
   }
 
   // Fastify options
+  const loggerEnabled = options.logger ?? true;
   const fastifyOptions = {
-    logger: options.logger ?? true,
+    logger: loggerEnabled ? { level: options.logLevel || 'info' } : false,
+    disableRequestLogging: true,
     trustProxy: true,
     // Handle raw body for non-JSON content
     bodyLimit: 10 * 1024 * 1024 // 10MB
@@ -167,6 +169,18 @@ export function createServer(options = {}) {
         }
       }
     }
+  });
+
+  // Unified access log — one line per request
+  fastify.addHook('onResponse', async (request, reply) => {
+    request.log.info({
+      req: { method: request.method, url: request.url, remoteAddress: request.ip },
+      res: { statusCode: reply.statusCode },
+      responseTime: Math.round(reply.elapsedTime * 100) / 100,
+      userAgent: request.headers['user-agent'] || undefined,
+      referrer: request.headers.referer || undefined,
+      contentLength: reply.getHeader('content-length') || undefined,
+    }, `${request.method} ${request.url} ${reply.statusCode} ${Math.round(reply.elapsedTime)}ms`);
   });
 
   // Register WebSocket notifications plugin if enabled (or live reload needs it)


### PR DESCRIPTION
## Summary

- Add `--log-level` flag (error/warn/info/debug) and `JSS_LOG_LEVEL` env var
- Replace Fastify's default 2-line-per-request logging with a single structured access log line
- Rate-limit DID resolution errors to max 1 per key per 60s

## Before (2 lines per request, no user-agent)
```json
{"level":30,"time":...,"reqId":"req-1","req":{"method":"GET","url":"/"},"msg":"incoming request"}
{"level":30,"time":...,"reqId":"req-1","res":{"statusCode":200},"responseTime":5.15,"msg":"request completed"}
```

## After (1 line per request, with user-agent/referrer/bytes)
```json
{"level":30,"time":...,"reqId":"req-1","req":{"method":"GET","url":"/","remoteAddress":"86.49.17.222"},"res":{"statusCode":200},"responseTime":6.02,"userAgent":"Mozilla/5.0...","referrer":"https://example.com","contentLength":"1234","msg":"GET / 200 6ms"}
```

## DID error rate limiting
Before: 30 identical lines per minute
After: 1 line per minute with `(27 similar suppressed)` suffix

## Test plan
- [x] `jss start` — single JSON line per request with ua/referrer/bytes
- [x] `jss start --log-level warn` — suppresses access log, only warn+ messages
- [x] Server starts and handles requests correctly

Refs #129 (PR 1 of 2 — follow-up PR will migrate console.error calls to request.log)