### PR TITLE
Add Mastodon-compatible API endpoints

### DIFF
--- a/src/ap/index.js
+++ b/src/ap/index.js
@@ -10,6 +10,7 @@ import { createInboxHandler } from './routes/inbox.js'
 import { createOutboxHandler, createOutboxPostHandler } from './routes/outbox.js'
 import { createCollectionsHandler } from './routes/collections.js'
 import { createActorHandler } from './routes/actor.js'
+import { createAppsHandler, createVerifyCredentialsHandler, createInstanceHandler } from './routes/mastodon.js'
 
 // Shared state for actor handler (accessed by server.js)
 let sharedActorHandler = null
@@ -173,6 +174,11 @@ export async function activityPubPlugin(fastify, options = {}) {
   const collectionsHandler = createCollectionsHandler(config)
   fastify.get('/profile/card/followers', (req, reply) => collectionsHandler(req, reply, 'followers'))
   fastify.get('/profile/card/following', (req, reply) => collectionsHandler(req, reply, 'following'))
+
+  // Mastodon-compatible API endpoints
+  fastify.post('/api/v1/apps', createAppsHandler())
+  fastify.get('/api/v1/accounts/verify_credentials', createVerifyCredentialsHandler(config))
+  fastify.get('/api/v1/instance', createInstanceHandler(config))
 }
 
 export default activityPubPlugin

--- a/src/ap/routes/mastodon.js
+++ b/src/ap/routes/mastodon.js
@@ -1,0 +1,129 @@
+/**
+ * Mastodon-compatible API endpoints
+ * Allows Mastodon clients (Elk, Phanpy, Ice Cubes) to connect to JSS
+ *
+ * Step 1: Dynamic client registration + account verification
+ * Refs: https://docs.joinmastodon.org/methods/apps/
+ *       https://docs.joinmastodon.org/methods/accounts/#verify_credentials
+ */
+
+// In-memory client store (replace with persistent storage later)
+const clients = new Map()
+
+/**
+ * POST /api/v1/apps — Dynamic client registration
+ * Mastodon clients call this to register before OAuth
+ */
+export function createAppsHandler () {
+  return async (request, reply) => {
+    const { client_name, redirect_uris, scopes, website } = request.body || {}
+
+    if (!client_name || !redirect_uris) {
+      return reply.code(422).send({ error: 'client_name and redirect_uris are required' })
+    }
+
+    const clientId = crypto.randomUUID()
+    const clientSecret = crypto.randomUUID()
+
+    const client = {
+      id: clientId,
+      name: client_name,
+      redirect_uri: redirect_uris,
+      client_id: clientId,
+      client_secret: clientSecret,
+      scopes: scopes || 'read',
+      website: website || null
+    }
+
+    clients.set(clientId, client)
+
+    return reply.send(client)
+  }
+}
+
+/**
+ * GET /api/v1/accounts/verify_credentials — Who am I?
+ * Returns the authenticated user's profile as a Mastodon Account object
+ */
+export function createVerifyCredentialsHandler (config) {
+  return async (request, reply) => {
+    const protocol = request.headers['x-forwarded-proto'] || request.protocol
+    const host = request.headers['x-forwarded-host'] || request.hostname
+    const baseUrl = `${protocol}://${host}`
+
+    const account = {
+      id: '1',
+      username: config.username,
+      acct: config.username,
+      display_name: config.displayName,
+      note: config.summary ? `<p>${config.summary}</p>` : '',
+      url: `${baseUrl}/profile/card`,
+      uri: `${baseUrl}/profile/card#me`,
+      avatar: `${baseUrl}/profile/avatar.png`,
+      header: '',
+      locked: false,
+      bot: false,
+      created_at: new Date().toISOString(),
+      followers_count: 0,
+      following_count: 0,
+      statuses_count: 0,
+      source: {
+        privacy: 'public',
+        sensitive: false,
+        language: 'en',
+        note: config.summary || ''
+      }
+    }
+
+    return reply.send(account)
+  }
+}
+
+/**
+ * GET /api/v1/instance — Instance information
+ * Required by most Mastodon clients before login
+ */
+export function createInstanceHandler (config) {
+  return async (request, reply) => {
+    const protocol = request.headers['x-forwarded-proto'] || request.protocol
+    const host = request.headers['x-forwarded-host'] || request.hostname
+    const baseUrl = `${protocol}://${host}`
+
+    return reply.send({
+      uri: host,
+      title: config.displayName || 'JSS',
+      description: 'SAND Stack: Solid + ActivityPub + Nostr + DID',
+      short_description: 'Solid pod with Mastodon-compatible API',
+      version: '4.0.0 (compatible; JSS 0.0.67)',
+      urls: {
+        streaming_api: `wss://${host}`
+      },
+      stats: {
+        user_count: 1,
+        status_count: 0,
+        domain_count: 1
+      },
+      languages: ['en'],
+      registrations: false,
+      approval_required: false,
+      configuration: {
+        statuses: { max_characters: 5000 },
+        media_attachments: { supported_mime_types: [] }
+      }
+    })
+  }
+}
+
+/**
+ * Look up a registered client
+ */
+export function getClient (clientId) {
+  return clients.get(clientId) || null
+}
+
+export default {
+  createAppsHandler,
+  createVerifyCredentialsHandler,
+  createInstanceHandler,
+  getClient
+}

