### PR TITLE
Add primary market: buy tokens with sat balance

### DIFF
--- a/bin/jss.js
+++ b/bin/jss.js
@@ -85,6 +85,8 @@ program
   .option('--pay-cost <n>', 'Cost per request in satoshis (default: 1)', parseInt)
   .option('--pay-mempool-url <url>', 'Mempool API URL for deposit verification')
   .option('--pay-address <addr>', 'Address for receiving deposits')
+  .option('--pay-token <ticker>', 'Token to sell (enables primary market)')
+  .option('--pay-rate <n>', 'Sats per token for primary market (default: 1)', parseInt)
   .option('--mongo', 'Enable MongoDB-backed /db/ route')
   .option('--no-mongo', 'Disable MongoDB-backed /db/ route')
   .option('--mongo-url <url>', 'MongoDB connection URL (default: mongodb://localhost:27017)')
@@ -155,6 +157,8 @@ program
         payCost: config.payCost,
         payMempoolUrl: config.payMempoolUrl,
         payAddress: config.payAddress,
+        payToken: config.payToken,
+        payRate: config.payRate,
         mongo: config.mongo,
         mongoUrl: config.mongoUrl,
         mongoDatabase: config.mongoDatabase,
@@ -193,7 +197,10 @@ program
           }
           console.log('     Do not expose to the internet!');
         }
-        if (config.pay) console.log(`  Pay: ${config.payCost} sat/req (402 enabled)`);
+        if (config.pay) {
+          console.log(`  Pay: ${config.payCost} sat/req (402 enabled)`);
+          if (config.payToken) console.log(`  Token: ${config.payToken} @ ${config.payRate} sat/token`);
+        }
         if (config.mongo) console.log(`  MongoDB: ${config.mongoUrl} (${config.mongoDatabase})`);
         if (config.readOnly) console.log('  Read-only: enabled (PUT/DELETE/PATCH disabled)');
         console.log('\n  Press Ctrl+C to stop\n');

