### PR TITLE
Harden buy/withdraw body parsing and add error tests

### DIFF
--- a/src/handlers/pay.js
+++ b/src/handlers/pay.js
@@ -305,8 +305,12 @@ export function createPayHandler(options = {}) {
 
       // Parse buy request
       let body = request.body;
-      if (Buffer.isBuffer(body)) body = JSON.parse(body.toString('utf8'));
-      if (typeof body === 'string') body = JSON.parse(body);
+      try {
+        if (Buffer.isBuffer(body)) body = JSON.parse(body.toString('utf8'));
+        if (typeof body === 'string') body = JSON.parse(body);
+      } catch {
+        return reply.code(400).send({ error: 'Invalid JSON body' });
+      }
 
       const ticker = body?.ticker || payToken;
       if (ticker !== payToken) {
@@ -403,8 +407,12 @@ export function createPayHandler(options = {}) {
 
       // Parse withdraw request
       let body = request.body;
-      if (Buffer.isBuffer(body)) body = JSON.parse(body.toString('utf8'));
-      if (typeof body === 'string') body = JSON.parse(body);
+      try {
+        if (Buffer.isBuffer(body)) body = JSON.parse(body.toString('utf8'));
+        if (typeof body === 'string') body = JSON.parse(body);
+      } catch {
+        return reply.code(400).send({ error: 'Invalid JSON body' });
+      }
 
       const didUri = pubkeyToDidNostr(pubkey);
       const ledger = await readLedger();

--- a/test/pay.test.js
+++ b/test/pay.test.js
@@ -353,6 +353,19 @@ describe('HTTP 402 Pay Middleware', () => {
       assert.ok(body.error.includes('only sells TEST'));
     });
 
+    it('POST /pay/.buy should reject malformed JSON', async () => {
+      const url = `${tokenUrl}/pay/.buy`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': tokenNip98(url, 'POST'),
+          'Content-Type': 'application/json'
+        },
+        body: '{not valid json'
+      });
+      assertStatus(res, 400);
+    });
+
     it('POST /pay/.buy should reject missing amount', async () => {
       const url = `${tokenUrl}/pay/.buy`;
       const res = await fetch(url, {
@@ -396,6 +409,19 @@ describe('HTTP 402 Pay Middleware', () => {
       assertStatus(res, 402);
       const body = await res.json();
       assert.strictEqual(body.error, 'Insufficient balance');
+    });
+
+    it('POST /pay/.withdraw should reject malformed JSON', async () => {
+      const url = `${tokenUrl}/pay/.withdraw`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': tokenNip98(url, 'POST'),
+          'Content-Type': 'application/json'
+        },
+        body: '{bad json'
+      });
+      assertStatus(res, 400);
     });
 
     it('POST /pay/.withdraw should reject missing params', async () => {


### PR DESCRIPTION
## Summary
- Wrap JSON.parse in try/catch for `/pay/.buy` and `/pay/.withdraw` (defense-in-depth)
- Add 2 tests for malformed JSON body handling
- Test count: 302 → 304

## Test plan
- [x] All 304 tests pass

Closes #188