### PR TITLE
Fix: handle ECONNRESET gracefully instead of crashing

### DIFF
--- a/bin/jss.js
+++ b/bin/jss.js
@@ -188,6 +188,16 @@ program
       process.on('SIGINT', shutdown);
       process.on('SIGTERM', shutdown);
 
+      // Gracefully handle ECONNRESET — normal network noise from clients
+      // closing connections early (browser navigation, health checks, etc.)
+      process.on('uncaughtException', (err) => {
+        if (err.code === 'ECONNRESET' || err.code === 'EPIPE' || err.code === 'ECONNABORTED') {
+          return;
+        }
+        console.error('Uncaught exception:', err);
+        process.exit(1);
+      });
+
     } catch (err) {
       console.error(`Error: ${err.message}`);
       process.exit(1);

--- a/src/server.js
+++ b/src/server.js
@@ -95,7 +95,16 @@ export function createServer(options = {}) {
     disableRequestLogging: true,
     trustProxy: true,
     // Handle raw body for non-JSON content
-    bodyLimit: 10 * 1024 * 1024 // 10MB
+    bodyLimit: 10 * 1024 * 1024, // 10MB
+    // Gracefully handle client TCP errors (ECONNRESET, EPIPE, etc.)
+    clientErrorHandler: (err, socket) => {
+      if (err.code === 'ECONNRESET' || err.code === 'EPIPE' || err.code === 'ECONNABORTED') {
+        socket.destroy();
+        return;
+      }
+      // Default Fastify behavior for other client errors
+      socket.destroy(err);
+    }
   };
 
   // Add HTTPS support if SSL config provided


### PR DESCRIPTION
## Summary
- Add Fastify `clientErrorHandler` to silently handle ECONNRESET, EPIPE, and ECONNABORTED at the socket level
- Add process-level `uncaughtException` safety net for any TCP errors that escape Fastify
- Prevents server crashes from normal network noise (browser navigation, health checks, aborted requests)

Closes #138

## Test plan
- [ ] Verify existing test suite passes
- [ ] Deploy behind haproxy and confirm no crashes on connection resets
- [ ] Confirm non-TCP uncaught exceptions still crash with error output