### PR TITLE
Add MRC20 token deposit support

### DIFF
--- a/src/handlers/pay.js
+++ b/src/handlers/pay.js
@@ -6,7 +6,7 @@
  *
  * Routes:
  *   GET  /pay/.balance  — check your balance
- *   POST /pay/.deposit  — deposit sats via TXO URI
+ *   POST /pay/.deposit  — deposit sats (TXO URI) or tokens (MRC20 state proof)
  *   GET  /pay/*         — paid resource access (requires balance >= cost)
  *   PUT  /pay/*         — upload resources (standard auth)
  *
@@ -16,16 +16,18 @@
  *   - Web Ledgers spec: https://webledgers.org/
  *   - NIP-98 HTTP Auth: https://nips.nostr.com/98
  *   - TXO URI: https://www.npmjs.com/package/txo_parser
+ *   - MRC20 profile: https://blocktrails.org/
  */
 
 import { getNostrPubkey, pubkeyToDidNostr } from '../auth/nostr.js';
 import { readLedger, writeLedger, getBalance, credit, debit } from '../webledger.js';
+import { verifyMrc20Deposit } from '../mrc20.js';
 
 const DEFAULT_COST = 1; // satoshis per request
 
 // --- Deposit verification via mempool API ---
 
-async function verifyDeposit(txoUri, mempoolUrl) {
+async function verifySatsDeposit(txoUri, mempoolUrl) {
   const match = txoUri.match(/([0-9a-f]{64}):(\d+)/i);
   if (!match) {
     return { valid: false, amount: 0, error: 'Invalid TXO URI format (expected txid:vout)' };
@@ -45,6 +47,60 @@ async function verifyDeposit(txoUri, mempoolUrl) {
   }
 }
 
+/**
+ * Parse deposit request body — returns either a sats TXO URI or MRC20 state proof
+ * @param {*} body - Request body (Buffer, string, or parsed object)
+ * @returns {{type: 'sats', txo: string} | {type: 'mrc20', state: object, prevState: object} | {type: 'unknown'}}
+ */
+function parseDepositBody(body) {
+  // Buffer → string first
+  if (Buffer.isBuffer(body)) {
+    const str = body.toString('utf8').trim();
+    // Try JSON parse
+    try {
+      const obj = JSON.parse(str);
+      return classifyDepositObject(obj);
+    } catch {
+      // Not JSON — treat as TXO URI string
+      return { type: 'sats', txo: str };
+    }
+  }
+
+  // Already parsed object
+  if (body && typeof body === 'object') {
+    return classifyDepositObject(body);
+  }
+
+  // String
+  if (typeof body === 'string') {
+    const trimmed = body.trim();
+    try {
+      const obj = JSON.parse(trimmed);
+      return classifyDepositObject(obj);
+    } catch {
+      return { type: 'sats', txo: trimmed };
+    }
+  }
+
+  return { type: 'unknown' };
+}
+
+function classifyDepositObject(obj) {
+  // Explicit type field
+  if (obj.type === 'mrc20' && obj.state && obj.prevState) {
+    return { type: 'mrc20', state: obj.state, prevState: obj.prevState };
+  }
+  // Auto-detect: if it has state + prevState with MRC20 profile
+  if (obj.state?.profile === 'mono.mrc20.v0.1' && obj.prevState) {
+    return { type: 'mrc20', state: obj.state, prevState: obj.prevState };
+  }
+  // Fall back to TXO URI in .txo field
+  if (obj.txo) {
+    return { type: 'sats', txo: obj.txo };
+  }
+  return { type: 'unknown' };
+}
+
 // --- Check if URL is a /pay/ route ---
 
 export function isPayRequest(url) {
@@ -59,11 +115,13 @@ export function isPayRequest(url) {
  * @param {object} options
  * @param {number} options.cost - Cost per request in satoshis (default 1)
  * @param {string} options.mempoolUrl - Mempool API base URL
+ * @param {string} options.payAddress - Pod's MRC20 address for receiving token transfers
  * @returns {function} Fastify preHandler hook
  */
 export function createPayHandler(options = {}) {
   const cost = options.cost ?? DEFAULT_COST;
   const mempoolUrl = options.mempoolUrl ?? 'https://mempool.space/testnet4';
+  const payAddress = options.payAddress ?? null;
 
   return async function payHandler(request, reply) {
     const url = request.url.split('?')[0];
@@ -92,34 +150,66 @@ export function createPayHandler(options = {}) {
         return reply.code(401).send({ error: 'NIP-98 authentication required' });
       }
 
-      let txoUri;
-      if (Buffer.isBuffer(request.body)) {
-        txoUri = request.body.toString('utf8').trim();
-      } else if (typeof request.body === 'string') {
-        txoUri = request.body.trim();
-      } else if (request.body && typeof request.body === 'object') {
-        txoUri = request.body.txo;
+      const deposit = parseDepositBody(request.body);
+
+      // --- MRC20 token deposit ---
+      if (deposit.type === 'mrc20') {
+        if (!payAddress) {
+          return reply.code(400).send({
+            error: 'MRC20 deposits not configured (no payAddress set)'
+          });
+        }
+
+        const result = verifyMrc20Deposit({
+          state: deposit.state,
+          prevState: deposit.prevState,
+          toAddress: payAddress
+        });
+
+        if (!result.valid) {
+          return reply.code(400).send({ error: result.error });
+        }
+
+        const didUri = pubkeyToDidNostr(pubkey);
+        const ledger = await readLedger();
+        const newBalance = credit(ledger, didUri, result.amount);
+        await writeLedger(ledger);
+
+        return reply.send({
+          did: didUri,
+          deposited: result.amount,
+          ticker: result.ticker,
+          balance: newBalance,
+          unit: 'token'
+        });
       }
 
-      if (!txoUri) {
-        return reply.code(400).send({ error: 'Missing TXO URI in request body' });
+      // --- Sats deposit (TXO URI) ---
+      if (deposit.type === 'sats') {
+        const result = await verifySatsDeposit(deposit.txo, mempoolUrl);
+        if (!result.valid) {
+          return reply.code(400).send({ error: result.error });
+        }
+
+        const didUri = pubkeyToDidNostr(pubkey);
+        const ledger = await readLedger();
+        const newBalance = credit(ledger, didUri, result.amount);
+        await writeLedger(ledger);
+
+        return reply.send({
+          did: didUri,
+          deposited: result.amount,
+          balance: newBalance,
+          unit: 'sat'
+        });
       }
 
-      const result = await verifyDeposit(txoUri, mempoolUrl);
-      if (!result.valid) {
-        return reply.code(400).send({ error: result.error });
-      }
-
-      const didUri = pubkeyToDidNostr(pubkey);
-      const ledger = await readLedger();
-      const newBalance = credit(ledger, didUri, result.amount);
-      await writeLedger(ledger);
-
-      return reply.send({
-        did: didUri,
-        deposited: result.amount,
-        balance: newBalance,
-        unit: 'sat'
+      return reply.code(400).send({
+        error: 'Invalid deposit format. Send a TXO URI string or MRC20 state proof.',
+        formats: {
+          sats: 'POST body: "<txid>:<vout>" or {"txo": "<txid>:<vout>"}',
+          mrc20: 'POST body: {"type": "mrc20", "state": {...}, "prevState": {...}}'
+        }
       });
     }
 

--- a/src/mrc20.js
+++ b/src/mrc20.js
@@ -1,0 +1,146 @@
+/**
+ * MRC20 Token Verification
+ *
+ * Verifies MRC20 state chain integrity and extracts transfer operations.
+ * Used by the pay middleware to accept token deposits.
+ *
+ * MRC20 profile: mono.mrc20.v0.1
+ * State chain: each state links to previous via SHA-256 of JCS-encoded state.
+ *
+ * References:
+ *   - Blocktrails: https://blocktrails.org/
+ *   - JCS (RFC 8785): JSON Canonicalization Scheme
+ */
+
+import crypto from 'crypto';
+
+const MRC20_PROFILE = 'mono.mrc20.v0.1';
+const TRANSFER_OP = 'urn:mono:op:transfer';
+
+/**
+ * JSON Canonicalization Scheme (RFC 8785)
+ * Produces deterministic JSON — sorted keys, no whitespace.
+ * @param {*} obj
+ * @returns {string}
+ */
+export function jcs(obj) {
+  if (obj === null || typeof obj !== 'object') return JSON.stringify(obj);
+  if (Array.isArray(obj)) return '[' + obj.map(v => jcs(v)).join(',') + ']';
+  const keys = Object.keys(obj).sort();
+  return '{' + keys.map(k => JSON.stringify(k) + ':' + jcs(obj[k])).join(',') + '}';
+}
+
+/**
+ * SHA-256 hex digest of a string
+ * @param {string} str
+ * @returns {string} Hex hash
+ */
+export function sha256Hex(str) {
+  return crypto.createHash('sha256').update(str).digest('hex');
+}
+
+/**
+ * Verify state chain link: state.prev must equal SHA-256(JCS(prevState))
+ * @param {object} state - Current state
+ * @param {object} prevState - Previous state
+ * @returns {{valid: boolean, error?: string}}
+ */
+export function verifyStateLink(state, prevState) {
+  if (!state || !prevState) {
+    return { valid: false, error: 'Missing state or prevState' };
+  }
+
+  const expectedPrev = sha256Hex(jcs(prevState));
+  if (state.prev !== expectedPrev) {
+    return { valid: false, error: `State chain break: expected prev ${expectedPrev}, got ${state.prev}` };
+  }
+
+  // Verify sequence number
+  if (typeof state.seq === 'number' && typeof prevState.seq === 'number') {
+    if (state.seq !== prevState.seq + 1) {
+      return { valid: false, error: `Sequence mismatch: expected ${prevState.seq + 1}, got ${state.seq}` };
+    }
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Validate that a state object is a valid MRC20 state
+ * @param {object} state
+ * @returns {{valid: boolean, error?: string}}
+ */
+export function validateMrc20State(state) {
+  if (!state || typeof state !== 'object') {
+    return { valid: false, error: 'State must be an object' };
+  }
+  if (state.profile !== MRC20_PROFILE) {
+    return { valid: false, error: `Invalid profile: expected ${MRC20_PROFILE}, got ${state.profile}` };
+  }
+  if (!Array.isArray(state.ops)) {
+    return { valid: false, error: 'State must have ops array' };
+  }
+  if (typeof state.prev !== 'string') {
+    return { valid: false, error: 'State must have prev hash' };
+  }
+  return { valid: true };
+}
+
+/**
+ * Extract transfer operations targeting a specific address
+ * @param {object} state - MRC20 state
+ * @param {string} toAddress - Recipient address to filter by
+ * @returns {Array<{from: string, to: string, amt: number}>} Matching transfers
+ */
+export function extractTransfersTo(state, toAddress) {
+  if (!state.ops || !Array.isArray(state.ops)) return [];
+  return state.ops.filter(op =>
+    op.op === TRANSFER_OP && op.to === toAddress && typeof op.amt === 'number' && op.amt > 0
+  );
+}
+
+/**
+ * Get total amount transferred to an address in a state
+ * @param {object} state - MRC20 state
+ * @param {string} toAddress - Recipient address
+ * @returns {number} Total amount transferred
+ */
+export function totalTransferredTo(state, toAddress) {
+  const transfers = extractTransfersTo(state, toAddress);
+  return transfers.reduce((sum, op) => sum + op.amt, 0);
+}
+
+/**
+ * Verify an MRC20 deposit: validate state chain + extract transfer amount
+ * @param {object} params
+ * @param {object} params.state - New state containing transfer ops
+ * @param {object} params.prevState - Previous state (for chain verification)
+ * @param {string} params.toAddress - Pod's address to check transfers against
+ * @returns {{valid: boolean, amount: number, ticker?: string, error?: string}}
+ */
+export function verifyMrc20Deposit(params) {
+  const { state, prevState, toAddress } = params;
+
+  // Validate MRC20 format
+  const stateCheck = validateMrc20State(state);
+  if (!stateCheck.valid) return { valid: false, amount: 0, error: stateCheck.error };
+
+  const prevCheck = validateMrc20State(prevState);
+  if (!prevCheck.valid) return { valid: false, amount: 0, error: `prevState: ${prevCheck.error}` };
+
+  // Verify state chain link
+  const linkCheck = verifyStateLink(state, prevState);
+  if (!linkCheck.valid) return { valid: false, amount: 0, error: linkCheck.error };
+
+  // Extract transfers to pod
+  const amount = totalTransferredTo(state, toAddress);
+  if (amount <= 0) {
+    return { valid: false, amount: 0, error: `No transfers to ${toAddress} found in state ops` };
+  }
+
+  return {
+    valid: true,
+    amount,
+    ticker: state.ticker || 'UNKNOWN'
+  };
+}

--- a/src/server.js
+++ b/src/server.js
@@ -46,6 +46,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
  * @param {boolean} options.pay - Enable HTTP 402 paid /pay/* routes (default false)
  * @param {number} options.payCost - Cost per request in satoshis (default 1)
  * @param {string} options.payMempoolUrl - Mempool API base URL (default testnet4)
+ * @param {string} options.payAddress - Pod's MRC20 address for receiving token transfers
  */
 export function createServer(options = {}) {
   // Content negotiation is OFF by default - we're a JSON-LD native server
@@ -98,6 +99,7 @@ export function createServer(options = {}) {
   const payEnabled = options.pay ?? false;
   const payCost = options.payCost ?? 1;
   const payMempoolUrl = options.payMempoolUrl ?? 'https://mempool.space/testnet4';
+  const payAddress = options.payAddress ?? null; // Pod's MRC20 address for token deposits
 
   // Set data root via environment variable if provided
   if (options.root) {
@@ -372,7 +374,7 @@ export function createServer(options = {}) {
 
   // HTTP 402 Payment Required handler for /pay/* routes
   if (payEnabled) {
-    fastify.addHook('preHandler', createPayHandler({ cost: payCost, mempoolUrl: payMempoolUrl }));
+    fastify.addHook('preHandler', createPayHandler({ cost: payCost, mempoolUrl: payMempoolUrl, payAddress }));
   }
 
   // Authorization hook - check WAC permissions

--- a/test/mrc20.test.js
+++ b/test/mrc20.test.js
@@ -1,0 +1,237 @@
+/**
+ * MRC20 Token Verification tests
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  jcs,
+  sha256Hex,
+  verifyStateLink,
+  validateMrc20State,
+  extractTransfersTo,
+  totalTransferredTo,
+  verifyMrc20Deposit
+} from '../src/mrc20.js';
+
+const PROFILE = 'mono.mrc20.v0.1';
+
+// Helper: create a valid state chain pair
+function createStatePair(ops, toAddress) {
+  const prevState = {
+    profile: PROFILE,
+    prev: '0'.repeat(64),
+    seq: 0,
+    ticker: 'TEST',
+    name: 'Test Token',
+    decimals: 0,
+    supply: 1000,
+    balances: { creator: 1000 },
+    ops: []
+  };
+
+  const state = {
+    profile: PROFILE,
+    prev: sha256Hex(jcs(prevState)),
+    seq: 1,
+    ticker: 'TEST',
+    name: 'Test Token',
+    decimals: 0,
+    supply: 1000,
+    balances: { creator: 900, [toAddress]: 100 },
+    ops: ops || [{ op: 'urn:mono:op:transfer', from: 'creator', to: toAddress, amt: 100 }]
+  };
+
+  return { prevState, state };
+}
+
+describe('MRC20 Verification', () => {
+  describe('jcs', () => {
+    it('should sort keys alphabetically', () => {
+      assert.strictEqual(jcs({ b: 1, a: 2 }), '{"a":2,"b":1}');
+    });
+
+    it('should handle nested objects', () => {
+      assert.strictEqual(jcs({ z: { b: 1, a: 2 }, a: 3 }), '{"a":3,"z":{"a":2,"b":1}}');
+    });
+
+    it('should handle arrays', () => {
+      assert.strictEqual(jcs([3, 1, 2]), '[3,1,2]');
+    });
+
+    it('should handle null and primitives', () => {
+      assert.strictEqual(jcs(null), 'null');
+      assert.strictEqual(jcs(42), '42');
+      assert.strictEqual(jcs('hello'), '"hello"');
+      assert.strictEqual(jcs(true), 'true');
+    });
+
+    it('should be deterministic', () => {
+      const obj = { name: 'TEST', profile: PROFILE, seq: 0, prev: '0'.repeat(64) };
+      assert.strictEqual(jcs(obj), jcs(obj));
+    });
+  });
+
+  describe('sha256Hex', () => {
+    it('should return 64-char hex string', () => {
+      const hash = sha256Hex('hello');
+      assert.strictEqual(hash.length, 64);
+      assert.ok(/^[0-9a-f]{64}$/.test(hash));
+    });
+
+    it('should be deterministic', () => {
+      assert.strictEqual(sha256Hex('test'), sha256Hex('test'));
+    });
+  });
+
+  describe('verifyStateLink', () => {
+    it('should verify valid state chain link', () => {
+      const { prevState, state } = createStatePair();
+      const result = verifyStateLink(state, prevState);
+      assert.strictEqual(result.valid, true);
+    });
+
+    it('should reject invalid prev hash', () => {
+      const { prevState, state } = createStatePair();
+      state.prev = 'bad' + state.prev.slice(3);
+      const result = verifyStateLink(state, prevState);
+      assert.strictEqual(result.valid, false);
+      assert.ok(result.error.includes('State chain break'));
+    });
+
+    it('should reject wrong sequence number', () => {
+      const { prevState, state } = createStatePair();
+      state.seq = 5; // should be 1
+      const result = verifyStateLink(state, prevState);
+      assert.strictEqual(result.valid, false);
+      assert.ok(result.error.includes('Sequence mismatch'));
+    });
+
+    it('should reject missing states', () => {
+      assert.strictEqual(verifyStateLink(null, {}).valid, false);
+      assert.strictEqual(verifyStateLink({}, null).valid, false);
+    });
+  });
+
+  describe('validateMrc20State', () => {
+    it('should accept valid MRC20 state', () => {
+      const { state } = createStatePair();
+      assert.strictEqual(validateMrc20State(state).valid, true);
+    });
+
+    it('should reject wrong profile', () => {
+      const { state } = createStatePair();
+      state.profile = 'wrong.profile';
+      assert.strictEqual(validateMrc20State(state).valid, false);
+    });
+
+    it('should reject missing ops', () => {
+      const { state } = createStatePair();
+      delete state.ops;
+      assert.strictEqual(validateMrc20State(state).valid, false);
+    });
+
+    it('should reject non-object', () => {
+      assert.strictEqual(validateMrc20State(null).valid, false);
+      assert.strictEqual(validateMrc20State('string').valid, false);
+    });
+  });
+
+  describe('extractTransfersTo', () => {
+    it('should extract transfers to specific address', () => {
+      const { state } = createStatePair(
+        [
+          { op: 'urn:mono:op:transfer', from: 'alice', to: 'pod', amt: 50 },
+          { op: 'urn:mono:op:transfer', from: 'bob', to: 'other', amt: 30 },
+          { op: 'urn:mono:op:transfer', from: 'carol', to: 'pod', amt: 25 }
+        ],
+        'pod'
+      );
+      const transfers = extractTransfersTo(state, 'pod');
+      assert.strictEqual(transfers.length, 2);
+      assert.strictEqual(transfers[0].amt, 50);
+      assert.strictEqual(transfers[1].amt, 25);
+    });
+
+    it('should return empty for no matching transfers', () => {
+      const { state } = createStatePair();
+      const transfers = extractTransfersTo(state, 'nobody');
+      assert.strictEqual(transfers.length, 0);
+    });
+
+    it('should ignore non-transfer ops', () => {
+      const { state } = createStatePair(
+        [{ op: 'urn:mono:op:mint', to: 'pod', amt: 100 }],
+        'pod'
+      );
+      const transfers = extractTransfersTo(state, 'pod');
+      assert.strictEqual(transfers.length, 0);
+    });
+  });
+
+  describe('totalTransferredTo', () => {
+    it('should sum all transfers to address', () => {
+      const { state } = createStatePair(
+        [
+          { op: 'urn:mono:op:transfer', from: 'a', to: 'pod', amt: 50 },
+          { op: 'urn:mono:op:transfer', from: 'b', to: 'pod', amt: 25 }
+        ],
+        'pod'
+      );
+      assert.strictEqual(totalTransferredTo(state, 'pod'), 75);
+    });
+  });
+
+  describe('verifyMrc20Deposit', () => {
+    it('should verify valid deposit', () => {
+      const { prevState, state } = createStatePair(
+        [{ op: 'urn:mono:op:transfer', from: 'user', to: 'mypod', amt: 200 }],
+        'mypod'
+      );
+      const result = verifyMrc20Deposit({ state, prevState, toAddress: 'mypod' });
+      assert.strictEqual(result.valid, true);
+      assert.strictEqual(result.amount, 200);
+      assert.strictEqual(result.ticker, 'TEST');
+    });
+
+    it('should reject broken state chain', () => {
+      const { prevState, state } = createStatePair(
+        [{ op: 'urn:mono:op:transfer', from: 'user', to: 'pod', amt: 100 }],
+        'pod'
+      );
+      state.prev = 'tampered';
+      const result = verifyMrc20Deposit({ state, prevState, toAddress: 'pod' });
+      assert.strictEqual(result.valid, false);
+    });
+
+    it('should reject deposit to wrong address', () => {
+      const { prevState, state } = createStatePair(
+        [{ op: 'urn:mono:op:transfer', from: 'user', to: 'other-pod', amt: 100 }],
+        'other-pod'
+      );
+      const result = verifyMrc20Deposit({ state, prevState, toAddress: 'my-pod' });
+      assert.strictEqual(result.valid, false);
+      assert.ok(result.error.includes('No transfers'));
+    });
+
+    it('should reject invalid MRC20 profile', () => {
+      const { prevState, state } = createStatePair();
+      state.profile = 'wrong';
+      const result = verifyMrc20Deposit({ state, prevState, toAddress: 'pod' });
+      assert.strictEqual(result.valid, false);
+    });
+
+    it('should sum multiple transfers in same state', () => {
+      const { prevState, state } = createStatePair(
+        [
+          { op: 'urn:mono:op:transfer', from: 'a', to: 'pod', amt: 100 },
+          { op: 'urn:mono:op:transfer', from: 'b', to: 'pod', amt: 50 }
+        ],
+        'pod'
+      );
+      const result = verifyMrc20Deposit({ state, prevState, toAddress: 'pod' });
+      assert.strictEqual(result.valid, true);
+      assert.strictEqual(result.amount, 150);
+    });
+  });
+});

--- a/test/pay.test.js
+++ b/test/pay.test.js
@@ -12,6 +12,7 @@ import {
   getBaseUrl,
   assertStatus
 } from './helpers.js';
+import { jcs, sha256Hex } from '../src/mrc20.js';
 
 // Generate a test keypair for NIP-98 auth
 const privkey = crypto.randomBytes(32);
@@ -45,8 +46,10 @@ function createNip98Header(url, method = 'GET') {
 }
 
 describe('HTTP 402 Pay Middleware', () => {
+  const POD_ADDRESS = 'test-pod-address';
+
   before(async () => {
-    await startTestServer({ pay: true, payCost: 10 });
+    await startTestServer({ pay: true, payCost: 10, payAddress: POD_ADDRESS });
   });
 
   after(async () => {
@@ -119,6 +122,86 @@ describe('HTTP 402 Pay Middleware', () => {
       assertStatus(res, 400);
       const body = await res.json();
       assert.ok(body.error.includes('Invalid TXO URI'));
+    });
+  });
+
+  describe('POST /pay/.deposit (MRC20)', () => {
+    function makeStatePair(toAddress, amt = 100) {
+      const prevState = {
+        profile: 'mono.mrc20.v0.1',
+        prev: '0'.repeat(64),
+        seq: 0,
+        ticker: 'TEST',
+        name: 'Test Token',
+        decimals: 0,
+        supply: 1000,
+        balances: { creator: 1000 },
+        ops: []
+      };
+      const state = {
+        profile: 'mono.mrc20.v0.1',
+        prev: sha256Hex(jcs(prevState)),
+        seq: 1,
+        ticker: 'TEST',
+        name: 'Test Token',
+        decimals: 0,
+        supply: 1000,
+        balances: { creator: 1000 - amt, [toAddress]: amt },
+        ops: [{ op: 'urn:mono:op:transfer', from: 'creator', to: toAddress, amt }]
+      };
+      return { prevState, state };
+    }
+
+    it('should accept valid MRC20 deposit', async () => {
+      const { prevState, state } = makeStatePair(POD_ADDRESS, 500);
+      const url = `${getBaseUrl()}/pay/.deposit`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': createNip98Header(url, 'POST'),
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ type: 'mrc20', state, prevState })
+      });
+      assertStatus(res, 200);
+      const body = await res.json();
+      assert.strictEqual(body.deposited, 500);
+      assert.strictEqual(body.ticker, 'TEST');
+      assert.strictEqual(body.unit, 'token');
+      assert.ok(body.balance >= 500);
+    });
+
+    it('should reject MRC20 deposit with broken chain', async () => {
+      const { prevState, state } = makeStatePair(POD_ADDRESS);
+      state.prev = 'tampered';
+      const url = `${getBaseUrl()}/pay/.deposit`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': createNip98Header(url, 'POST'),
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ type: 'mrc20', state, prevState })
+      });
+      assertStatus(res, 400);
+      const body = await res.json();
+      assert.ok(body.error.includes('State chain break'));
+    });
+
+    it('should reject MRC20 deposit to wrong address', async () => {
+      const { prevState, state } = makeStatePair('wrong-address');
+      const url = `${getBaseUrl()}/pay/.deposit`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': createNip98Header(url, 'POST'),
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ type: 'mrc20', state, prevState })
+      });
+      assertStatus(res, 400);
+      const body = await res.json();
+      assert.ok(body.error.includes('No transfers'));
     });
   });
 


### PR DESCRIPTION
## Summary

Extends `/pay/.deposit` to accept MRC20 token transfers alongside sats deposits.

- **New module `src/mrc20.js`**: JCS (RFC 8785), SHA-256 hashing, state chain verification, transfer extraction
- **Auto-detect deposit format**: string body → sats (TXO URI), JSON with `state`/`prevState` → MRC20 token
- **State chain verification**: validates `prev` hash linking and sequence numbers
- **Transfer validation**: extracts `urn:mono:op:transfer` ops targeting the pod's `payAddress`
- **New option**: `payAddress` — pod's MRC20 address for receiving token transfers

### MRC20 deposit request

```json
POST /pay/.deposit
{
  "type": "mrc20",
  "state": { "profile": "mono.mrc20.v0.1", "prev": "...", "seq": 1, "ops": [...], ... },
  "prevState": { "profile": "mono.mrc20.v0.1", "prev": "000...", "seq": 0, ... }
}
```

### Usage

```js
createServer({ pay: true, payAddress: 'did:nostr:abc123...' });
```

## Test plan

- [x] 24 unit tests for MRC20 verification (JCS, SHA-256, state chain, transfers)
- [x] 3 integration tests (valid deposit, broken chain, wrong address)
- [x] All 8 existing pay + 17 webledger tests still pass (52 total)