### PR TITLE
Add secondary market: sell orders and swaps

### DIFF
--- a/PAY.md
+++ b/PAY.md
@@ -1,0 +1,338 @@
+# PAY.md — HTTP 402 Payment System
+
+## What This Is
+
+JSS has a built-in payment system. Resources under `/pay/*` cost satoshis to access. Users authenticate with a Nostr key, deposit sats, and spend them on API requests. Optionally, the pod mints its own token (MRC20 on Bitcoin) that users can buy, sell, and trade.
+
+## Architecture
+
+```
+User (Nostr keypair)
+  │
+  ├── POST /pay/.deposit   → credit sat balance
+  ├── GET  /pay/.balance   → check balance
+  ├── GET  /pay/*          → spend 1 sat, get resource
+  ├── POST /pay/.buy       → spend sats, get tokens (Bitcoin TX)
+  ├── POST /pay/.withdraw  → spend balance, get tokens back
+  ├── POST /pay/.sell      → list tokens for sale
+  └── POST /pay/.swap      → buy someone's sell order
+```
+
+All state lives in two places:
+- **Webledger** — `/.well-known/webledgers/webledgers.json` — sat balances per `did:nostr:<pubkey>`
+- **Token trail** — `/.well-known/token/<ticker>.json` — MRC20 state chain anchored to Bitcoin
+
+## Authentication
+
+Every request to `/pay/*` (except `.info` and `.offers`) requires a NIP-98 auth header:
+
+```
+Authorization: Nostr <base64-encoded-signed-event>
+```
+
+The event is kind 27235 with tags `["u", "<url>"]` and `["method", "<METHOD>"]`, signed with the user's Nostr private key. The server extracts the pubkey and maps it to `did:nostr:<pubkey>` for balance lookup.
+
+## Endpoints
+
+### GET /pay/.info
+**Public. No auth required.**
+
+Returns pod payment configuration.
+
+Response:
+```json
+{
+  "cost": 1,
+  "unit": "sat",
+  "deposit": "/pay/.deposit",
+  "balance": "/pay/.balance",
+  "token": {
+    "ticker": "PODS",
+    "rate": 10,
+    "buy": "/pay/.buy",
+    "withdraw": "/pay/.withdraw",
+    "supply": 10000,
+    "issuer": "025e60b6..."
+  }
+}
+```
+
+The `token` field is only present when `--pay-token` is configured. `rate` is sats per token.
+
+### GET /pay/.balance
+**Requires NIP-98 auth.**
+
+Returns the caller's sat balance.
+
+Response:
+```json
+{
+  "did": "did:nostr:4fa459ad...",
+  "balance": 1041588,
+  "cost": 1,
+  "unit": "sat"
+}
+```
+
+### POST /pay/.deposit
+**Requires NIP-98 auth.**
+
+Credits the caller's balance. Two deposit types:
+
+**Sats (TXO URI):**
+```
+POST /pay/.deposit
+Content-Type: text/plain
+Body: <txid>:<vout>
+```
+
+The server calls the mempool API to verify the UTXO exists and reads its value. The sat amount is credited to the caller's webledger balance.
+
+**MRC20 tokens (state proof):**
+```json
+POST /pay/.deposit
+Content-Type: application/json
+{
+  "type": "mrc20",
+  "state": { ... },
+  "prevState": { ... },
+  "anchor": {
+    "pubkey": "<issuer-compressed-pubkey>",
+    "stateStrings": ["<jcs-of-each-state>"],
+    "network": "testnet4"
+  }
+}
+```
+
+The server verifies: state chain integrity (`state.prev == SHA256(JCS(prevState))`), transfer to the pod's `payAddress`, and optionally anchor verification (derives expected taproot address from pubkey + state chain, checks mempool for UTXO). Replay protection rejects duplicate state hashes.
+
+### POST /pay/.buy
+**Requires NIP-98 auth. Requires `--pay-token` configured.**
+
+Buy tokens from the pod at the configured `payRate` (sats per token).
+
+Request (pick one):
+```json
+{ "amount": 100 }       // buy 100 tokens
+{ "sats": 1000 }        // spend 1000 sats worth
+```
+
+The server:
+1. Checks caller's sat balance >= cost
+2. Loads the pod's MRC20 token trail
+3. Calls `transferToken()` — creates a new MRC20 state transferring tokens to the buyer's pubkey, derives a new taproot address via BIP-341 key chaining, builds and broadcasts a Bitcoin transaction
+4. Debits sats from caller's webledger balance
+
+Response includes a portable proof:
+```json
+{
+  "bought": 100,
+  "ticker": "PODS",
+  "cost": 1000,
+  "rate": 10,
+  "balance": 1040588,
+  "txid": "c3183f41...",
+  "proof": {
+    "state": { ... },
+    "prevState": { ... },
+    "anchor": {
+      "pubkey": "025e60b6...",
+      "stateStrings": ["<jcs>", "<jcs>"],
+      "network": "testnet4"
+    }
+  }
+}
+```
+
+The proof is independently verifiable: anyone can derive the expected taproot address from the pubkey + stateStrings and check the Bitcoin UTXO.
+
+### POST /pay/.withdraw
+**Requires NIP-98 auth. Requires `--pay-token` configured.**
+
+Convert sat balance back to portable tokens. Same mechanism as buy.
+
+Request (pick one):
+```json
+{ "tokens": 50 }        // withdraw 50 tokens
+{ "sats": 500 }         // withdraw 500 sats worth
+{ "all": true }         // drain entire balance
+```
+
+Response is identical to buy, with `"withdrawn"` instead of `"bought"`.
+
+### GET /pay/.offers
+**Public. No auth required.**
+
+Returns open sell orders from the secondary market.
+
+Response:
+```json
+[
+  {
+    "id": "uuid",
+    "seller": "<pubkey>",
+    "ticker": "PODS",
+    "amount": 100,
+    "price": 1500,
+    "rate": 15,
+    "status": "pending",
+    "created": 1773259044534
+  }
+]
+```
+
+### POST /pay/.sell
+**Requires NIP-98 auth. Requires `--pay-token` configured.**
+
+Create a sell order. The seller must have tokens on the pod's MRC20 trail.
+
+Request:
+```json
+{
+  "amount": 100,
+  "price": 1500
+}
+```
+
+`amount` = tokens to sell, `price` = total sats asked. The server verifies the seller's token balance on the trail before creating the order.
+
+### POST /pay/.swap
+**Requires NIP-98 auth. Requires `--pay-token` configured.**
+
+Execute a swap against an open sell order.
+
+Request:
+```json
+{ "id": "<offer-uuid>" }
+```
+
+The server:
+1. Finds the pending offer
+2. Checks buyer's sat balance >= offer price
+3. Transfers tokens from seller to buyer on the MRC20 trail (Bitcoin TX)
+4. Debits buyer's sats, credits seller's sats on the webledger
+5. Marks offer as filled
+
+Response includes the portable proof, same as buy.
+
+### GET /pay/*
+**Requires NIP-98 auth.**
+
+Access a paid resource. The server deducts `cost` sats from the caller's balance. If balance < cost, returns 402:
+
+```json
+{
+  "error": "Payment Required",
+  "balance": 0,
+  "cost": 1,
+  "unit": "sat",
+  "deposit": "/pay/.deposit"
+}
+```
+
+On success, the resource is served normally with headers:
+```
+X-Balance: 1040587
+X-Cost: 1
+```
+
+### PUT /pay/*
+
+Standard upload — goes through normal WAC auth, not the pay middleware. Only the pod owner can write to `/pay/`.
+
+## Configuration
+
+### CLI flags
+```
+--pay                    Enable HTTP 402 for /pay/* routes
+--pay-cost <n>           Cost per request in satoshis (default: 1)
+--pay-mempool-url <url>  Mempool API URL (default: testnet4)
+--pay-address <addr>     Address for receiving MRC20 deposits
+--pay-token <ticker>     Token ticker (enables buy/withdraw/sell/swap)
+--pay-rate <n>           Sats per token for buy/withdraw (default: 1)
+```
+
+### Environment variables
+```
+JSS_PAY=true
+JSS_PAY_COST=1
+JSS_PAY_MEMPOOL_URL=https://mempool.space/testnet4
+JSS_PAY_ADDRESS=tb1q...
+JSS_PAY_TOKEN=PODS
+JSS_PAY_RATE=10
+```
+
+## Token Management (CLI)
+
+```bash
+# Mint a new token (requires funded Bitcoin UTXO)
+jss token mint --ticker PODS --supply 10000 \
+  --voucher "txo:btc:<txid>:<vout>?amount=<sats>&key=<privkey-hex>"
+
+# Transfer tokens
+jss token transfer --ticker PODS --to <pubkey> --amount 100
+
+# Show token info
+jss token info PODS
+```
+
+## Data Files
+
+| File | Contents |
+|------|----------|
+| `/.well-known/webledgers/webledgers.json` | Sat balances per DID (webledgers.org spec) |
+| `/.well-known/webledgers/replay.json` | Seen MRC20 state hashes (replay protection) |
+| `/.well-known/webledgers/offers.json` | Open sell orders (secondary market) |
+| `/.well-known/token/<ticker>.json` | MRC20 token trail (state chain, keys, UTXO) |
+
+## Source Files
+
+| File | Purpose |
+|------|---------|
+| `src/handlers/pay.js` | All `/pay/*` route handling |
+| `src/webledger.js` | Balance read/write/credit/debit |
+| `src/mrc20.js` | MRC20 verification, JCS, BIP-341 key chaining, bech32m |
+| `src/token.js` | Token mint/transfer, Bitcoin TX building, trail persistence |
+| `src/auth/nostr.js` | NIP-98 auth extraction |
+
+## Key Concepts
+
+**Webledger**: A JSON file mapping URIs to numerical balances, following the [webledgers.org](https://webledgers.org/) spec. The URI format is `did:nostr:<pubkey>`.
+
+**MRC20**: A token profile on blocktrails. Each state is a JSON object with `profile`, `prev` (hash link to previous state), `seq`, `ticker`, `balances`, and `ops`. States form a hash chain.
+
+**BIP-341 Key Chaining**: Each MRC20 state is hashed and used as a taproot tweak scalar. The scalar is added to the issuer's public key via elliptic curve addition to derive a unique P2TR address per state. This anchors the state chain to Bitcoin — anyone can verify by re-deriving the address and checking the UTXO.
+
+**JCS (RFC 8785)**: JSON Canonicalization Scheme — sorted keys, no whitespace, deterministic serialization. Used for hashing states.
+
+**NIP-98**: Nostr HTTP Authentication. A signed event (kind 27235) with the request URL and method in tags, base64-encoded in the Authorization header.
+
+**NIP-69 (kind 38383)**: P2P order events for trading. Used as the convention for sell orders in the secondary market.
+
+## Flow Examples
+
+### Agent buys API access
+```
+1. Agent has a funded TXO (Bitcoin UTXO with known private key)
+2. GET  /pay/.info           → learns cost=1, deposit endpoint
+3. POST /pay/.deposit        → posts TXO URI, gets 1M sats credited
+4. GET  /pay/data/feed.json  → costs 1 sat, returns data
+5. (repeat step 4 up to 1M times)
+```
+
+### User buys and trades tokens
+```
+1. POST /pay/.deposit        → deposit sats
+2. POST /pay/.buy            → buy 100 PODS for 1000 sats, get Bitcoin proof
+3. POST /pay/.sell           → list 50 PODS for sale at 750 sats
+4. (another user)
+5. GET  /pay/.offers         → sees the sell order
+6. POST /pay/.swap           → buys the 50 PODS, seller gets 750 sats credited
+```
+
+### Full exit
+```
+1. POST /pay/.withdraw { "all": true }  → converts entire balance to portable tokens
+2. User now holds MRC20 proof, independently verifiable on Bitcoin
+3. Can deposit on another pod, or trade peer-to-peer
+```

--- a/src/handlers/pay.js
+++ b/src/handlers/pay.js
@@ -10,6 +10,9 @@
  *   POST /pay/.deposit   — deposit sats (TXO URI) or tokens (MRC20 state proof)
  *   POST /pay/.buy       — buy tokens with sat balance (primary market)
  *   POST /pay/.withdraw  — withdraw balance as tokens (portable MRC20 proof)
+ *   GET  /pay/.offers    — list open sell orders (secondary market)
+ *   POST /pay/.sell      — create a sell order (NIP-69 kind 38383)
+ *   POST /pay/.swap      — execute a swap against a sell order
  *   GET  /pay/*          — paid resource access (requires balance >= cost)
  *   PUT  /pay/*          — upload resources (standard auth)
  *
@@ -22,6 +25,7 @@
  *   - MRC20 profile: https://blocktrails.org/
  */
 
+import crypto from 'crypto';
 import { getNostrPubkey, pubkeyToDidNostr } from '../auth/nostr.js';
 import { readLedger, writeLedger, getBalance, credit, debit } from '../webledger.js';
 import { verifyMrc20Deposit, verifyMrc20Anchor, jcs, sha256Hex } from '../mrc20.js';
@@ -52,6 +56,21 @@ async function checkAndRecordState(stateHash) {
   seen.add(stateHash);
   await saveReplaySet(seen);
   return true;
+}
+
+// --- Offers storage (secondary market) ---
+const offersFile = () => path.join(process.env.DATA_ROOT || './data', '.well-known/webledgers/offers.json');
+
+async function loadOffers() {
+  try {
+    const data = await fs.readFile(offersFile(), 'utf8');
+    return JSON.parse(data);
+  } catch { return []; }
+}
+
+async function saveOffers(offers) {
+  await fs.ensureDir(path.dirname(offersFile()));
+  await fs.writeFile(offersFile(), JSON.stringify(offers, null, 2));
 }
 
 // --- Deposit verification via mempool API ---
@@ -481,6 +500,166 @@ export function createPayHandler(options = {}) {
         rate: payRate,
         balance: getBalance(ledger, didUri),
         unit: 'sat',
+        txid: result.txid,
+        proof: {
+          state: result.state,
+          prevState: result.prevState,
+          anchor: {
+            pubkey: result.trail.pubkeyBase,
+            stateStrings: result.trail.stateStrings,
+            network: result.trail.network
+          }
+        }
+      });
+    }
+
+    // --- GET /pay/.offers — list open sell orders ---
+    if (url === '/pay/.offers' && request.method === 'GET') {
+      const offers = await loadOffers();
+      return reply.send(offers.filter(o => o.status === 'pending'));
+    }
+
+    // --- POST /pay/.sell — create a sell order ---
+    if (url === '/pay/.sell' && request.method === 'POST') {
+      const pubkey = await getNostrPubkey(request);
+      if (!pubkey) {
+        return reply.code(401).send({ error: 'NIP-98 authentication required' });
+      }
+
+      if (!payToken) {
+        return reply.code(400).send({ error: 'Secondary market not configured (no --pay-token set)' });
+      }
+
+      let body = request.body;
+      try {
+        if (Buffer.isBuffer(body)) body = JSON.parse(body.toString('utf8'));
+        if (typeof body === 'string') body = JSON.parse(body);
+      } catch {
+        return reply.code(400).send({ error: 'Invalid JSON body' });
+      }
+
+      const amount = Math.floor(body?.amount || 0);
+      const price = Math.floor(body?.price || 0); // total sats for the lot
+      if (amount <= 0 || price <= 0) {
+        return reply.code(400).send({ error: 'Specify amount (tokens) and price (total sats)' });
+      }
+
+      // Verify seller has tokens on the trail
+      const trail = await loadTrail(payToken);
+      if (!trail) {
+        return reply.code(500).send({ error: `Token ${payToken} not minted on this pod` });
+      }
+      const currentState = trail.states[trail.states.length - 1];
+      const sellerBalance = currentState.balances[pubkey] || 0;
+      if (sellerBalance < amount) {
+        return reply.code(400).send({
+          error: 'Insufficient token balance on trail',
+          balance: sellerBalance,
+          amount
+        });
+      }
+
+      const offer = {
+        id: crypto.randomUUID(),
+        seller: pubkey,
+        ticker: payToken,
+        amount,
+        price,
+        rate: Math.round(price / amount * 100) / 100,
+        status: 'pending',
+        created: Date.now()
+      };
+
+      const offers = await loadOffers();
+      offers.push(offer);
+      await saveOffers(offers);
+
+      return reply.send(offer);
+    }
+
+    // --- POST /pay/.swap — execute a swap against a sell order ---
+    if (url === '/pay/.swap' && request.method === 'POST') {
+      const pubkey = await getNostrPubkey(request);
+      if (!pubkey) {
+        return reply.code(401).send({ error: 'NIP-98 authentication required' });
+      }
+
+      if (!payToken) {
+        return reply.code(400).send({ error: 'Secondary market not configured (no --pay-token set)' });
+      }
+
+      let body = request.body;
+      try {
+        if (Buffer.isBuffer(body)) body = JSON.parse(body.toString('utf8'));
+        if (typeof body === 'string') body = JSON.parse(body);
+      } catch {
+        return reply.code(400).send({ error: 'Invalid JSON body' });
+      }
+
+      const offerId = body?.id;
+      if (!offerId) {
+        return reply.code(400).send({ error: 'Specify offer id' });
+      }
+
+      // Find the offer
+      const offers = await loadOffers();
+      const offer = offers.find(o => o.id === offerId && o.status === 'pending');
+      if (!offer) {
+        return reply.code(404).send({ error: 'Offer not found or already filled' });
+      }
+
+      // Can't buy your own offer
+      if (offer.seller === pubkey) {
+        return reply.code(400).send({ error: 'Cannot swap with your own offer' });
+      }
+
+      // Check buyer's sat balance
+      const didUri = pubkeyToDidNostr(pubkey);
+      const sellerDid = pubkeyToDidNostr(offer.seller);
+      const ledger = await readLedger();
+      const balance = getBalance(ledger, didUri);
+      if (balance < offer.price) {
+        return reply.code(402).send({
+          error: 'Insufficient sat balance',
+          balance,
+          cost: offer.price,
+          deposit: '/pay/.deposit'
+        });
+      }
+
+      // Transfer tokens from seller to buyer on the trail
+      let result;
+      try {
+        result = await transferToken({
+          ticker: payToken,
+          from: offer.seller,
+          to: pubkey,
+          amount: offer.amount,
+          mempoolUrl
+        });
+      } catch (err) {
+        return reply.code(500).send({ error: `Transfer failed: ${err.message}` });
+      }
+
+      // Debit buyer, credit seller
+      debit(ledger, didUri, offer.price);
+      credit(ledger, sellerDid, offer.price);
+      await writeLedger(ledger);
+
+      // Mark offer as filled
+      offer.status = 'filled';
+      offer.buyer = pubkey;
+      offer.filledAt = Date.now();
+      offer.txid = result.txid;
+      await saveOffers(offers);
+
+      return reply.send({
+        swapped: offer.amount,
+        ticker: payToken,
+        cost: offer.price,
+        rate: offer.rate,
+        balance: getBalance(ledger, didUri),
+        sellerCredited: offer.price,
         txid: result.txid,
         proof: {
           state: result.state,

--- a/src/token.js
+++ b/src/token.js
@@ -306,7 +306,7 @@ export async function mintToken({ ticker, name, supply, voucher, mempoolUrl = 'h
 }
 
 // --- Transfer: send tokens to an address ---
-export async function transferToken({ ticker, to, amount, mempoolUrl = 'https://mempool.space/testnet4' }) {
+export async function transferToken({ ticker, from, to, amount, mempoolUrl = 'https://mempool.space/testnet4' }) {
   const trail = await loadTrail(ticker);
   if (!trail) throw new Error(`Token ${ticker} not found`);
 
@@ -317,15 +317,15 @@ export async function transferToken({ ticker, to, amount, mempoolUrl = 'https://
   const currentState = trail.states[trail.states.length - 1];
   const currentBalances = { ...currentState.balances };
 
-  // Check issuer balance
-  const issuerAddr = trail.pubkeyBase;
-  const issuerBalance = currentBalances[issuerAddr] || 0;
-  if (issuerBalance < amount) {
-    throw new Error(`Insufficient balance: ${issuerBalance} < ${amount}`);
+  // Check sender balance (default: issuer)
+  const senderAddr = from || trail.pubkeyBase;
+  const senderBalance = currentBalances[senderAddr] || 0;
+  if (senderBalance < amount) {
+    throw new Error(`Insufficient balance: ${senderBalance} < ${amount}`);
   }
 
   // Create transfer state
-  currentBalances[issuerAddr] = issuerBalance - amount;
+  currentBalances[senderAddr] = senderBalance - amount;
   currentBalances[to] = (currentBalances[to] || 0) + amount;
   // Remove zero balances
   for (const [k, v] of Object.entries(currentBalances)) {
@@ -342,7 +342,7 @@ export async function transferToken({ ticker, to, amount, mempoolUrl = 'https://
     decimals: 0,
     supply: trail.supply,
     balances: currentBalances,
-    ops: [{ op: 'urn:mono:op:transfer', from: issuerAddr, to, amt: amount }]
+    ops: [{ op: 'urn:mono:op:transfer', from: senderAddr, to, amt: amount }]
   };
   const newJcs = jcs(newState);
 

--- a/test/pay.test.js
+++ b/test/pay.test.js
@@ -438,6 +438,112 @@ describe('HTTP 402 Pay Middleware', () => {
       const body = await res.json();
       assert.ok(body.error.includes('Specify'));
     });
+
+    it('POST /pay/.sell should reject missing amount/price', async () => {
+      const url = `${tokenUrl}/pay/.sell`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': tokenNip98(url, 'POST'),
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({})
+      });
+      assertStatus(res, 400);
+      const body = await res.json();
+      assert.ok(body.error.includes('Specify'));
+    });
+
+    it('POST /pay/.swap should reject missing offer id', async () => {
+      const url = `${tokenUrl}/pay/.swap`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': tokenNip98(url, 'POST'),
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({})
+      });
+      assertStatus(res, 400);
+      const body = await res.json();
+      assert.ok(body.error.includes('Specify offer id'));
+    });
+
+    it('POST /pay/.swap should return 404 for unknown offer', async () => {
+      const url = `${tokenUrl}/pay/.swap`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': tokenNip98(url, 'POST'),
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ id: 'nonexistent' })
+      });
+      assertStatus(res, 404);
+    });
+
+    it('GET /pay/.offers should return empty list', async () => {
+      const res = await fetch(`${tokenUrl}/pay/.offers`);
+      assertStatus(res, 200);
+      const body = await res.json();
+      assert.ok(Array.isArray(body));
+    });
+  });
+
+  describe('GET /pay/.offers', () => {
+    it('should return empty list without auth', async () => {
+      const res = await fetch(`${getBaseUrl()}/pay/.offers`);
+      assertStatus(res, 200);
+      const body = await res.json();
+      assert.ok(Array.isArray(body));
+      assert.strictEqual(body.length, 0);
+    });
+  });
+
+  describe('POST /pay/.sell', () => {
+    it('should return 401 without auth', async () => {
+      const url = `${getBaseUrl()}/pay/.sell`;
+      const res = await fetch(url, { method: 'POST', body: '{}' });
+      assertStatus(res, 401);
+    });
+
+    it('should return 400 when payToken not configured', async () => {
+      const url = `${getBaseUrl()}/pay/.sell`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': createNip98Header(url, 'POST'),
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ amount: 10, price: 100 })
+      });
+      assertStatus(res, 400);
+      const body = await res.json();
+      assert.ok(body.error.includes('not configured'));
+    });
+  });
+
+  describe('POST /pay/.swap', () => {
+    it('should return 401 without auth', async () => {
+      const url = `${getBaseUrl()}/pay/.swap`;
+      const res = await fetch(url, { method: 'POST', body: '{}' });
+      assertStatus(res, 401);
+    });
+
+    it('should return 400 when payToken not configured', async () => {
+      const url = `${getBaseUrl()}/pay/.swap`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': createNip98Header(url, 'POST'),
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ id: 'test-id' })
+      });
+      assertStatus(res, 400);
+      const body = await res.json();
+      assert.ok(body.error.includes('not configured'));
+    });
   });
 
   describe('Pay disabled', () => {


### PR DESCRIPTION
## Summary
- `GET /pay/.offers` — list open sell orders (public, no auth)
- `POST /pay/.sell` — create sell order (verifies seller has tokens on trail)
- `POST /pay/.swap` — execute swap (debit buyer sats, credit seller, transfer tokens on Bitcoin)
- `transferToken` now accepts `from` param for user-to-user transfers
- Order format follows NIP-69 (kind 38383) convention

## Test plan
- [x] 9 new tests: auth, validation, missing params, unknown offer, empty offers
- [x] All 313 tests pass
- [x] `transferToken` backward compatible (from defaults to issuer)

Closes #190