### PR TITLE
Fix handleUnauthorized serving old mashlib when mashlibModule configured

### DIFF
--- a/src/auth/middleware.js
+++ b/src/auth/middleware.js
@@ -9,7 +9,7 @@ import { checkAccess, getRequiredMode } from '../wac/checker.js';
 import { AccessMode } from '../wac/parser.js';
 import * as storage from '../storage/filesystem.js';
 import { getEffectiveUrlPath } from '../utils/url.js';
-import { generateDatabrowserHtml, generateSolidosUiHtml } from '../mashlib/index.js';
+import { generateDatabrowserHtml, generateModuleDatabrowserHtml, generateSolidosUiHtml } from '../mashlib/index.js';
 
 /**
  * Check if request is authorized
@@ -123,10 +123,12 @@ export function handleUnauthorized(request, reply, isAuthenticated, wacAllow, au
     // If mashlib is enabled, serve mashlib instead of static error page
     // Mashlib has built-in login functionality via panes.runDataBrowser()
     if (request.mashlibEnabled) {
-      // Use SolidOS UI if enabled, otherwise fallback to classic mashlib
+      // Use SolidOS UI if enabled, ES module if configured, otherwise classic mashlib
       const html = request.solidosUiEnabled
         ? generateSolidosUiHtml()
-        : generateDatabrowserHtml(request.url, request.mashlibCdn ? request.mashlibVersion : null);
+        : request.mashlibModule
+          ? generateModuleDatabrowserHtml(request.mashlibModule)
+          : generateDatabrowserHtml(request.url, request.mashlibCdn ? request.mashlibVersion : null);
       return reply.code(statusCode).type('text/html').send(html);
     }
     return reply.code(statusCode).type('text/html').send(getErrorPage(statusCode, isAuthenticated, request));


### PR DESCRIPTION
## Summary
- Add `generateModuleDatabrowserHtml` import to auth middleware
- Add `mashlibModule` check in `handleUnauthorized()` to match the ternary pattern used in resource handlers

## Problem
When `mashlibModule` is configured, unauthenticated/unauthorized requests still get the classic mashlib HTML (referencing local `/mashlib.min.js` and `/mash.css`) instead of the ES module HTML. This causes 404 errors since the local mashlib files aren't installed.

## Test plan
- [ ] Set `mashlibModule` in config, visit a resource without auth → mashlib-next module HTML served
- [ ] With `mashlibCdn` config → classic CDN mashlib HTML still works
- [ ] With `solidosUi` config → SolidOS UI HTML still works
- [ ] With `mashlib: true` (local) → classic local mashlib HTML still works

Fixes #143