### PR TITLE
OAuth 2.0 authorize/token flow

### DIFF
--- a/src/ap/index.js
+++ b/src/ap/index.js
@@ -183,7 +183,15 @@ export async function activityPubPlugin(fastify, options = {}) {
 
   // OAuth 2.0 authorize/token flow (Mastodon clients, remoteStorage, third-party panes)
   fastify.get('/oauth/authorize', createAuthorizeHandler())
-  fastify.post('/oauth/authorize', createAuthorizePostHandler())
+  fastify.post('/oauth/authorize', {
+    config: {
+      rateLimit: {
+        max: 10,
+        timeWindow: '1 minute',
+        keyGenerator: (request) => request.ip
+      }
+    }
+  }, createAuthorizePostHandler())
   fastify.post('/oauth/token', createTokenHandler())
 }
 

--- a/src/ap/index.js
+++ b/src/ap/index.js
@@ -192,7 +192,15 @@ export async function activityPubPlugin(fastify, options = {}) {
       }
     }
   }, createAuthorizePostHandler())
-  fastify.post('/oauth/token', createTokenHandler())
+  fastify.post('/oauth/token', {
+    config: {
+      rateLimit: {
+        max: 10,
+        timeWindow: '1 minute',
+        keyGenerator: (request) => request.ip
+      }
+    }
+  }, createTokenHandler())
 }
 
 export default activityPubPlugin

--- a/src/ap/index.js
+++ b/src/ap/index.js
@@ -11,6 +11,7 @@ import { createOutboxHandler, createOutboxPostHandler } from './routes/outbox.js
 import { createCollectionsHandler } from './routes/collections.js'
 import { createActorHandler } from './routes/actor.js'
 import { createAppsHandler, createVerifyCredentialsHandler, createInstanceHandler } from './routes/mastodon.js'
+import { createAuthorizeHandler, createAuthorizePostHandler, createTokenHandler } from './routes/oauth.js'
 
 // Shared state for actor handler (accessed by server.js)
 let sharedActorHandler = null
@@ -179,6 +180,11 @@ export async function activityPubPlugin(fastify, options = {}) {
   fastify.post('/api/v1/apps', createAppsHandler())
   fastify.get('/api/v1/accounts/verify_credentials', createVerifyCredentialsHandler(config))
   fastify.get('/api/v1/instance', createInstanceHandler(config))
+
+  // OAuth 2.0 authorize/token flow (Mastodon clients, remoteStorage, third-party panes)
+  fastify.get('/oauth/authorize', createAuthorizeHandler())
+  fastify.post('/oauth/authorize', createAuthorizePostHandler())
+  fastify.post('/oauth/token', createTokenHandler())
 }
 
 export default activityPubPlugin

--- a/src/ap/routes/oauth.js
+++ b/src/ap/routes/oauth.js
@@ -12,6 +12,9 @@ import { getClient } from './mastodon.js'
 import { authenticate } from '../../idp/accounts.js'
 import { createToken } from '../../auth/token.js'
 
+// Mastodon OOB redirect — display code instead of redirecting
+const OOB_REDIRECT = 'urn:ietf:wg:oauth:2.0:oob'
+
 // Auth codes: code → { clientId, redirectUri, webId, scope, expiresAt }
 const authCodes = new Map()
 
