### PR TITLE
Add --mashlib-module flag for ES module data browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ jss --help             # Show help
 | `--base-domain <domain>` | Base domain for subdomains | - |
 | `--mashlib` | Enable Mashlib (local mode) | false |
 | `--mashlib-cdn` | Enable Mashlib (CDN mode) | false |
+| `--mashlib-module <url>` | Enable ES module data browser from a URL | - |
 | `--mashlib-version <ver>` | Mashlib CDN version | 2.0.0 |
 | `--solidos-ui` | Enable modern SolidOS UI (requires --mashlib) | false |
 | `--git` | Enable Git HTTP backend | false |
@@ -161,6 +162,7 @@ export JSS_CONNEG=true
 export JSS_SUBDOMAINS=true
 export JSS_BASE_DOMAIN=example.com
 export JSS_MASHLIB=true
+export JSS_MASHLIB_MODULE=https://example.com/mashlib.js
 export JSS_NOSTR=true
 export JSS_INVITE_ONLY=true
 export JSS_WEBID_TLS=true
@@ -366,6 +368,12 @@ Serves mashlib from `src/mashlib-local/dist/`. Requires building mashlib locally
 cd src/mashlib-local
 npm install && npm run build
 ```
+
+**ES Module Mode** (for custom or next-gen mashlib builds):
+```bash
+jss start --mashlib-module https://example.com/mashlib.js
+```
+Loads an ES module-based data browser from any URL. Uses `<script type="module">` and `<div id="mashlib">` (self-initializing). CSS is auto-derived by replacing `.js` with `.css`. Content negotiation is auto-enabled.
 
 **How it works:**
 1. Browser requests `/alice/public/data.ttl` with `Accept: text/html`

--- a/bin/jss.js
+++ b/bin/jss.js
@@ -55,6 +55,7 @@ program
   .option('--base-domain <domain>', 'Base domain for subdomain pods (e.g., "example.com")')
   .option('--mashlib', 'Enable Mashlib data browser (local mode, requires mashlib in node_modules)')
   .option('--mashlib-cdn', 'Enable Mashlib data browser (CDN mode, no local files needed)')
+  .option('--mashlib-module <url>', 'Enable ES module data browser from a URL')
   .option('--no-mashlib', 'Disable Mashlib data browser')
   .option('--mashlib-version <version>', 'Mashlib version for CDN mode (default: 2.0.0)')
   .option('--solidos-ui', 'Enable modern Nextcloud-style UI (requires --mashlib)')
@@ -123,6 +124,7 @@ program
         mashlib: config.mashlib || config.mashlibCdn,
         mashlibCdn: config.mashlibCdn,
         mashlibVersion: config.mashlibVersion,
+        mashlibModule: config.mashlibModule,
         solidosUi: config.solidosUi,
         git: config.git,
         nostr: config.nostr,
@@ -158,6 +160,7 @@ program
         } else if (config.mashlib) {
           console.log(`  Mashlib: local (data browser enabled)`);
         }
+        if (config.mashlibModule) console.log(`  Mashlib module: ${config.mashlibModule}`);
         if (config.solidosUi) console.log('  SolidOS UI: enabled (modern interface)');
         if (config.git) console.log('  Git: enabled (clone/push support)');
         if (config.nostr) console.log(`  Nostr: enabled (${config.nostrPath})`);

--- a/src/config.js
+++ b/src/config.js
@@ -41,6 +41,7 @@ export const defaults = {
   mashlib: false,
   mashlibCdn: false,
   mashlibVersion: '2.0.0',
+  mashlibModule: false,
 
   // SolidOS UI (modern Nextcloud-style interface)
   solidosUi: false,
@@ -113,6 +114,7 @@ const envMap = {
   JSS_MASHLIB: 'mashlib',
   JSS_MASHLIB_CDN: 'mashlibCdn',
   JSS_MASHLIB_VERSION: 'mashlibVersion',
+  JSS_MASHLIB_MODULE: 'mashlibModule',
   JSS_SOLIDOS_UI: 'solidosUi',
   JSS_GIT: 'git',
   JSS_NOSTR: 'nostr',
@@ -238,7 +240,7 @@ export async function loadConfig(cliOptions = {}, configFile = null) {
   }
 
   // Mashlib requires content negotiation for Turtle support
-  if (config.mashlib || config.mashlibCdn) {
+  if (config.mashlib || config.mashlibCdn || config.mashlibModule) {
     config.conneg = true;
   }
 
@@ -293,7 +295,7 @@ export function printConfig(config) {
   console.log(`  Notifications: ${config.notifications}`);
   console.log(`  IdP:           ${config.idp ? (config.idpIssuer || 'enabled') : 'disabled'}`);
   console.log(`  Subdomains:    ${config.subdomains ? (config.baseDomain || 'enabled') : 'disabled'}`);
-  console.log(`  Mashlib:       ${config.mashlibCdn ? `CDN v${config.mashlibVersion}` : config.mashlib ? 'local' : 'disabled'}`);
+  console.log(`  Mashlib:       ${config.mashlibModule ? `module (${config.mashlibModule})` : config.mashlibCdn ? `CDN v${config.mashlibVersion}` : config.mashlib ? 'local' : 'disabled'}`);
   console.log(`  SolidOS UI:    ${config.solidosUi ? 'enabled' : 'disabled'}`);
   console.log('─'.repeat(40));
 }

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -15,7 +15,7 @@ import {
 } from '../rdf/conneg.js';
 import { emitChange } from '../notifications/events.js';
 import { checkIfMatch, checkIfNoneMatchForGet, checkIfNoneMatchForWrite } from '../utils/conditional.js';
-import { generateDatabrowserHtml, generateSolidosUiHtml, shouldServeMashlib } from '../mashlib/index.js';
+import { generateDatabrowserHtml, generateModuleDatabrowserHtml, generateSolidosUiHtml, shouldServeMashlib } from '../mashlib/index.js';
 
 /**
  * Live reload script - injected into HTML when --live-reload is enabled
@@ -230,10 +230,12 @@ export async function handleGet(request, reply) {
 
     // Check if we should serve Mashlib data browser for containers
     if (shouldServeMashlib(request, request.mashlibEnabled, 'application/ld+json')) {
-      // Use SolidOS UI if enabled, otherwise fallback to classic mashlib
+      // Use SolidOS UI if enabled, ES module if configured, otherwise classic mashlib
       const html = request.solidosUiEnabled
         ? generateSolidosUiHtml()
-        : generateDatabrowserHtml(resourceUrl, request.mashlibCdn ? request.mashlibVersion : null);
+        : request.mashlibModule
+          ? generateModuleDatabrowserHtml(request.mashlibModule)
+          : generateDatabrowserHtml(resourceUrl, request.mashlibCdn ? request.mashlibVersion : null);
       const headers = getAllHeaders({
         isContainer: true,
         etag: stats.etag,
@@ -307,10 +309,12 @@ export async function handleGet(request, reply) {
   // Check if we should serve Mashlib data browser
   // Only for RDF resources when Accept: text/html is requested
   if (shouldServeMashlib(request, request.mashlibEnabled, storedContentType)) {
-    // Use SolidOS UI if enabled, otherwise fallback to classic mashlib
+    // Use SolidOS UI if enabled, ES module if configured, otherwise classic mashlib
     const html = request.solidosUiEnabled
       ? generateSolidosUiHtml()
-      : generateDatabrowserHtml(resourceUrl, request.mashlibCdn ? request.mashlibVersion : null);
+      : request.mashlibModule
+        ? generateModuleDatabrowserHtml(request.mashlibModule)
+        : generateDatabrowserHtml(resourceUrl, request.mashlibCdn ? request.mashlibVersion : null);
     const headers = getAllHeaders({
       isContainer: false,
       etag: stats.etag,

--- a/src/mashlib/index.js
+++ b/src/mashlib/index.js
@@ -41,6 +41,23 @@ export function generateDatabrowserHtml(resourceUrl, cdnVersion = null) {
 }
 
 /**
+ * Generate ES module-based databrowser HTML
+ *
+ * @param {string} moduleUrl - URL to the ES module entry point
+ * @returns {string} HTML content
+ */
+export function generateModuleDatabrowserHtml(moduleUrl) {
+  const cssUrl = moduleUrl.replace(/\.js$/, '.css');
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Solid Data Browser</title>
+<link rel="stylesheet" href="${cssUrl}"></head>
+<body><div id="mashlib"></div>
+<script type="module" src="${moduleUrl}"></script>
+</body></html>`;
+}
+
+/**
  * Check if request wants HTML and mashlib should handle it
  * @param {object} request - Fastify request
  * @param {boolean} mashlibEnabled - Whether mashlib is enabled

--- a/src/server.js
+++ b/src/server.js
@@ -54,7 +54,9 @@ export function createServer(options = {}) {
   const baseDomain = options.baseDomain || null;
   // Mashlib data browser is OFF by default
   // mashlibCdn: if true, load from CDN; if false, serve locally
-  const mashlibEnabled = options.mashlib ?? false;
+  // mashlibModule: URL to ES module entry point (alternative to classic mashlib)
+  const mashlibModule = options.mashlibModule ?? false;
+  const mashlibEnabled = options.mashlib || !!mashlibModule;
   const mashlibCdn = options.mashlibCdn ?? false;
   const mashlibVersion = options.mashlibVersion ?? '2.0.0';
   // SolidOS UI (modern Nextcloud-style interface) - requires mashlib
@@ -147,6 +149,7 @@ export function createServer(options = {}) {
   fastify.decorateRequest('mashlibEnabled', null);
   fastify.decorateRequest('mashlibCdn', null);
   fastify.decorateRequest('mashlibVersion', null);
+  fastify.decorateRequest('mashlibModule', null);
   fastify.decorateRequest('solidosUiEnabled', null);
   fastify.decorateRequest('defaultQuota', null);
   fastify.decorateRequest('config', null);
@@ -160,6 +163,7 @@ export function createServer(options = {}) {
     request.mashlibEnabled = mashlibEnabled;
     request.mashlibCdn = mashlibCdn;
     request.mashlibVersion = mashlibVersion;
+    request.mashlibModule = mashlibModule;
     request.solidosUiEnabled = solidosUiEnabled;
     request.defaultQuota = defaultQuota;
     request.config = { public: options.public, readOnly: options.readOnly };


### PR DESCRIPTION
## Summary
- Add `--mashlib-module <url>` CLI flag and `JSS_MASHLIB_MODULE` env var
- New `generateModuleDatabrowserHtml()` in `src/mashlib/index.js` using `<script type="module">` and `<div id="mashlib">`
- CSS URL auto-derived from JS URL (`.js` → `.css`)
- Integrated into both container and resource GET handlers
- Auto-enables content negotiation (same as `--mashlib`)
- Backwards compatible: `--mashlib` and `--mashlib-cdn` unchanged

Closes #140

## Files changed
- `bin/jss.js` — new CLI option, pass-through to config, banner output
- `src/config.js` — default, env var mapping, conneg auto-enable, printConfig
- `src/server.js` — request decoration, mashlibEnabled includes module
- `src/mashlib/index.js` — new `generateModuleDatabrowserHtml()` export
- `src/handlers/resource.js` — use module HTML when `mashlibModule` is set

## Test plan
- [x] All 69 core tests pass (LDP, conformance, conneg)
- [ ] Manual test: `jss start --mashlib-module https://example.com/mashlib.js`