### PR TITLE
Add public GET /pay/.info endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,6 +834,7 @@ jss start --pay --pay-cost 10 --pay-address your-address --pay-token PODS --pay-
 
 | Method | Path | Description |
 |--------|------|-------------|
+| GET | `/pay/.info` | Public: cost, token info, available routes |
 | GET | `/pay/.balance` | Check your balance (NIP-98 auth) |
 | POST | `/pay/.deposit` | Deposit sats via TXO URI or MRC20 state proof |
 | POST | `/pay/.buy` | Buy tokens with sat balance (requires `--pay-token`) |

--- a/src/handlers/pay.js
+++ b/src/handlers/pay.js
@@ -5,6 +5,7 @@
  * Authentication via NIP-98. Balance tracking via Web Ledgers spec.
  *
  * Routes:
+ *   GET  /pay/.info      — public endpoint: cost, token info, available routes
  *   GET  /pay/.balance   — check your balance
  *   POST /pay/.deposit   — deposit sats (TXO URI) or tokens (MRC20 state proof)
  *   POST /pay/.buy       — buy tokens with sat balance (primary market)
@@ -156,6 +157,30 @@ export function createPayHandler(options = {}) {
   return async function payHandler(request, reply) {
     const url = request.url.split('?')[0];
     if (!isPayRequest(request.url)) return;
+
+    // --- GET /pay/.info — public, no auth ---
+    if (url === '/pay/.info' && request.method === 'GET') {
+      const info = {
+        cost,
+        unit: 'sat',
+        deposit: '/pay/.deposit',
+        balance: '/pay/.balance'
+      };
+      if (payToken) {
+        const trail = await loadTrail(payToken);
+        info.token = {
+          ticker: payToken,
+          rate: payRate,
+          buy: '/pay/.buy',
+          withdraw: '/pay/.withdraw'
+        };
+        if (trail) {
+          info.token.supply = trail.latestState?.supply ?? null;
+          info.token.issuer = trail.pubkeyBase ?? null;
+        }
+      }
+      return reply.send(info);
+    }
 
     // --- GET /pay/.balance ---
     if (url === '/pay/.balance' && request.method === 'GET') {


### PR DESCRIPTION
## Summary
- Adds `GET /pay/.info` — public endpoint (no auth) returning pay configuration
- Shows cost, unit, token info (ticker, rate, supply, issuer), and available routes
- Lets clients discover pricing and capabilities before authenticating
- README updated with new route

## Test plan
- [x] Tested with `curl` — returns correct JSON with cost, token config, routes
- [x] No auth required — works without NIP-98 header
- [x] Gracefully handles missing token trail (omits supply/issuer)
- [x] 289 existing tests pass

Closes #181