### PR TITLE
Route PUT text/html to index.html for existing containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-solid-server",
-  "version": "0.0.90",
+  "version": "0.0.91",
   "description": "A minimal, fast Solid server",
   "main": "src/index.js",
   "type": "module",

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -553,18 +553,17 @@ export async function handlePut(request, reply) {
   if (isContainer(urlPath)) {
     const stats = await storage.stat(storagePath);
     if (stats?.isDirectory) {
-      // If container has index.html and PUT sends HTML, route to the index document
-      // This mirrors GET behavior (line 138) which serves index.html for container URLs
+      // If container has index.html and PUT sends HTML, rewrite URL to target the
+      // index document and delegate to the standard PUT pipeline. This mirrors GET
+      // behavior (line 138) which serves index.html for container URLs, and reuses
+      // If-Match/If-None-Match, quota checks, and notification handling.
       const indexPath = storagePath.endsWith('/') ? `${storagePath}index.html` : `${storagePath}/index.html`;
       const contentType = request.headers['content-type'] || '';
       if (contentType.includes('text/html') && await storage.exists(indexPath)) {
-        const body = typeof request.body === 'string' ? request.body : Buffer.from(request.body).toString();
-        await storage.write(indexPath, body);
-        const origin = request.headers.origin;
-        const headers = getAllHeaders({ isContainer: false, origin, connegEnabled });
-        Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
-        emitChange(request.protocol + '://' + request.hostname, urlPath + 'index.html', 'updated');
-        return reply.code(204).send();
+        const indexUrl = urlPath.endsWith('/') ? `${urlPath}index.html` : `${urlPath}/index.html`;
+        // Fastify request.url is a getter, so proxy it with the rewritten path
+        const proxied = Object.create(request, { url: { value: indexUrl } });
+        return handlePut(proxied, reply);
       }
       // Container exists but no index routing applies - reject
       return reply.code(409).send({ error: 'Cannot PUT to existing container' });

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -553,7 +553,20 @@ export async function handlePut(request, reply) {
   if (isContainer(urlPath)) {
     const stats = await storage.stat(storagePath);
     if (stats?.isDirectory) {
-      // Container already exists - don't allow PUT to modify
+      // If container has index.html and PUT sends HTML, route to the index document
+      // This mirrors GET behavior (line 138) which serves index.html for container URLs
+      const indexPath = storagePath.endsWith('/') ? `${storagePath}index.html` : `${storagePath}/index.html`;
+      const contentType = request.headers['content-type'] || '';
+      if (contentType.includes('text/html') && await storage.exists(indexPath)) {
+        const body = typeof request.body === 'string' ? request.body : Buffer.from(request.body).toString();
+        await storage.write(indexPath, body);
+        const origin = request.headers.origin;
+        const headers = getAllHeaders({ isContainer: false, origin, connegEnabled });
+        Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
+        emitChange(request.protocol + '://' + request.hostname, urlPath + 'index.html', 'updated');
+        return reply.code(204).send();
+      }
+      // Container exists but no index routing applies - reject
       return reply.code(409).send({ error: 'Cannot PUT to existing container' });
     }
 

--- a/test/ldp.test.js
+++ b/test/ldp.test.js
@@ -163,6 +163,47 @@ describe('LDP CRUD Operations', () => {
       const verify = await request('/ldptest/public/new-container/');
       assertHeaderContains(verify, 'Link', 'Container');
     });
+
+    it('should PUT HTML to container with index.html routing to index document', async () => {
+      // Create container with an index.html inside
+      await request('/ldptest/public/board/', { method: 'PUT', auth: 'ldptest' });
+      await request('/ldptest/public/board/index.html', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'text/html' },
+        body: '<html><body>original</body></html>',
+        auth: 'ldptest'
+      });
+
+      // PUT to container URL with text/html should route to index.html
+      const res = await request('/ldptest/public/board/', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'text/html' },
+        body: '<html><body>updated</body></html>',
+        auth: 'ldptest'
+      });
+
+      assertStatus(res, 204);
+
+      // Verify index.html was updated
+      const verify = await request('/ldptest/public/board/index.html');
+      const content = await verify.text();
+      assert.ok(content.includes('updated'), 'index.html should contain updated content');
+    });
+
+    it('should still 409 on PUT to container without index.html', async () => {
+      // Create an empty container
+      await request('/ldptest/public/empty-dir/', { method: 'PUT', auth: 'ldptest' });
+
+      // PUT text/html to container without index.html should still 409
+      const res = await request('/ldptest/public/empty-dir/', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'text/html' },
+        body: '<html><body>test</body></html>',
+        auth: 'ldptest'
+      });
+
+      assertStatus(res, 409);
+    });
   });
 
   describe('POST', () => {


### PR DESCRIPTION
## Summary

- When a container has an `index.html` and receives a `PUT` with `Content-Type: text/html`, route the write to the index document instead of returning 409
- Mirrors GET behavior which already serves `index.html` for container URLs
- Containers without `index.html` or non-HTML PUTs still get 409 (no behavior change)

## Motivation

Self-editing HTML documents (JSON-LD panes) use `PUT` to `window.location.href` to save themselves. Since GET resolves `/` to `/index.html`, the save URL is `/` — which previously returned 409 "Cannot PUT to existing container".

Partially addresses #14 (PUT only — PATCH routing to index.html is left for future work)

## Test plan

- [x] PUT `text/html` to container with `index.html` returns 204 and updates the file
- [x] PUT to container without `index.html` still returns 409
- [x] All existing tests pass