### PR TITLE
Add multi-chain deposits and AMM pool

### DIFF
--- a/bin/jss.js
+++ b/bin/jss.js
@@ -87,6 +87,7 @@ program
   .option('--pay-address <addr>', 'Address for receiving deposits')
   .option('--pay-token <ticker>', 'Token to sell (enables primary market)')
   .option('--pay-rate <n>', 'Sats per token for primary market (default: 1)', parseInt)
+  .option('--pay-chains <chains>', 'Comma-separated chain IDs for multi-chain deposits/AMM (e.g. "tbtc3,tbtc4")')
   .option('--mongo', 'Enable MongoDB-backed /db/ route')
   .option('--no-mongo', 'Disable MongoDB-backed /db/ route')
   .option('--mongo-url <url>', 'MongoDB connection URL (default: mongodb://localhost:27017)')
@@ -159,6 +160,7 @@ program
         payAddress: config.payAddress,
         payToken: config.payToken,
         payRate: config.payRate,
+        payChains: config.payChains,
         mongo: config.mongo,
         mongoUrl: config.mongoUrl,
         mongoDatabase: config.mongoDatabase,

--- a/src/config.js
+++ b/src/config.js
@@ -90,6 +90,7 @@ export const defaults = {
   payAddress: null,
   payToken: null,
   payRate: 1,
+  payChains: null,  // comma-separated chain IDs, e.g. "tbtc3,tbtc4"
 
   // MongoDB-backed /db/ route
   mongo: false,
@@ -152,6 +153,7 @@ const envMap = {
   JSS_PAY_ADDRESS: 'payAddress',
   JSS_PAY_TOKEN: 'payToken',
   JSS_PAY_RATE: 'payRate',
+  JSS_PAY_CHAINS: 'payChains',
   JSS_MONGO: 'mongo',
   JSS_MONGO_URL: 'mongoUrl',
   JSS_MONGO_DATABASE: 'mongoDatabase',

--- a/src/handlers/pay.js
+++ b/src/handlers/pay.js
@@ -35,6 +35,40 @@ import path from 'path';
 
 const DEFAULT_COST = 1; // satoshis per request
 
+// --- Chain registry for multi-chain deposits ---
+const CHAIN_REGISTRY = {
+  tbtc3: { explorer: 'https://mempool.space/testnet/api', unit: 'tbtc3', name: 'Bitcoin Testnet3' },
+  tbtc4: { explorer: 'https://mempool.space/testnet4/api', unit: 'tbtc4', name: 'Bitcoin Testnet4' },
+  btc:   { explorer: 'https://mempool.space/api', unit: 'sat', name: 'Bitcoin' },
+  ltc:   { explorer: 'https://litecoinspace.org/api', unit: 'ltc', name: 'Litecoin' },
+  signet:{ explorer: 'https://mempool.space/signet/api', unit: 'signet', name: 'Bitcoin Signet' },
+};
+
+/**
+ * Parse chain ID from a TXO URI body string.
+ * Supports: "txo:tbtc3:txid:vout", "txo:btc:txid:vout", or bare "txid:vout" (returns null).
+ */
+function parseTxoChain(body) {
+  const str = typeof body === 'string' ? body.trim() : '';
+  const match = str.match(/^txo:([a-z0-9]+):/i);
+  return match ? match[1].toLowerCase() : null;
+}
+
+// --- AMM pool storage ---
+const poolFile = () => path.join(process.env.DATA_ROOT || './data', '.well-known/webledgers/pool.json');
+
+async function loadPool() {
+  try {
+    const data = await fs.readFile(poolFile(), 'utf8');
+    return JSON.parse(data);
+  } catch { return null; }
+}
+
+async function savePool(pool) {
+  await fs.ensureDir(path.dirname(poolFile()));
+  await fs.writeFile(poolFile(), JSON.stringify(pool, null, 2));
+}
+
 // --- Replay protection ---
 const replayFile = () => path.join(process.env.DATA_ROOT || './data', '.well-known/webledgers/replay.json');
 
@@ -173,6 +207,11 @@ export function createPayHandler(options = {}) {
   const payToken = options.payToken ?? null;
   const payRate = options.payRate ?? 1;
 
+  // Parse multi-chain config: "tbtc3,tbtc4" → ['tbtc3', 'tbtc4']
+  const payChains = options.payChains
+    ? options.payChains.split(',').map(c => c.trim()).filter(c => CHAIN_REGISTRY[c])
+    : null;
+
   return async function payHandler(request, reply) {
     const url = request.url.split('?')[0];
     if (!isPayRequest(request.url)) return;
@@ -198,6 +237,10 @@ export function createPayHandler(options = {}) {
           info.token.issuer = trail.pubkeyBase ?? null;
         }
       }
+      if (payChains) {
+        info.chains = payChains.map(id => ({ id, unit: CHAIN_REGISTRY[id].unit, name: CHAIN_REGISTRY[id].name }));
+        info.pool = '/pay/.pool';
+      }
       return reply.send(info);
     }
 
@@ -209,12 +252,21 @@ export function createPayHandler(options = {}) {
       }
       const didUri = pubkeyToDidNostr(pubkey);
       const ledger = await readLedger();
-      return reply.send({
+      const response = {
         did: didUri,
         balance: getBalance(ledger, didUri),
         cost,
         unit: 'sat'
-      });
+      };
+      // Include per-chain balances when multi-chain is enabled
+      if (payChains) {
+        response.balances = {};
+        for (const chainId of payChains) {
+          const unit = CHAIN_REGISTRY[chainId].unit;
+          response.balances[unit] = getBalance(ledger, didUri, unit);
+        }
+      }
+      return reply.send(response);
     }
 
     // --- POST /pay/.deposit ---
@@ -284,21 +336,37 @@ export function createPayHandler(options = {}) {
 
       // --- Sats deposit (TXO URI) ---
       if (deposit.type === 'sats') {
-        const result = await verifySatsDeposit(deposit.txo, mempoolUrl);
+        // Detect chain from TXO URI prefix (e.g. "txo:tbtc3:txid:vout")
+        const chainId = parseTxoChain(deposit.txo);
+        let depositMempoolUrl = mempoolUrl;
+        let currency = null; // null = default (simple string format)
+
+        if (chainId && payChains && payChains.includes(chainId)) {
+          const chain = CHAIN_REGISTRY[chainId];
+          depositMempoolUrl = chain.explorer.replace(/\/api$/, '');
+          currency = chain.unit;
+        } else if (chainId && payChains) {
+          return reply.code(400).send({
+            error: `Chain '${chainId}' not enabled. Enabled chains: ${payChains.join(', ')}`,
+          });
+        }
+
+        const result = await verifySatsDeposit(deposit.txo, depositMempoolUrl);
         if (!result.valid) {
           return reply.code(400).send({ error: result.error });
         }
 
         const didUri = pubkeyToDidNostr(pubkey);
         const ledger = await readLedger();
-        const newBalance = credit(ledger, didUri, result.amount);
+        const newBalance = credit(ledger, didUri, result.amount, currency);
         await writeLedger(ledger);
 
         return reply.send({
           did: didUri,
           deposited: result.amount,
           balance: newBalance,
-          unit: 'sat'
+          unit: currency || 'sat',
+          ...(chainId ? { chain: chainId } : {})
         });
       }
 
@@ -671,6 +739,237 @@ export function createPayHandler(options = {}) {
           }
         }
       });