@@ -39,23 +42,41 @@ function parseBody (request) {
 }
 
 /**
+ * Validate client_id and redirect_uri against registered client
+ * Returns { client, error } — client is null if validation fails
+ */
+function validateClient (clientId, redirectUri) {
+  if (!clientId || !redirectUri) {
+    return { client: null, error: 'Missing client_id or redirect_uri' }
+  }
+
+  const client = getClient(clientId)
+  if (!client) {
+    return { client: null, error: 'Unknown client_id. Register via POST /api/v1/apps first.' }
+  }
+
+  // Validate redirect_uri matches registered value (RFC 6749 §10.6)
+  if (redirectUri !== OOB_REDIRECT && redirectUri !== client.redirect_uri) {
+    return { client: null, error: 'redirect_uri does not match registered value' }
+  }
+
+  return { client, error: null }
+}
+
+/**
  * GET /oauth/authorize — Show login/consent page
  */
 export function createAuthorizeHandler () {
   return async (request, reply) => {
     const { client_id, redirect_uri, response_type, scope } = request.query
 
-    if (!client_id || !redirect_uri) {
-      return reply.code(400).send({ error: 'Missing client_id or redirect_uri' })
-    }
-
     if (response_type && response_type !== 'code') {
       return reply.code(400).send({ error: 'unsupported_response_type', error_description: 'Only response_type=code is supported' })
     }
 
-    const client = getClient(client_id)
+    const { client, error } = validateClient(client_id, redirect_uri)
     if (!client) {
-      return reply.code(400).send({ error: 'invalid_client', error_description: 'Unknown client_id. Register via POST /api/v1/apps first.' })
+      return reply.code(400).send({ error: 'invalid_client', error_description: error })
     }
 
     return reply.type('text/html').send(
@@ -72,16 +93,22 @@ export function createAuthorizePostHandler () {
     const body = parseBody(request)
     const { username, password, client_id, redirect_uri, scope } = body
 
+    // Validate client + redirect_uri (prevent open redirect via form tampering)
+    const { client, error: clientError } = validateClient(client_id, redirect_uri)
+    if (!client) {
+      return reply.code(400).send({ error: 'invalid_client', error_description: clientError })
+    }
+
     if (!username || !password) {
       return reply.type('text/html').send(
-        loginPage({ clientId: client_id, redirectUri: redirect_uri, scope, error: 'Username and password are required' })
+        loginPage({ clientId: client_id, redirectUri: redirect_uri, scope, clientName: client.name, error: 'Username and password are required' })
       )
     }
 
     const account = await authenticate(username, password)
     if (!account) {
       return reply.type('text/html').send(
-        loginPage({ clientId: client_id, redirectUri: redirect_uri, scope, error: 'Invalid username or password' })
+        loginPage({ clientId: client_id, redirectUri: redirect_uri, scope, clientName: client.name, error: 'Invalid username or password' })
       )
     }
 
@@ -94,6 +121,11 @@ export function createAuthorizePostHandler () {
       scope: scope || 'read',
       expiresAt: Date.now() + 600_000
     })
+
+    // Handle OOB redirect — display code to user instead of redirecting
+    if (redirect_uri === OOB_REDIRECT) {
+      return reply.type('text/html').send(oobPage(code))
+    }
 
     // Redirect back to client with code
     const url = new URL(redirect_uri)
@@ -116,6 +148,15 @@ export function createTokenHandler () {
 
     if (!code) {
       return reply.code(400).send({ error: 'invalid_request', error_description: 'Missing code' })
+    }
+
+    // Validate client credentials (RFC 6749 §2.3)
+    const client = getClient(client_id)
+    if (!client) {
+      return reply.code(401).send({ error: 'invalid_client', error_description: 'Unknown client_id' })
+    }
+    if (client.client_secret !== client_secret) {
+      return reply.code(401).send({ error: 'invalid_client', error_description: 'Invalid client_secret' })
     }
 
     // Look up and validate auth code
@@ -192,6 +233,36 @@ function loginPage ({ clientId, redirectUri, scope, clientName, error }) {
       <input type="password" id="password" name="password" required autocomplete="current-password">
       <button type="submit">Authorize</button>
     </form>
+  </div>
+</body>
+</html>`
+}
+
+/**
+ * OOB (out-of-band) code display page
+ * Used when redirect_uri is urn:ietf:wg:oauth:2.0:oob
+ */
+function oobPage (code) {
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Authorization Code</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif; background: #f5f5f5; display: flex; justify-content: center; align-items: center; min-height: 100vh; }
+    .card { background: white; border-radius: 12px; padding: 2rem; max-width: 400px; width: 90%; box-shadow: 0 2px 8px rgba(0,0,0,0.1); text-align: center; }
+    h1 { font-size: 1.25rem; margin-bottom: 1rem; }
+    .code { background: #f0f0f0; padding: 1rem; border-radius: 6px; font-family: monospace; font-size: 0.9rem; word-break: break-all; user-select: all; }
+    p { color: #666; margin-top: 1rem; font-size: 0.85rem; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Authorization Successful</h1>
+    <div class="code">${escapeHtml(code)}</div>
+    <p>Copy this code and paste it into your application.</p>
   </div>
 </body>
 </html>`

--- a/src/ap/routes/oauth.js
+++ b/src/ap/routes/oauth.js
@@ -8,6 +8,7 @@
  * Related: #158, #159 (Mastodon API), #106 (remoteStorage), #160 (this)
  */
 
+import crypto from 'crypto'
 import { getClient } from './mastodon.js'
 import { authenticate } from '../../idp/accounts.js'
 import { createToken } from '../../auth/token.js'
@@ -68,7 +69,7 @@ function validateClient (clientId, redirectUri) {
  */
 export function createAuthorizeHandler () {
   return async (request, reply) => {
-    const { client_id, redirect_uri, response_type, scope } = request.query
+    const { client_id, redirect_uri, response_type, scope, state } = request.query
 
     if (response_type && response_type !== 'code') {
       return reply.code(400).send({ error: 'unsupported_response_type', error_description: 'Only response_type=code is supported' })
@@ -80,7 +81,7 @@ export function createAuthorizeHandler () {
     }
 
     return reply.type('text/html').send(
-      loginPage({ clientId: client_id, redirectUri: redirect_uri, scope: scope || 'read', clientName: client.name })
+      loginPage({ clientId: client_id, redirectUri: redirect_uri, scope: scope || 'read', state, clientName: client.name })
     )
   }
 }
@@ -91,7 +92,7 @@ export function createAuthorizeHandler () {
 export function createAuthorizePostHandler () {
   return async (request, reply) => {
     const body = parseBody(request)
-    const { username, password, client_id, redirect_uri, scope } = body
+    const { username, password, client_id, redirect_uri, scope, state } = body
 
     // Validate client + redirect_uri (prevent open redirect via form tampering)
     const { client, error: clientError } = validateClient(client_id, redirect_uri)
@@ -101,14 +102,14 @@ export function createAuthorizePostHandler () {
 
     if (!username || !password) {
       return reply.type('text/html').send(
-        loginPage({ clientId: client_id, redirectUri: redirect_uri, scope, clientName: client.name, error: 'Username and password are required' })
+        loginPage({ clientId: client_id, redirectUri: redirect_uri, scope, state, clientName: client.name, error: 'Username and password are required' })
       )
     }
 
     const account = await authenticate(username, password)
     if (!account) {
       return reply.type('text/html').send(
-        loginPage({ clientId: client_id, redirectUri: redirect_uri, scope, clientName: client.name, error: 'Invalid username or password' })
+        loginPage({ clientId: client_id, redirectUri: redirect_uri, scope, state, clientName: client.name, error: 'Invalid username or password' })
       )
     }
 
@@ -127,9 +128,10 @@ export function createAuthorizePostHandler () {
       return reply.type('text/html').send(oobPage(code))
     }
 
-    // Redirect back to client with code
+    // Redirect back to client with code + state (RFC 6749 §4.1.2)
     const url = new URL(redirect_uri)
     url.searchParams.set('code', code)
+    if (state) url.searchParams.set('state', state)
     return reply.redirect(url.toString())
   }
 }
@@ -155,7 +157,11 @@ export function createTokenHandler () {
     if (!client) {
       return reply.code(401).send({ error: 'invalid_client', error_description: 'Unknown client_id' })
     }
-    if (client.client_secret !== client_secret) {
+    try {
+      if (!crypto.timingSafeEqual(Buffer.from(client.client_secret), Buffer.from(client_secret || ''))) {
+        return reply.code(401).send({ error: 'invalid_client', error_description: 'Invalid client_secret' })
+      }
+    } catch {
       return reply.code(401).send({ error: 'invalid_client', error_description: 'Invalid client_secret' })
     }
 
@@ -192,7 +198,7 @@ export function createTokenHandler () {
 /**
  * Minimal login page HTML
  */
-function loginPage ({ clientId, redirectUri, scope, clientName, error }) {
+function loginPage ({ clientId, redirectUri, scope, state, clientName, error }) {
   const escapedError = error ? escapeHtml(error) : ''
   const escapedName = escapeHtml(clientName || clientId || 'Unknown app')
 
@@ -227,6 +233,7 @@ function loginPage ({ clientId, redirectUri, scope, clientName, error }) {
       <input type="hidden" name="client_id" value="${escapeHtml(clientId || '')}">
       <input type="hidden" name="redirect_uri" value="${escapeHtml(redirectUri || '')}">
       <input type="hidden" name="scope" value="${escapeHtml(scope || 'read')}">
+      ${state ? `<input type="hidden" name="state" value="${escapeHtml(state)}">` : ''}
       <label for="username">Username</label>
       <input type="text" id="username" name="username" required autocomplete="username">
       <label for="password">Password</label>

--- a/src/ap/routes/oauth.js
+++ b/src/ap/routes/oauth.js
@@ -1,0 +1,208 @@
+/**
+ * OAuth 2.0 authorize/token flow
+ * Shared infrastructure for Mastodon clients, remoteStorage apps, and third-party panes
+ *
+ * Refs: https://docs.joinmastodon.org/methods/oauth/
+ *       https://datatracker.ietf.org/doc/html/rfc6749
+ *
+ * Related: #158, #159 (Mastodon API), #106 (remoteStorage), #160 (this)
+ */
+
+import { getClient } from './mastodon.js'
+import { authenticate } from '../../idp/accounts.js'
+import { createToken } from '../../auth/token.js'
+
+// Auth codes: code → { clientId, redirectUri, webId, scope, expiresAt }
+const authCodes = new Map()
+
+// Clean up expired codes every 60s
+setInterval(() => {
+  const now = Date.now()
+  for (const [code, data] of authCodes) {
+    if (data.expiresAt < now) authCodes.delete(code)
+  }
+}, 60000).unref()
+
+/**
+ * Parse request body — handles JSON and form-urlencoded
+ */
+function parseBody (request) {
+  if (request.body && typeof request.body === 'object' && !Buffer.isBuffer(request.body)) {
+    return request.body
+  }
+  const raw = Buffer.isBuffer(request.body) ? request.body.toString() : String(request.body || '')
+  const ct = request.headers['content-type'] || ''
+  if (ct.includes('application/json')) {
+    try { return JSON.parse(raw) } catch { return {} }
+  }
+  return Object.fromEntries(new URLSearchParams(raw))
+}
+
+/**
+ * GET /oauth/authorize — Show login/consent page
+ */
+export function createAuthorizeHandler () {
+  return async (request, reply) => {
+    const { client_id, redirect_uri, response_type, scope } = request.query
+
+    if (!client_id || !redirect_uri) {
+      return reply.code(400).send({ error: 'Missing client_id or redirect_uri' })
+    }
+
+    if (response_type && response_type !== 'code') {
+      return reply.code(400).send({ error: 'unsupported_response_type', error_description: 'Only response_type=code is supported' })
+    }
+
+    const client = getClient(client_id)
+    if (!client) {
+      return reply.code(400).send({ error: 'invalid_client', error_description: 'Unknown client_id. Register via POST /api/v1/apps first.' })
+    }
+
+    return reply.type('text/html').send(
+      loginPage({ clientId: client_id, redirectUri: redirect_uri, scope: scope || 'read', clientName: client.name })
+    )
+  }
+}
+
+/**
+ * POST /oauth/authorize — Process login form
+ */
+export function createAuthorizePostHandler () {
+  return async (request, reply) => {
+    const body = parseBody(request)
+    const { username, password, client_id, redirect_uri, scope } = body
+
+    if (!username || !password) {
+      return reply.type('text/html').send(
+        loginPage({ clientId: client_id, redirectUri: redirect_uri, scope, error: 'Username and password are required' })
+      )
+    }
+
+    const account = await authenticate(username, password)
+    if (!account) {
+      return reply.type('text/html').send(
+        loginPage({ clientId: client_id, redirectUri: redirect_uri, scope, error: 'Invalid username or password' })
+      )
+    }
+
+    // Generate one-time auth code (10 min TTL)
+    const code = crypto.randomUUID()
+    authCodes.set(code, {
+      clientId: client_id,
+      redirectUri: redirect_uri,
+      webId: account.webId,
+      scope: scope || 'read',
+      expiresAt: Date.now() + 600_000
+    })
+
+    // Redirect back to client with code
+    const url = new URL(redirect_uri)
+    url.searchParams.set('code', code)
+    return reply.redirect(url.toString())
+  }
+}
+
+/**
+ * POST /oauth/token — Exchange auth code for Bearer token
+ */
+export function createTokenHandler () {
+  return async (request, reply) => {
+    const body = parseBody(request)
+    const { grant_type, code, client_id, client_secret, redirect_uri } = body
+
+    if (grant_type !== 'authorization_code') {
+      return reply.code(400).send({ error: 'unsupported_grant_type' })
+    }
+
+    if (!code) {
+      return reply.code(400).send({ error: 'invalid_request', error_description: 'Missing code' })
+    }
+
+    // Look up and validate auth code
+    const authCode = authCodes.get(code)
+    if (!authCode || authCode.expiresAt < Date.now()) {
+      authCodes.delete(code)
+      return reply.code(400).send({ error: 'invalid_grant', error_description: 'Code expired or invalid' })
+    }
+
+    if (authCode.clientId !== client_id) {
+      return reply.code(400).send({ error: 'invalid_client' })
+    }
+
+    if (authCode.redirectUri !== redirect_uri) {
+      return reply.code(400).send({ error: 'invalid_grant', error_description: 'redirect_uri mismatch' })
+    }
+
+    // Consume code (one-time use)
+    authCodes.delete(code)
+
+    // Generate Bearer token using existing token infrastructure
+    const accessToken = createToken(authCode.webId)
+
+    return reply.send({
+      access_token: accessToken,
+      token_type: 'Bearer',
+      scope: authCode.scope,
+      created_at: Math.floor(Date.now() / 1000)
+    })
+  }
+}
+
+/**
+ * Minimal login page HTML
+ */
+function loginPage ({ clientId, redirectUri, scope, clientName, error }) {
+  const escapedError = error ? escapeHtml(error) : ''
+  const escapedName = escapeHtml(clientName || clientId || 'Unknown app')
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Authorize ${escapedName}</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif; background: #f5f5f5; display: flex; justify-content: center; align-items: center; min-height: 100vh; }
+    .card { background: white; border-radius: 12px; padding: 2rem; max-width: 400px; width: 90%; box-shadow: 0 2px 8px rgba(0,0,0,0.1); }
+    h1 { font-size: 1.25rem; margin-bottom: 0.5rem; }
+    .subtitle { color: #666; margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .scope { background: #f0f0f0; padding: 0.5rem 0.75rem; border-radius: 6px; margin-bottom: 1.5rem; font-size: 0.85rem; color: #444; }
+    label { display: block; font-size: 0.85rem; font-weight: 500; margin-bottom: 0.25rem; color: #333; }
+    input[type="text"], input[type="password"] { width: 100%; padding: 0.6rem; border: 1px solid #ddd; border-radius: 6px; font-size: 1rem; margin-bottom: 1rem; }
+    input:focus { outline: none; border-color: #4a9eff; box-shadow: 0 0 0 2px rgba(74,158,255,0.2); }
+    button { width: 100%; padding: 0.7rem; background: #4a9eff; color: white; border: none; border-radius: 6px; font-size: 1rem; font-weight: 500; cursor: pointer; }
+    button:hover { background: #3a8eef; }
+    .error { background: #fee; color: #c00; padding: 0.6rem; border-radius: 6px; margin-bottom: 1rem; font-size: 0.85rem; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Authorize</h1>
+    <p class="subtitle"><strong>${escapedName}</strong> wants access to your account</p>
+    <div class="scope">Scope: ${escapeHtml(scope || 'read')}</div>
+    ${escapedError ? `<div class="error">${escapedError}</div>` : ''}
+    <form method="POST" action="/oauth/authorize">
+      <input type="hidden" name="client_id" value="${escapeHtml(clientId || '')}">
+      <input type="hidden" name="redirect_uri" value="${escapeHtml(redirectUri || '')}">
+      <input type="hidden" name="scope" value="${escapeHtml(scope || 'read')}">
+      <label for="username">Username</label>
+      <input type="text" id="username" name="username" required autocomplete="username">
+      <label for="password">Password</label>
+      <input type="password" id="password" name="password" required autocomplete="current-password">
+      <button type="submit">Authorize</button>
+    </form>
+  </div>
+</body>
+</html>`
+}
+
+function escapeHtml (str) {
+  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+export default {
+  createAuthorizeHandler,
+  createAuthorizePostHandler,
+  createTokenHandler
+}

--- a/src/ap/routes/oauth.js
+++ b/src/ap/routes/oauth.js
@@ -165,10 +165,11 @@ export function createTokenHandler () {
       return reply.code(401).send({ error: 'invalid_client', error_description: 'Invalid client_secret' })
     }
 
-    // Look up and validate auth code
+    // Look up auth code and consume immediately (RFC 6749 §10.5 — one-time use)
     const authCode = authCodes.get(code)
+    authCodes.delete(code)
+
     if (!authCode || authCode.expiresAt < Date.now()) {
-      authCodes.delete(code)
       return reply.code(400).send({ error: 'invalid_grant', error_description: 'Code expired or invalid' })
     }
 
@@ -179,9 +180,6 @@ export function createTokenHandler () {
     if (authCode.redirectUri !== redirect_uri) {
       return reply.code(400).send({ error: 'invalid_grant', error_description: 'redirect_uri mismatch' })
     }
-
-    // Consume code (one-time use)
-    authCodes.delete(code)
 
     // Generate Bearer token using existing token infrastructure
     const accessToken = createToken(authCode.webId)
@@ -203,7 +201,7 @@ function loginPage ({ clientId, redirectUri, scope, state, clientName, error }) 
   const escapedName = escapeHtml(clientName || clientId || 'Unknown app')
 
   return `<!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -251,7 +249,7 @@ function loginPage ({ clientId, redirectUri, scope, state, clientName, error }) 
  */
 function oobPage (code) {
   return `<!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/server.js
+++ b/src/server.js
@@ -354,7 +354,8 @@ export function createServer(options = {}) {
     // Skip auth for pod creation, OPTIONS, IdP routes, mashlib, solidos-ui, well-known, notifications, nostr, git, and AP
     const mashlibPaths = ['/mashlib.min.js', '/mash.css', '/841.mashlib.min.js'];
     const apPaths = ['/inbox', '/profile/card/inbox', '/profile/card/outbox', '/profile/card/followers', '/profile/card/following',
-      '/api/v1/apps', '/api/v1/instance', '/api/v1/accounts/verify_credentials'];
+      '/api/v1/apps', '/api/v1/instance', '/api/v1/accounts/verify_credentials',
+      '/oauth/authorize', '/oauth/token'];
     // Check if request wants ActivityPub content for profile
     const accept = request.headers.accept || '';
     const wantsAP = accept.includes('activity+json') || accept.includes('ld+json; profile="https://www.w3.org/ns/activitystreams"');


### PR DESCRIPTION
## Summary

- Adds `GET /oauth/authorize` — login/consent page for Mastodon clients and remoteStorage apps
- Adds `POST /oauth/authorize` — validates credentials via existing `authenticate()`, generates one-time auth code, redirects back to client
- Adds `POST /oauth/token` — exchanges auth code for Bearer token via existing `createToken()`
- Auth skip added for `/oauth/authorize` and `/oauth/token` in server.js

Reuses existing infrastructure:
- **Account system** (`authenticate()` from `src/idp/accounts.js`) — no new auth code
- **Token system** (`createToken()` from `src/auth/token.js`) — HMAC-signed Bearer tokens already verified by `getWebIdFromRequestAsync()`
- **Client registration** (`getClient()` from `src/ap/routes/mastodon.js`) — validates client_id from Step 1

~208 lines. No new dependencies.

## Motivation

One OAuth flow unlocks three ecosystems:
- **Mastodon clients** (Elk, Phanpy, Ice Cubes) — complete the login flow started by #159
- **remoteStorage apps** (100+ apps) — OAuth Phase 2 of #106
- **Third-party pane auth** — any external app/pane needing user authorization

## Flow

```
1. Client registers:     POST /api/v1/apps → {client_id, client_secret}
2. Client redirects to:  GET /oauth/authorize?client_id=X&redirect_uri=Y&scope=read
3. User logs in:          POST /oauth/authorize → redirect to Y?code=CODE
4. Client exchanges:     POST /oauth/token {grant_type=authorization_code, code, client_id, ...}
5. Server returns:       {access_token, token_type: "Bearer", scope}
6. Client uses:          Authorization: Bearer <token>
```

## Test plan

- [ ] `POST /api/v1/apps` to register client
- [ ] `GET /oauth/authorize` shows login page with client name
- [ ] Login with wrong credentials shows error
- [ ] Login with correct credentials redirects with `?code=`
- [ ] `POST /oauth/token` exchanges code for Bearer token
- [ ] Code is one-time use (second exchange fails)
- [ ] Expired codes (>10 min) are rejected
- [ ] Bearer token works with existing `Authorization: Bearer` verification
- [ ] Elk/Phanpy can complete OAuth login flow

Closes #160
Refs #106, #158, #159