### PR TITLE
Add withdrawal endpoint for portable token exit

### DIFF
--- a/src/handlers/pay.js
+++ b/src/handlers/pay.js
@@ -5,10 +5,12 @@
  * Authentication via NIP-98. Balance tracking via Web Ledgers spec.
  *
  * Routes:
- *   GET  /pay/.balance  — check your balance
- *   POST /pay/.deposit  — deposit sats (TXO URI) or tokens (MRC20 state proof)
- *   GET  /pay/*         — paid resource access (requires balance >= cost)
- *   PUT  /pay/*         — upload resources (standard auth)
+ *   GET  /pay/.balance   — check your balance
+ *   POST /pay/.deposit   — deposit sats (TXO URI) or tokens (MRC20 state proof)
+ *   POST /pay/.buy       — buy tokens with sat balance (primary market)
+ *   POST /pay/.withdraw  — withdraw balance as tokens (portable MRC20 proof)
+ *   GET  /pay/*          — paid resource access (requires balance >= cost)
+ *   PUT  /pay/*          — upload resources (standard auth)
  *
  * Ledger: /.well-known/webledgers/webledgers.json (webledgers.org spec)
  *
@@ -346,6 +348,102 @@ export function createPayHandler(options = {}) {
       return reply.send({
         bought: tokenAmount,
         ticker,
+        cost: satCost,
+        rate: payRate,
+        balance: getBalance(ledger, didUri),
+        unit: 'sat',
+        txid: result.txid,
+        proof: {
+          state: result.state,
+          prevState: result.prevState,
+          anchor: {
+            pubkey: result.trail.pubkeyBase,
+            stateStrings: result.trail.stateStrings,
+            network: result.trail.network
+          }
+        }
+      });
+    }
+
+    // --- POST /pay/.withdraw — withdraw balance as tokens ---
+    if (url === '/pay/.withdraw' && request.method === 'POST') {
+      const pubkey = await getNostrPubkey(request);
+      if (!pubkey) {
+        return reply.code(401).send({ error: 'NIP-98 authentication required' });
+      }
+
+      if (!payToken) {
+        return reply.code(400).send({ error: 'Withdrawal not configured (no --pay-token set)' });
+      }
+
+      // Parse withdraw request
+      let body = request.body;
+      if (Buffer.isBuffer(body)) body = JSON.parse(body.toString('utf8'));
+      if (typeof body === 'string') body = JSON.parse(body);
+
+      const didUri = pubkeyToDidNostr(pubkey);
+      const ledger = await readLedger();
+      const balance = getBalance(ledger, didUri);
+
+      // Calculate withdrawal amount
+      let satCost, tokenAmount;
+      if (body?.all) {
+        satCost = balance;
+        tokenAmount = Math.floor(balance / payRate);
+      } else if (body?.sats) {
+        satCost = Math.floor(body.sats);
+        tokenAmount = Math.floor(satCost / payRate);
+      } else if (body?.tokens) {
+        tokenAmount = Math.floor(body.tokens);
+        satCost = tokenAmount * payRate;
+      } else {
+        return reply.code(400).send({
+          error: 'Specify tokens, sats, or all: true',
+          balance,
+          rate: payRate,
+          unit: 'sat/token'
+        });
+      }
+
+      if (tokenAmount <= 0) {
+        return reply.code(400).send({ error: 'Nothing to withdraw', balance, rate: payRate });
+      }
+
+      if (balance < satCost) {
+        return reply.code(402).send({
+          error: 'Insufficient balance',
+          balance,
+          cost: satCost,
+          rate: payRate
+        });
+      }
+
+      // Load token trail
+      const trail = await loadTrail(payToken);
+      if (!trail) {
+        return reply.code(500).send({ error: `Token ${payToken} not minted on this pod` });
+      }
+
+      // Transfer tokens to user
+      let result;
+      try {
+        result = await transferToken({
+          ticker: payToken,
+          to: pubkey,
+          amount: tokenAmount,
+          mempoolUrl
+        });
+      } catch (err) {
+        return reply.code(500).send({ error: `Transfer failed: ${err.message}` });
+      }
+
+      // Debit balance
+      debit(ledger, didUri, satCost);
+      await writeLedger(ledger);
+
+      return reply.send({
+        withdrawn: tokenAmount,
+        ticker: payToken,
         cost: satCost,
         rate: payRate,
         balance: getBalance(ledger, didUri),


### PR DESCRIPTION
## Summary
- Adds `POST /pay/.withdraw` endpoint to convert sat balance into portable MRC20 tokens
- Supports `tokens`, `sats`, or `all: true` to drain entire balance
- Uses same `payRate` as buy endpoint for symmetric pricing
- Returns portable proof (state chain + anchor) for independent verification

## Test plan
- [x] Deposit sats, withdraw 50 tokens — balance deducted correctly
- [x] Bitcoin TX broadcast on testnet4
- [x] Portable proof returned with full state chain and anchor
- [x] 289 existing tests pass

Closes #179