+    }
+
+    // --- GET /pay/.pool — AMM pool state (public) ---
+    if (url === '/pay/.pool' && request.method === 'GET') {
+      if (!payChains || payChains.length < 2) {
+        return reply.code(400).send({ error: 'AMM not configured (requires --pay-chains with 2 chains)' });
+      }
+      const pool = await loadPool();
+      if (!pool) {
+        return reply.send({
+          pair: [CHAIN_REGISTRY[payChains[0]].unit, CHAIN_REGISTRY[payChains[1]].unit],
+          reserves: { [CHAIN_REGISTRY[payChains[0]].unit]: 0, [CHAIN_REGISTRY[payChains[1]].unit]: 0 },
+          k: 0,
+          fee: 0.003,
+          totalShares: 0,
+          lpShares: {}
+        });
+      }
+      return reply.send(pool);
+    }
+
+    // --- POST /pay/.pool — AMM operations (swap, add-liquidity, remove-liquidity) ---
+    if (url === '/pay/.pool' && request.method === 'POST') {
+      if (!payChains || payChains.length < 2) {
+        return reply.code(400).send({ error: 'AMM not configured (requires --pay-chains with 2 chains)' });
+      }
+
+      const pubkey = await getNostrPubkey(request);
+      if (!pubkey) {
+        return reply.code(401).send({ error: 'NIP-98 authentication required' });
+      }
+
+      let body = request.body;
+      try {
+        if (Buffer.isBuffer(body)) body = JSON.parse(body.toString('utf8'));
+        if (typeof body === 'string') body = JSON.parse(body);
+      } catch {
+        return reply.code(400).send({ error: 'Invalid JSON body' });
+      }
+
+      const didUri = pubkeyToDidNostr(pubkey);
+      const unitA = CHAIN_REGISTRY[payChains[0]].unit;
+      const unitB = CHAIN_REGISTRY[payChains[1]].unit;
+      const action = body?.action;
+
+      // --- ADD LIQUIDITY ---
+      if (action === 'add-liquidity') {
+        const amountA = Math.floor(body?.[unitA] || 0);
+        const amountB = Math.floor(body?.[unitB] || 0);
+        if (amountA <= 0 || amountB <= 0) {
+          return reply.code(400).send({ error: `Specify ${unitA} and ${unitB} amounts` });
+        }
+
+        const ledger = await readLedger();
+        const balA = getBalance(ledger, didUri, unitA);
+        const balB = getBalance(ledger, didUri, unitB);
+        if (balA < amountA) {
+          return reply.code(402).send({ error: `Insufficient ${unitA} balance`, balance: balA, required: amountA });
+        }
+        if (balB < amountB) {
+          return reply.code(402).send({ error: `Insufficient ${unitB} balance`, balance: balB, required: amountB });
+        }
+
+        let pool = await loadPool();
+        if (!pool) {
+          pool = {
+            pair: [unitA, unitB],
+            reserves: { [unitA]: 0, [unitB]: 0 },
+            k: 0,
+            fee: 0.003,
+            totalShares: 0,
+            lpShares: {}
+          };
+        }
+
+        // Calculate LP shares (initial: shares = sqrt(amountA * amountB))
+        let newShares;
+        if (pool.totalShares === 0) {
+          newShares = Math.floor(Math.sqrt(amountA * amountB));
+        } else {
+          // Proportional: min(amountA/reserveA, amountB/reserveB) * totalShares
+          const ratioA = amountA / pool.reserves[unitA];
+          const ratioB = amountB / pool.reserves[unitB];
+          newShares = Math.floor(Math.min(ratioA, ratioB) * pool.totalShares);
+        }
+        if (newShares <= 0) {
+          return reply.code(400).send({ error: 'Amounts too small to mint LP shares' });
+        }
+
+        // Debit user balances
+        debit(ledger, didUri, amountA, unitA);
+        debit(ledger, didUri, amountB, unitB);
+        await writeLedger(ledger);
+
+        // Update pool
+        pool.reserves[unitA] += amountA;
+        pool.reserves[unitB] += amountB;
+        pool.k = pool.reserves[unitA] * pool.reserves[unitB];
+        pool.totalShares += newShares;
+        pool.lpShares[didUri] = (pool.lpShares[didUri] || 0) + newShares;
+        await savePool(pool);
+
+        return reply.send({
+          action: 'add-liquidity',
+          deposited: { [unitA]: amountA, [unitB]: amountB },
+          shares: newShares,
+          totalShares: pool.totalShares,
+          reserves: pool.reserves,
+          k: pool.k
+        });
+      }
+
+      // --- REMOVE LIQUIDITY ---
+      if (action === 'remove-liquidity') {
+        const shares = Math.floor(body?.shares || 0);
+        const pool = await loadPool();
+        if (!pool || pool.totalShares === 0) {
+          return reply.code(400).send({ error: 'Pool has no liquidity' });
+        }
+
+        const userShares = pool.lpShares[didUri] || 0;
+        const toRemove = body?.all ? userShares : shares;
+        if (toRemove <= 0 || toRemove > userShares) {
+          return reply.code(400).send({ error: 'Invalid shares', yours: userShares });
+        }
+
+        // Calculate proportional withdrawal
+        const fraction = toRemove / pool.totalShares;
+        const outA = Math.floor(pool.reserves[unitA] * fraction);
+        const outB = Math.floor(pool.reserves[unitB] * fraction);
+
+        // Credit user
+        const ledger = await readLedger();
+        credit(ledger, didUri, outA, unitA);
+        credit(ledger, didUri, outB, unitB);
+        await writeLedger(ledger);
+
+        // Update pool
+        pool.reserves[unitA] -= outA;
+        pool.reserves[unitB] -= outB;
+        pool.k = pool.reserves[unitA] * pool.reserves[unitB];
+        pool.totalShares -= toRemove;
+        pool.lpShares[didUri] -= toRemove;
+        if (pool.lpShares[didUri] <= 0) delete pool.lpShares[didUri];
+        await savePool(pool);
+
+        return reply.send({
+          action: 'remove-liquidity',
+          withdrawn: { [unitA]: outA, [unitB]: outB },
+          sharesRemoved: toRemove,
+          totalShares: pool.totalShares,
+          reserves: pool.reserves
+        });
+      }
+
+      // --- SWAP ---
+      if (action === 'swap') {
+        const sellUnit = body?.sell;
+        const amount = Math.floor(body?.amount || 0);
+        if (!sellUnit || ![unitA, unitB].includes(sellUnit)) {
+          return reply.code(400).send({ error: `Specify sell: "${unitA}" or "${unitB}"` });
+        }
+        if (amount <= 0) {
+          return reply.code(400).send({ error: 'Amount must be positive' });
+        }
+
+        const pool = await loadPool();
+        if (!pool || pool.k === 0) {
+          return reply.code(400).send({ error: 'Pool has no liquidity' });
+        }
+
+        const buyUnit = sellUnit === unitA ? unitB : unitA;
+
+        // Check user balance
+        const ledger = await readLedger();
+        const userBal = getBalance(ledger, didUri, sellUnit);
+        if (userBal < amount) {
+          return reply.code(402).send({
+            error: `Insufficient ${sellUnit} balance`,
+            balance: userBal,
+            required: amount,
+            deposit: '/pay/.deposit'
+          });
+        }
+
+        // Constant product: (reserveIn + amountIn * (1-fee)) * (reserveOut - amountOut) = k
+        const reserveIn = pool.reserves[sellUnit];
+        const reserveOut = pool.reserves[buyUnit];
+        const amountInAfterFee = amount * (1 - pool.fee);
+        const amountOut = Math.floor((reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee));
+
+        if (amountOut <= 0) {
+          return reply.code(400).send({ error: 'Trade too small' });
+        }
+
+        // Slippage protection
+        if (body?.minReceived && amountOut < body.minReceived) {
+          return reply.code(400).send({
+            error: 'Slippage exceeded',
+            wouldReceive: amountOut,
+            minReceived: body.minReceived
+          });
+        }
+
+        // Execute: debit sellUnit, credit buyUnit
+        debit(ledger, didUri, amount, sellUnit);
+        credit(ledger, didUri, amountOut, buyUnit);
+        await writeLedger(ledger);
+
+        // Update pool reserves
+        pool.reserves[sellUnit] += amount;
+        pool.reserves[buyUnit] -= amountOut;
+        pool.k = pool.reserves[unitA] * pool.reserves[unitB];
+        await savePool(pool);
+
+        const price = amount / amountOut;
+        return reply.send({
+          action: 'swap',
+          sold: { unit: sellUnit, amount },
+          bought: { unit: buyUnit, amount: amountOut },
+          price: Math.round(price * 10000) / 10000,
+          fee: Math.floor(amount * pool.fee),
+          reserves: pool.reserves,
+          balances: {
+            [sellUnit]: getBalance(ledger, didUri, sellUnit),
+            [buyUnit]: getBalance(ledger, didUri, buyUnit)
+          }
+        });
+      }
+
+      return reply.code(400).send({ error: 'Unknown action. Use: swap, add-liquidity, remove-liquidity' });
     }
 
     // --- GET/HEAD /pay/* — paid resource access ---