--- a/src/config.js
+++ b/src/config.js
@@ -88,6 +88,8 @@ export const defaults = {
   payCost: 1,
   payMempoolUrl: 'https://mempool.space/testnet4',
   payAddress: null,
+  payToken: null,
+  payRate: 1,
 
   // MongoDB-backed /db/ route
   mongo: false,
@@ -148,6 +150,8 @@ const envMap = {
   JSS_PAY_COST: 'payCost',
   JSS_PAY_MEMPOOL_URL: 'payMempoolUrl',
   JSS_PAY_ADDRESS: 'payAddress',
+  JSS_PAY_TOKEN: 'payToken',
+  JSS_PAY_RATE: 'payRate',
   JSS_MONGO: 'mongo',
   JSS_MONGO_URL: 'mongoUrl',
   JSS_MONGO_DATABASE: 'mongoDatabase',
@@ -177,7 +181,7 @@ function parseEnvValue(value, key) {
   if (value.toLowerCase() === 'false') return false;
 
   // Numeric values for known numeric keys
-  if ((key === 'port' || key === 'nostrMaxEvents' || key === 'payCost') && !isNaN(value)) {
+  if ((key === 'port' || key === 'nostrMaxEvents' || key === 'payCost' || key === 'payRate') && !isNaN(value)) {
     return parseInt(value, 10);
   }
 
@@ -315,7 +319,10 @@ export function printConfig(config) {
   console.log(`  Subdomains:    ${config.subdomains ? (config.baseDomain || 'enabled') : 'disabled'}`);
   console.log(`  Mashlib:       ${config.mashlibModule ? `module (${config.mashlibModule})` : config.mashlibCdn ? `CDN v${config.mashlibVersion}` : config.mashlib ? 'local' : 'disabled'}`);
   console.log(`  SolidOS UI:    ${config.solidosUi ? 'enabled' : 'disabled'}`);
-  if (config.pay) console.log(`  Pay:           ${config.payCost} sat/req`);
+  if (config.pay) {
+    console.log(`  Pay:           ${config.payCost} sat/req`);
+    if (config.payToken) console.log(`  Token:         ${config.payToken} @ ${config.payRate} sat/token`);
+  }
   if (config.mongo) console.log(`  MongoDB:       ${config.mongoUrl} (${config.mongoDatabase})`);
   console.log('─'.repeat(40));
 }

--- a/src/handlers/pay.js
+++ b/src/handlers/pay.js
@@ -21,7 +21,8 @@
 
 import { getNostrPubkey, pubkeyToDidNostr } from '../auth/nostr.js';
 import { readLedger, writeLedger, getBalance, credit, debit } from '../webledger.js';
-import { verifyMrc20Deposit, verifyMrc20Anchor, jcs } from '../mrc20.js';
+import { verifyMrc20Deposit, verifyMrc20Anchor, jcs, sha256Hex } from '../mrc20.js';
+import { loadTrail, transferToken } from '../token.js';
 import fs from 'fs-extra';
 import path from 'path';
 
@@ -147,6 +148,8 @@ export function createPayHandler(options = {}) {
   const cost = options.cost ?? DEFAULT_COST;
   const mempoolUrl = options.mempoolUrl ?? 'https://mempool.space/testnet4';
   const payAddress = options.payAddress ?? null;
+  const payToken = options.payToken ?? null;
+  const payRate = options.payRate ?? 1;
 
   return async function payHandler(request, reply) {
     const url = request.url.split('?')[0];
@@ -258,6 +261,104 @@ export function createPayHandler(options = {}) {
         formats: {
           sats: 'POST body: "<txid>:<vout>" or {"txo": "<txid>:<vout>"}',
           mrc20: 'POST body: {"type": "mrc20", "state": {...}, "prevState": {...}}'
+        }
+      });
+    }
+
+    // --- POST /pay/.buy — primary market: buy tokens with sats ---
+    if (url === '/pay/.buy' && request.method === 'POST') {
+      const pubkey = await getNostrPubkey(request);
+      if (!pubkey) {
+        return reply.code(401).send({ error: 'NIP-98 authentication required' });
+      }
+
+      if (!payToken) {
+        return reply.code(400).send({ error: 'Primary market not configured (no --pay-token set)' });
+      }
+
+      // Parse buy request
+      let body = request.body;
+      if (Buffer.isBuffer(body)) body = JSON.parse(body.toString('utf8'));
+      if (typeof body === 'string') body = JSON.parse(body);
+
+      const ticker = body?.ticker || payToken;
+      if (ticker !== payToken) {
+        return reply.code(400).send({ error: `This pod only sells ${payToken}` });
+      }
+
+      // Calculate amount and cost
+      let tokenAmount, satCost;
+      if (body?.amount) {
+        tokenAmount = Math.floor(body.amount);
+        satCost = tokenAmount * payRate;
+      } else if (body?.sats) {
+        satCost = Math.floor(body.sats);
+        tokenAmount = Math.floor(satCost / payRate);
+      } else {
+        return reply.code(400).send({
+          error: 'Specify amount (tokens to buy) or sats (sats to spend)',
+          rate: payRate,
+          unit: 'sat/token'
+        });
+      }
+
+      if (tokenAmount <= 0) {
+        return reply.code(400).send({ error: 'Amount must be positive' });
+      }
+
+      // Check sat balance
+      const didUri = pubkeyToDidNostr(pubkey);
+      const ledger = await readLedger();
+      const balance = getBalance(ledger, didUri);
+      if (balance < satCost) {
+        return reply.code(402).send({
+          error: 'Insufficient sat balance',
+          balance,
+          cost: satCost,
+          rate: payRate,
+          deposit: '/pay/.deposit'
+        });
+      }
+
+      // Load token trail
+      const trail = await loadTrail(ticker);
+      if (!trail) {
+        return reply.code(500).send({ error: `Token ${ticker} not minted on this pod` });
+      }
+
+      // Transfer tokens to buyer
+      let result;
+      try {
+        result = await transferToken({
+          ticker,
+          to: pubkey,
+          amount: tokenAmount,
+          mempoolUrl
+        });
+      } catch (err) {
+        return reply.code(500).send({ error: `Transfer failed: ${err.message}` });
+      }
+
+      // Debit sats from buyer
+      debit(ledger, didUri, satCost);
+      await writeLedger(ledger);
+
+      return reply.send({
+        bought: tokenAmount,
+        ticker,
+        cost: satCost,
+        rate: payRate,
+        balance: getBalance(ledger, didUri),
+        unit: 'sat',
+        txid: result.txid,
+        proof: {
+          state: result.state,
+          prevState: result.prevState,
+          anchor: {
+            pubkey: result.trail.pubkeyBase,
+            stateStrings: result.trail.stateStrings,
+            network: result.trail.network
+          }
         }
       });
     }

--- a/src/server.js
+++ b/src/server.js
@@ -100,6 +100,8 @@ export function createServer(options = {}) {
   const payCost = options.payCost ?? 1;
   const payMempoolUrl = options.payMempoolUrl ?? 'https://mempool.space/testnet4';
   const payAddress = options.payAddress ?? null; // Pod's MRC20 address for token deposits
+  const payToken = options.payToken ?? null; // Token ticker for primary market
+  const payRate = options.payRate ?? 1; // Sats per token
 
   // Set data root via environment variable if provided
   if (options.root) {
@@ -374,7 +376,7 @@ export function createServer(options = {}) {
 
   // HTTP 402 Payment Required handler for /pay/* routes
   if (payEnabled) {
-    fastify.addHook('preHandler', createPayHandler({ cost: payCost, mempoolUrl: payMempoolUrl, payAddress }));
+    fastify.addHook('preHandler', createPayHandler({ cost: payCost, mempoolUrl: payMempoolUrl, payAddress, payToken, payRate }));
   }
 
   // Authorization hook - check WAC permissions


### PR DESCRIPTION
## Summary
- Adds `POST /pay/.buy` endpoint for purchasing tokens with deposited sat balance
- New CLI options `--pay-token <ticker>` and `--pay-rate <n>` (sats per token)
- Returns portable proof (state chain + anchor) for independent verification
- Config/env support: `JSS_PAY_TOKEN`, `JSS_PAY_RATE`

## Test plan
- [x] Mint token with `jss token mint`, start pod with `--pay-token PODS --pay-rate 10`
- [x] Deposit sats via `POST /pay/.deposit`, verify balance
- [x] Buy tokens via `POST /pay/.buy`, verify sat deduction and proof returned
- [x] Verify Bitcoin TX broadcast on testnet4

Closes #177