### PR TITLE
Fix WAC 403 for path-based pod access when subdomains enabled

### DIFF
--- a/src/auth/middleware.js
+++ b/src/auth/middleware.js
@@ -12,6 +12,29 @@ import { getEffectiveUrlPath } from '../utils/url.js';
 import { generateDatabrowserHtml, generateSolidosUiHtml } from '../mashlib/index.js';
 
 /**
+ * Build a resource URL for WAC checking, normalizing path-based pod access
+ * to subdomain form so URLs match ACL entries.
+ *
+ * In subdomain mode, ACLs reference subdomain URLs (e.g. https://alice.example.com/public/).
+ * Path-based access on the main domain (e.g. https://example.com/alice/public/) must be
+ * normalized to match.
+ *
+ * @param {object} request - Fastify request
+ * @param {string} urlPath - URL path (e.g. /alice/public/file.ttl)
+ * @returns {string} Normalized resource URL
+ */
+function buildResourceUrl(request, urlPath) {
+  if (request.subdomainsEnabled && request.baseDomain &&
+      request.hostname === request.baseDomain && !request.podName) {
+    const pathMatch = urlPath.match(/^\/([^/]+)(\/.*)$/);
+    if (pathMatch) {
+      return `${request.protocol}://${pathMatch[1]}.${request.baseDomain}${pathMatch[2]}`;
+    }
+  }
+  return `${request.protocol}://${request.hostname}${urlPath}`;
+}
+
+/**
  * Check if request is authorized
  * @param {object} request - Fastify request
  * @param {object} reply - Fastify reply
@@ -55,8 +78,8 @@ export async function authorize(request, reply, options = {}) {
   const resourceExists = stats !== null;
   const isContainer = stats?.isDirectory || urlPath.endsWith('/');
 
-  // Build resource URL (uses actual request hostname which may be subdomain)
-  const resourceUrl = `${request.protocol}://${request.hostname}${urlPath}`;
+  // Build resource URL, normalizing path-based pod access to subdomain form for WAC
+  const resourceUrl = buildResourceUrl(request, urlPath);
 
   // Get required access mode - use override if provided, otherwise derive from method
   const requiredMode = options.requiredMode || getRequiredMode(method);
@@ -70,9 +93,9 @@ export async function authorize(request, reply, options = {}) {
     // Check write permission on parent container
     const parentPath = getParentPath(storagePath);
     checkPath = parentPath;
-    // For URL, also need to get parent
+    // For URL, also need to get parent (normalized for subdomain WAC matching)
     const parentUrlPath = getParentPath(urlPath);
-    checkUrl = `${request.protocol}://${request.hostname}${parentUrlPath}`;
+    checkUrl = buildResourceUrl(request, parentUrlPath);
     checkIsContainer = true;
   }
 
@@ -379,7 +402,7 @@ async function authorizeAclAccess(request, urlPath, method, webId, authError) {
   // /foo/bar.acl protects /foo/bar (resource)
   const protectedPath = urlPath.replace(/\.acl$/, '');
   const isProtectedContainer = protectedPath.endsWith('/');
-  const protectedUrl = `${request.protocol}://${request.hostname}${protectedPath}`;
+  const protectedUrl = buildResourceUrl(request, protectedPath);
 
   // Get storage path for the protected resource
   const storagePath = getEffectiveUrlPath(request).replace(/\.acl$/, '');

--- a/src/auth/middleware.js
+++ b/src/auth/middleware.js
@@ -26,9 +26,11 @@ import { generateDatabrowserHtml, generateSolidosUiHtml } from '../mashlib/index
 function buildResourceUrl(request, urlPath) {
   if (request.subdomainsEnabled && request.baseDomain &&
       request.hostname === request.baseDomain && !request.podName) {
-    const pathMatch = urlPath.match(/^\/([^/]+)(\/.*)$/);
-    if (pathMatch) {
-      return `${request.protocol}://${pathMatch[1]}.${request.baseDomain}${pathMatch[2]}`;
+    const pathMatch = urlPath.match(/^\/([^/]+)(\/.*)?$/);
+    if (pathMatch && !pathMatch[1].startsWith('.')) {
+      const podName = pathMatch[1];
+      const remainder = pathMatch[2] || '/';
+      return `${request.protocol}://${podName}.${request.baseDomain}${remainder}`;
     }
   }
   return `${request.protocol}://${request.hostname}${urlPath}`;


### PR DESCRIPTION
## Summary
- Extracts a `buildResourceUrl()` helper that normalizes path-based pod URLs to subdomain form for WAC checking
- Applies normalization in three places: resource URL, parent container URL (write ops), and ACL protected resource URL
- No changes to behavior when subdomains are disabled or when accessing via subdomain directly

## Problem
With `subdomains: true`, accessing `example.com/alice/public/file.ttl` returns 403 even when the ACL grants public Read access. The WAC checker builds the resource URL as `https://example.com/alice/public/file.ttl` but ACLs reference `https://alice.example.com/public/`.

## Test plan
- [ ] Access public resource via path (`example.com/alice/public/file`) — should return 200
- [ ] Access public resource via subdomain (`alice.example.com/public/file`) — should still return 200
- [ ] Access private resource via path without auth — should return 401
- [ ] PUT to path-based URL with auth — parent container URL also normalized
- [ ] ACL file access via path — protected resource URL normalized

Fixes #144