### PR TITLE
402 middleware: fall back to chain-specific balances

### DIFF
--- a/src/handlers/pay.js
+++ b/src/handlers/pay.js
@@ -988,21 +988,41 @@ export function createPayHandler(options = {}) {
 
       const didUri = pubkeyToDidNostr(pubkey);
       const ledger = await readLedger();
-      const { success, balance } = debit(ledger, didUri, cost);
 
-      if (!success) {
-        return reply.code(402).send({
+      // Try generic sat balance first, then fall back to chain balances
+      const currency = request.headers['x-pay-currency'] || null;
+      let payUnit = currency && payChains && payChains.includes(currency) ? currency : null;
+      let result = debit(ledger, didUri, cost, payUnit);
+
+      // If generic sat failed and no explicit currency, try each chain balance
+      if (!result.success && !payUnit && payChains) {
+        for (const chainId of payChains) {
+          result = debit(ledger, didUri, cost, chainId);
+          if (result.success) { payUnit = chainId; break; }
+        }
+      }
+
+      if (!result.success) {
+        const response = {
           error: 'Payment Required',
-          balance,
+          balance: result.balance,
           cost,
           unit: 'sat',
           deposit: '/pay/.deposit'
-        });
+        };
+        if (payChains) {
+          response.balances = {};
+          for (const chainId of payChains) {
+            response.balances[chainId] = getBalance(ledger, didUri, chainId);
+          }
+        }
+        return reply.code(402).send(response);
       }
 
       await writeLedger(ledger);
-      reply.header('X-Balance', String(balance));
+      reply.header('X-Balance', String(result.balance));
       reply.header('X-Cost', String(cost));
+      if (payUnit) reply.header('X-Pay-Currency', payUnit);
       return; // continue to normal resource handler
     }
 


### PR DESCRIPTION
## Summary

- 402 paywall now tries chain-specific balances when generic `sat` is insufficient
- Clients can specify `X-Pay-Currency: tbtc4` header for explicit chain preference
- Without the header, auto-tries each enabled chain balance
- 402 response now includes available chain balances so clients know what they have

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| sat balance sufficient | 200 | 200 (unchanged) |
| sat=0, tbtc4=1000 | 402 | 200 (debits tbtc4) |
| sat=0, tbtc4=0 | 402 | 402 (with chain balances in response) |
| `X-Pay-Currency: tbtc4` header | ignored | uses tbtc4 explicitly |

Fixes #203