### PR TITLE
fix: skip /db/ ownership check in single-user mode

### DIFF
--- a/src/db/index.js
+++ b/src/db/index.js
@@ -49,6 +49,9 @@ export async function dbPlugin(fastify, options) {
       return reply.code(401).send({ error: 'Unauthorized', message: 'Authentication required' });
     }
 
+    // Single-user mode: any authenticated user is the owner
+    if (options.singleUser) return;
+
     // Ownership check: only pod owner can write to /db/{podName}/...
     const urlPath = request.url.split('?')[0];
     const relative = urlPath.replace(/^\/db\//, '');

--- a/src/server.js
+++ b/src/server.js
@@ -236,7 +236,7 @@ export function createServer(options = {}) {
 
   // Register MongoDB /db/ route if enabled
   if (mongoEnabled) {
-    fastify.register(dbPlugin, { mongoUrl, mongoDatabase });
+    fastify.register(dbPlugin, { mongoUrl, mongoDatabase, singleUser });
   }
 
   // Register rate limiting plugin


### PR DESCRIPTION
## Summary
- In single-user mode, any authenticated user is the owner — skip pod-name ownership check
- Passes `singleUser` option through to dbPlugin

Fixes #152