--- a/src/server.js
+++ b/src/server.js
@@ -102,6 +102,7 @@ export function createServer(options = {}) {
   const payAddress = options.payAddress ?? null; // Pod's MRC20 address for token deposits
   const payToken = options.payToken ?? null; // Token ticker for primary market
   const payRate = options.payRate ?? 1; // Sats per token
+  const payChains = options.payChains ?? null; // Multi-chain IDs (e.g. "tbtc3,tbtc4")
 
   // Set data root via environment variable if provided
   if (options.root) {
@@ -376,7 +377,7 @@ export function createServer(options = {}) {
 
   // HTTP 402 Payment Required handler for /pay/* routes
   if (payEnabled) {
-    fastify.addHook('preHandler', createPayHandler({ cost: payCost, mempoolUrl: payMempoolUrl, payAddress, payToken, payRate }));
+    fastify.addHook('preHandler', createPayHandler({ cost: payCost, mempoolUrl: payMempoolUrl, payAddress, payToken, payRate, payChains }));
   }
 
   // Authorization hook - check WAC permissions

--- a/src/webledger.js
+++ b/src/webledger.js
@@ -77,16 +77,21 @@ export async function writeLedger(ledger, ledgerPath = DEFAULT_PATH) {
  * Get balance for a URI
  * @param {object} ledger - WebLedger object
  * @param {string} uri - Agent URI (e.g. did:nostr:...)
+ * @param {string} [currency] - Currency code (e.g. 'tbtc3', 'tbtc4'). If omitted, reads default/simple amount.
  * @returns {number} Balance as integer
  */
-export function getBalance(ledger, uri) {
+export function getBalance(ledger, uri, currency) {
   const entry = ledger.entries.find(e => e.url === uri);
   if (!entry) return 0;
-  // Handle both simple string and array amount formats
+  // Handle array amount format
   if (Array.isArray(entry.amount)) {
-    const sat = entry.amount.find(a => a.currency === 'satoshi' || a.currency === 'sat');
-    return sat ? parseInt(sat.value, 10) || 0 : 0;
+    const target = currency
+      ? entry.amount.find(a => a.currency === currency)
+      : entry.amount.find(a => a.currency === 'satoshi' || a.currency === 'sat');
+    return target ? parseInt(target.value, 10) || 0 : 0;
   }
+  // Simple string format — only if no specific currency requested, or currency matches default
+  if (currency) return 0;
   return parseInt(entry.amount, 10) || 0;
 }
 
@@ -95,13 +100,34 @@ export function getBalance(ledger, uri) {
  * @param {object} ledger - WebLedger object
  * @param {string} uri - Agent URI
  * @param {number} amount - New balance
+ * @param {string} [currency] - Currency code. If provided, uses array amount format.
  */
-export function setBalance(ledger, uri, amount) {
-  const entry = ledger.entries.find(e => e.url === uri);
-  if (entry) {
-    entry.amount = String(amount);
+export function setBalance(ledger, uri, amount, currency) {
+  let entry = ledger.entries.find(e => e.url === uri);
+  if (!currency) {
+    // Simple string format (backward compatible)
+    if (entry) {
+      entry.amount = String(amount);
+    } else {
+      ledger.entries.push({ type: 'Entry', url: uri, amount: String(amount) });
+    }
+    return;
+  }
+  // Multi-currency: use array format
+  if (!entry) {
+    entry = { type: 'Entry', url: uri, amount: [] };
+    ledger.entries.push(entry);
+  }
+  // Migrate simple string to array if needed
+  if (!Array.isArray(entry.amount)) {
+    const oldVal = parseInt(entry.amount, 10) || 0;
+    entry.amount = oldVal > 0 ? [{ currency: 'satoshi', value: String(oldVal) }] : [];
+  }
+  const existing = entry.amount.find(a => a.currency === currency);
+  if (existing) {
+    existing.value = String(amount);
   } else {
-    ledger.entries.push({ type: 'Entry', url: uri, amount: String(amount) });
+    entry.amount.push({ currency, value: String(amount) });
   }
 }
 
@@ -110,12 +136,13 @@ export function setBalance(ledger, uri, amount) {
  * @param {object} ledger - WebLedger object
  * @param {string} uri - Agent URI
  * @param {number} amount - Amount to add
+ * @param {string} [currency] - Currency code
  * @returns {number} New balance
  */
-export function credit(ledger, uri, amount) {
-  const current = getBalance(ledger, uri);
+export function credit(ledger, uri, amount, currency) {
+  const current = getBalance(ledger, uri, currency);
   const newBalance = current + amount;
-  setBalance(ledger, uri, newBalance);
+  setBalance(ledger, uri, newBalance, currency);
   return newBalance;
 }
 
@@ -124,15 +151,16 @@ export function credit(ledger, uri, amount) {
  * @param {object} ledger - WebLedger object
  * @param {string} uri - Agent URI
  * @param {number} amount - Amount to subtract
+ * @param {string} [currency] - Currency code
  * @returns {{success: boolean, balance: number}} Result
  */
-export function debit(ledger, uri, amount) {
-  const current = getBalance(ledger, uri);
+export function debit(ledger, uri, amount, currency) {
+  const current = getBalance(ledger, uri, currency);
   if (current < amount) {
     return { success: false, balance: current };
   }
   const newBalance = current - amount;
-  setBalance(ledger, uri, newBalance);
+  setBalance(ledger, uri, newBalance, currency);
   return { success: true, balance: newBalance };
 }
 

--- a/test/pay.test.js
+++ b/test/pay.test.js
@@ -546,6 +546,151 @@ describe('HTTP 402 Pay Middleware', () => {
     });
   });
 
+  describe('AMM with multi-chain', () => {
+    let ammServer;
+    let ammUrl;
+    const ammPrivkey = crypto.randomBytes(32);
+    const ammPubkey = Buffer.from(schnorr.getPublicKey(ammPrivkey)).toString('hex');
+    const ammPrivkey2 = crypto.randomBytes(32);
+    const ammPubkey2 = Buffer.from(schnorr.getPublicKey(ammPrivkey2)).toString('hex');
+
+    function ammNip98(pk, url, method = 'GET') {
+      const event = {
+        pubkey: Buffer.from(schnorr.getPublicKey(pk)).toString('hex'),
+        created_at: Math.floor(Date.now() / 1000),
+        kind: 27235,
+        tags: [['u', url], ['method', method]],
+        content: ''
+      };
+      const serialized = JSON.stringify([0, event.pubkey, event.created_at, event.kind, event.tags, event.content]);
+      event.id = crypto.createHash('sha256').update(serialized).digest('hex');
+      event.sig = Buffer.from(schnorr.sign(event.id, pk)).toString('hex');
+      return `Nostr ${Buffer.from(JSON.stringify(event)).toString('base64')}`;
+    }
+
+    before(async () => {
+      const { createServer } = await import('../src/server.js');
+      ammServer = createServer({
+        logger: false,
+        forceCloseConnections: true,
+        pay: true,
+        payCost: 1,
+        payChains: 'tbtc3,tbtc4'
+      });
+      await ammServer.listen({ port: 0, host: '127.0.0.1' });
+      const addr = ammServer.server.address();
+      ammUrl = `http://127.0.0.1:${addr.port}`;
+    });
+
+    after(async () => {
+      if (ammServer) await ammServer.close();
+    });
+
+    it('GET /pay/.info should include chains and pool', async () => {
+      const res = await fetch(`${ammUrl}/pay/.info`);
+      assertStatus(res, 200);
+      const body = await res.json();
+      assert.ok(body.chains);
+      assert.strictEqual(body.chains.length, 2);
+      assert.strictEqual(body.chains[0].id, 'tbtc3');
+      assert.strictEqual(body.chains[1].id, 'tbtc4');
+      assert.strictEqual(body.pool, '/pay/.pool');
+    });
+
+    it('GET /pay/.pool should return empty pool', async () => {
+      const res = await fetch(`${ammUrl}/pay/.pool`);
+      assertStatus(res, 200);
+      const body = await res.json();
+      assert.strictEqual(body.reserves.tbtc3, 0);
+      assert.strictEqual(body.reserves.tbtc4, 0);
+      assert.strictEqual(body.k, 0);
+      assert.strictEqual(body.totalShares, 0);
+    });
+
+    it('GET /pay/.balance should include per-chain balances', async () => {
+      const url = `${ammUrl}/pay/.balance`;
+      const res = await fetch(url, {
+        headers: { 'Authorization': ammNip98(ammPrivkey, url) }
+      });
+      assertStatus(res, 200);
+      const body = await res.json();
+      assert.ok(body.balances);
+      assert.strictEqual(body.balances.tbtc3, 0);
+      assert.strictEqual(body.balances.tbtc4, 0);
+    });
+
+    it('POST /pay/.pool swap should fail with no liquidity', async () => {
+      const url = `${ammUrl}/pay/.pool`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': ammNip98(ammPrivkey, url, 'POST'),
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ action: 'swap', sell: 'tbtc3', amount: 100 })
+      });
+      assertStatus(res, 400);
+      const body = await res.json();
+      assert.ok(body.error.includes('no liquidity'));
+    });
+
+    it('POST /pay/.pool add-liquidity should fail with zero balance', async () => {
+      const url = `${ammUrl}/pay/.pool`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': ammNip98(ammPrivkey, url, 'POST'),
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ action: 'add-liquidity', tbtc3: 1000, tbtc4: 5000 })
+      });
+      assertStatus(res, 402);
+    });
+
+    it('POST /pay/.pool should reject unknown action', async () => {
+      const url = `${ammUrl}/pay/.pool`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': ammNip98(ammPrivkey, url, 'POST'),
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ action: 'invalid' })
+      });
+      assertStatus(res, 400);
+      const body = await res.json();
+      assert.ok(body.error.includes('Unknown action'));
+    });
+
+    it('POST /pay/.pool swap should reject invalid sell unit', async () => {
+      const url = `${ammUrl}/pay/.pool`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': ammNip98(ammPrivkey, url, 'POST'),
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ action: 'swap', sell: 'invalid', amount: 100 })
+      });
+      assertStatus(res, 400);
+    });
+
+    it('POST /pay/.pool remove-liquidity should fail with no pool', async () => {
+      const url = `${ammUrl}/pay/.pool`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': ammNip98(ammPrivkey, url, 'POST'),
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ action: 'remove-liquidity', shares: 10 })
+      });
+      assertStatus(res, 400);
+      const body = await res.json();
+      assert.ok(body.error.includes('no liquidity'));
+    });
+  });
+
   describe('Pay disabled', () => {
     let noPayServer;
     let noPayUrl;

--- a/test/webledger.test.js
+++ b/test/webledger.test.js
@@ -152,6 +152,68 @@ describe('Web Ledger', () => {
     });
   });
 