--- a/src/ap/routes/mastodon.js
+++ b/src/ap/routes/mastodon.js
@@ -10,13 +10,34 @@
 // In-memory client store (replace with persistent storage later)
 const clients = new Map()
 
+// Stable instance start time (used for created_at)
+const startedAt = new Date().toISOString()
+
+/**
+ * Parse request body — handles both JSON and form-urlencoded
+ * (JSS uses raw buffer parser for all content types)
+ */
+function parseBody (request) {
+  if (request.body && typeof request.body === 'object' && !Buffer.isBuffer(request.body)) {
+    return request.body
+  }
+  const raw = Buffer.isBuffer(request.body) ? request.body.toString() : String(request.body || '')
+  const ct = request.headers['content-type'] || ''
+  if (ct.includes('application/json')) {
+    try { return JSON.parse(raw) } catch { return {} }
+  }
+  // Default: parse as form-urlencoded
+  return Object.fromEntries(new URLSearchParams(raw))
+}
+
 /**
  * POST /api/v1/apps — Dynamic client registration
  * Mastodon clients call this to register before OAuth
  */
 export function createAppsHandler () {
   return async (request, reply) => {
-    const { client_name, redirect_uris, scopes, website } = request.body || {}
+    const body = parseBody(request)
+    const { client_name, redirect_uris, scopes, website } = body
 
     if (!client_name || !redirect_uris) {
       return reply.code(422).send({ error: 'client_name and redirect_uris are required' })
@@ -56,14 +77,14 @@ export function createVerifyCredentialsHandler (config) {
       username: config.username,
       acct: config.username,
       display_name: config.displayName,
-      note: config.summary ? `<p>${config.summary}</p>` : '',
+      note: config.summary ? `<p>${escapeHtml(config.summary)}</p>` : '',
       url: `${baseUrl}/profile/card`,
       uri: `${baseUrl}/profile/card#me`,
       avatar: `${baseUrl}/profile/avatar.png`,
       header: '',
       locked: false,
       bot: false,
-      created_at: new Date().toISOString(),
+      created_at: startedAt,
       followers_count: 0,
       following_count: 0,
       statuses_count: 0,
@@ -87,7 +108,7 @@ export function createInstanceHandler (config) {
   return async (request, reply) => {
     const protocol = request.headers['x-forwarded-proto'] || request.protocol
     const host = request.headers['x-forwarded-host'] || request.hostname
-    const baseUrl = `${protocol}://${host}`
+    const wsProtocol = protocol === 'https' ? 'wss' : 'ws'
 
     return reply.send({
       uri: host,
@@ -96,7 +117,7 @@ export function createInstanceHandler (config) {
       short_description: 'Solid pod with Mastodon-compatible API',
       version: '4.0.0 (compatible; JSS 0.0.67)',
       urls: {
-        streaming_api: `wss://${host}`
+        streaming_api: `${wsProtocol}://${host}`
       },
       stats: {
         user_count: 1,
@@ -119,6 +140,10 @@ export function createInstanceHandler (config) {
  */
 export function getClient (clientId) {
   return clients.get(clientId) || null
+}
+
+function escapeHtml (str) {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
 }
 
 export default {

--- a/src/server.js
+++ b/src/server.js
@@ -353,7 +353,8 @@ export function createServer(options = {}) {
   fastify.addHook('preHandler', async (request, reply) => {
     // Skip auth for pod creation, OPTIONS, IdP routes, mashlib, solidos-ui, well-known, notifications, nostr, git, and AP
     const mashlibPaths = ['/mashlib.min.js', '/mash.css', '/841.mashlib.min.js'];
-    const apPaths = ['/inbox', '/profile/card/inbox', '/profile/card/outbox', '/profile/card/followers', '/profile/card/following'];
+    const apPaths = ['/inbox', '/profile/card/inbox', '/profile/card/outbox', '/profile/card/followers', '/profile/card/following',
+      '/api/v1/apps', '/api/v1/instance', '/api/v1/accounts/verify_credentials'];
     // Check if request wants ActivityPub content for profile
     const accept = request.headers.accept || '';
     const wantsAP = accept.includes('activity+json') || accept.includes('ld+json; profile="https://www.w3.org/ns/activitystreams"');
@@ -366,7 +367,7 @@ export function createServer(options = {}) {
         request.url.startsWith('/solidos-ui/') ||
         (nostrEnabled && request.url.startsWith(nostrPath)) ||
         (gitEnabled && isGitRequest(request.url)) ||
-        (activitypubEnabled && (apPaths.some(p => request.url === p || request.url.startsWith(p + '?')) || request.url.startsWith('/api/v1/'))) ||
+        (activitypubEnabled && apPaths.some(p => request.url === p || request.url.startsWith(p + '?'))) ||
         isProfileAP ||
         (mongoEnabled && (request.url === '/db' || request.url.startsWith('/db/'))) ||
         mashlibPaths.some(p => request.url === p || request.url.startsWith(p + '.'))) {

--- a/src/server.js
+++ b/src/server.js
@@ -366,7 +366,7 @@ export function createServer(options = {}) {
         request.url.startsWith('/solidos-ui/') ||
         (nostrEnabled && request.url.startsWith(nostrPath)) ||
         (gitEnabled && isGitRequest(request.url)) ||
-        (activitypubEnabled && apPaths.some(p => request.url === p || request.url.startsWith(p + '?'))) ||
+        (activitypubEnabled && (apPaths.some(p => request.url === p || request.url.startsWith(p + '?')) || request.url.startsWith('/api/v1/'))) ||
         isProfileAP ||
         (mongoEnabled && (request.url === '/db' || request.url.startsWith('/db/'))) ||
         mashlibPaths.some(p => request.url === p || request.url.startsWith(p + '.'))) {


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/apps` — dynamic client registration for Mastodon clients
- Adds `GET /api/v1/accounts/verify_credentials` — returns WebID profile as Mastodon Account
- Adds `GET /api/v1/instance` — instance metadata for client discovery

This is Step 1 of Mastodon API compatibility. After this, clients like Elk, Phanpy, and Ice Cubes can connect to a JSS instance and identify the user.

## Motivation

The fediverse has ~10 million active users. JSS already speaks ActivityPub. Adding the Mastodon-compatible API surface lets existing Mastodon clients connect to JSS without users installing anything new — 10 million potential users, zero onboarding friction.

OIDC already provides the OAuth 2.0 layer. These endpoints add the Mastodon-specific API surface on top.

## Next steps

- Step 2: `GET /api/v1/timelines/home` — pod content as a Mastodon feed
- Step 3: `POST /api/v1/statuses` — write to pod, federate via ActivityPub

Closes #158

## Test plan

- [ ] `POST /api/v1/apps` returns client_id and client_secret
- [ ] `GET /api/v1/instance` returns valid instance metadata
- [ ] `GET /api/v1/accounts/verify_credentials` returns account object
- [ ] Elk or Phanpy can discover the instance via `/api/v1/instance`