+  describe('multi-currency', () => {
+    it('should credit and debit with specific currency', () => {
+      const ledger = createLedger();
+      const bal = credit(ledger, 'did:nostr:user1', 1000, 'tbtc3');
+      assert.strictEqual(bal, 1000);
+      assert.strictEqual(getBalance(ledger, 'did:nostr:user1', 'tbtc3'), 1000);
+      // Default balance should be 0 (no satoshi credits)
+      assert.strictEqual(getBalance(ledger, 'did:nostr:user1'), 0);
+    });
+
+    it('should track multiple currencies independently', () => {
+      const ledger = createLedger();
+      credit(ledger, 'did:nostr:user1', 1000, 'tbtc3');
+      credit(ledger, 'did:nostr:user1', 5000, 'tbtc4');
+      assert.strictEqual(getBalance(ledger, 'did:nostr:user1', 'tbtc3'), 1000);
+      assert.strictEqual(getBalance(ledger, 'did:nostr:user1', 'tbtc4'), 5000);
+    });
+
+    it('should debit specific currency', () => {
+      const ledger = createLedger();
+      credit(ledger, 'did:nostr:user1', 1000, 'tbtc3');
+      credit(ledger, 'did:nostr:user1', 5000, 'tbtc4');
+      const result = debit(ledger, 'did:nostr:user1', 300, 'tbtc3');
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.balance, 700);
+      // tbtc4 unchanged
+      assert.strictEqual(getBalance(ledger, 'did:nostr:user1', 'tbtc4'), 5000);
+    });
+
+    it('should fail debit when currency balance insufficient', () => {
+      const ledger = createLedger();
+      credit(ledger, 'did:nostr:user1', 100, 'tbtc3');
+      const result = debit(ledger, 'did:nostr:user1', 200, 'tbtc3');
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.balance, 100);
+    });
+
+    it('should migrate simple string to array on currency credit', () => {
+      const ledger = createLedger();
+      // First set a simple balance
+      setBalance(ledger, 'did:nostr:user1', 500);
+      assert.strictEqual(getBalance(ledger, 'did:nostr:user1'), 500);
+      // Now add a currency-specific balance — should migrate to array
+      credit(ledger, 'did:nostr:user1', 1000, 'tbtc3');
+      assert.strictEqual(getBalance(ledger, 'did:nostr:user1', 'tbtc3'), 1000);
+      // Old satoshi balance should be preserved in array
+      const entry = ledger.entries.find(e => e.url === 'did:nostr:user1');
+      assert.ok(Array.isArray(entry.amount));
+      const satEntry = entry.amount.find(a => a.currency === 'satoshi');
+      assert.strictEqual(parseInt(satEntry.value), 500);
+    });
+
+    it('should use array format in entries', () => {
+      const ledger = createLedger();
+      credit(ledger, 'did:nostr:user1', 1000, 'tbtc3');
+      const entry = ledger.entries.find(e => e.url === 'did:nostr:user1');
+      assert.ok(Array.isArray(entry.amount));
+      assert.strictEqual(entry.amount[0].currency, 'tbtc3');
+      assert.strictEqual(entry.amount[0].value, '1000');
+    });
+  });
+
   describe('URI format support', () => {
     it('should work with did:nostr URIs', () => {
       const ledger = createLedger();


### PR DESCRIPTION
## Summary
- Multi-chain sat deposits: detect chain from TXO URI prefix (`txo:tbtc3:`, `txo:tbtc4:`, etc.)
- Per-chain balance tracking using webledger multi-currency array format
- AMM constant-product pool at `/pay/.pool` with swap, add-liquidity, remove-liquidity
- 0.3% fee on swaps, slippage protection via `minReceived` param
- CLI flag: `--pay-chains "tbtc3,tbtc4"`
- 14 new tests (8 AMM + 6 multi-currency webledger)

## Test plan
- [x] All 43 pay tests pass
- [x] All 23 webledger tests pass
- [ ] Deploy to live server with `--pay-chains "tbtc3,tbtc4"`
- [ ] Test deposit from testnet3 and testnet4
- [ ] Test AMM: add liquidity, swap, remove liquidity

Closes #195