### PR TITLE
feat: add tunnel proxy plugin (decentralized ngrok)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ jss --help             # Show help
 | `--mongo-database <name>` | MongoDB database name | solid |
 | `--webrtc` | Enable WebRTC signaling server | false |
 | `--webrtc-path <path>` | WebRTC signaling WebSocket path | /.webrtc |
+| `--tunnel` | Enable tunnel proxy (decentralized ngrok) | false |
+| `--tunnel-path <path>` | Tunnel WebSocket path | /.tunnel |
 | `-q, --quiet` | Suppress logs | false |
 
 ### Environment Variables
@@ -861,6 +863,36 @@ Messages are JSON over WebSocket:
 ```
 
 On connect, peers receive a list of online users and get notified when others join or leave.
+
+## Tunnel Proxy (Decentralized ngrok)
+
+Expose a local dev server to the internet through your JSS pod. A tunnel client connects via WebSocket, registers a name, and receives proxied HTTP requests.
+
+```bash
+jss start --tunnel
+```
+
+### How It Works
+
+1. Tunnel client connects to `wss://your.pod/.tunnel` (WebID auth required)
+2. Client registers a name: `{ "type": "register", "name": "myapp" }`
+3. Public URL becomes available at `https://your.pod/tunnel/myapp/`
+4. HTTP requests to that URL are serialized and sent to the tunnel client over WebSocket
+5. Tunnel client forwards to localhost, returns the response
+
+### Tunnel Client Protocol
+
+```js
+// 1. Register a tunnel
+→ { "type": "register", "name": "myapp" }
+← { "type": "registered", "name": "myapp", "url": "/tunnel/myapp/" }
+
+// 2. Receive proxied HTTP requests
+← { "type": "request", "id": "uuid", "method": "GET", "path": "/api/hello", "headers": {...} }
+
+// 3. Return the response
+→ { "type": "response", "id": "uuid", "status": 200, "headers": {...}, "body": "..." }
+```
 
 ## HTTP 402 Paid Access
 

--- a/bin/jss.js
+++ b/bin/jss.js
@@ -68,6 +68,9 @@ program
   .option('--webrtc', 'Enable WebRTC signaling server')
   .option('--no-webrtc', 'Disable WebRTC signaling server')
   .option('--webrtc-path <path>', 'WebRTC signaling WebSocket path (default: /.webrtc)')
+  .option('--tunnel', 'Enable tunnel proxy (decentralized ngrok)')
+  .option('--no-tunnel', 'Disable tunnel proxy')
+  .option('--tunnel-path <path>', 'Tunnel WebSocket path (default: /.tunnel)')
   .option('--activitypub', 'Enable ActivityPub federation')
   .option('--no-activitypub', 'Disable ActivityPub federation')
   .option('--ap-username <name>', 'ActivityPub username (default: me)')
@@ -147,6 +150,8 @@ program
         nostrMaxEvents: config.nostrMaxEvents,
         webrtc: config.webrtc,
         webrtcPath: config.webrtcPath,
+        tunnel: config.tunnel,
+        tunnelPath: config.tunnelPath,
         activitypub: config.activitypub,
         apUsername: config.apUsername,
         apDisplayName: config.apDisplayName,
@@ -192,6 +197,7 @@ program
         if (config.git) console.log('  Git: enabled (clone/push support)');
         if (config.nostr) console.log(`  Nostr: enabled (${config.nostrPath})`);
         if (config.webrtc) console.log(`  WebRTC: enabled (${config.webrtcPath || '/.webrtc'})`);
+        if (config.tunnel) console.log(`  Tunnel: enabled (${config.tunnelPath || '/.tunnel'})`);
         if (config.activitypub) console.log(`  ActivityPub: enabled (@${config.apUsername || 'me'})`);
         if (config.singleUser) console.log(`  Single-user: ${config.singleUserName || 'me'} (registration disabled)`);
         else if (config.inviteOnly) console.log('  Registration: invite-only');

--- a/src/config.js
+++ b/src/config.js
@@ -58,6 +58,10 @@ export const defaults = {
   webrtc: false,
   webrtcPath: '/.webrtc',
 
+  // Tunnel (decentralized ngrok)
+  tunnel: false,
+  tunnelPath: '/.tunnel',
+
   // ActivityPub federation
   activitypub: false,
   apUsername: 'me',
@@ -140,6 +144,8 @@ const envMap = {
   JSS_NOSTR_MAX_EVENTS: 'nostrMaxEvents',
   JSS_WEBRTC: 'webrtc',
   JSS_WEBRTC_PATH: 'webrtcPath',
+  JSS_TUNNEL: 'tunnel',
+  JSS_TUNNEL_PATH: 'tunnelPath',
   JSS_ACTIVITYPUB: 'activitypub',
   JSS_AP_USERNAME: 'apUsername',
   JSS_AP_DISPLAY_NAME: 'apDisplayName',

--- a/src/server.js
+++ b/src/server.js
@@ -19,6 +19,7 @@ import { activityPubPlugin, getActorHandler } from './ap/index.js';
 import { remoteStoragePlugin } from './remotestorage.js';
 import { dbPlugin } from './db/index.js';
 import { webrtcPlugin } from './webrtc/index.js';
+import { tunnelPlugin } from './tunnel/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -78,6 +79,9 @@ export function createServer(options = {}) {
   // WebRTC signaling is OFF by default
   const webrtcEnabled = options.webrtc ?? false;
   const webrtcPath = options.webrtcPath ?? '/.webrtc';
+  // Tunnel proxy is OFF by default
+  const tunnelEnabled = options.tunnel ?? false;
+  const tunnelPath = options.tunnelPath ?? '/.tunnel';
   // ActivityPub federation is OFF by default
   const activitypubEnabled = options.activitypub ?? false;
   const apUsername = options.apUsername ?? 'me';
@@ -249,6 +253,11 @@ export function createServer(options = {}) {
     fastify.register(webrtcPlugin, { path: webrtcPath });
   }
 
+  // Register tunnel proxy if enabled
+  if (tunnelEnabled) {
+    fastify.register(tunnelPlugin, { path: tunnelPath });
+  }
+
   // Register ActivityPub plugin if enabled
   if (activitypubEnabled) {
     fastify.register(activityPubPlugin, {
@@ -340,8 +349,11 @@ export function createServer(options = {}) {
       return;
     }
 
-    // Allow WebRTC signaling endpoint through when enabled
+    // Allow WebRTC and tunnel endpoints through when enabled
     const urlNoQuery = request.url.split('?')[0];
+    if (tunnelEnabled && (urlNoQuery === tunnelPath || urlNoQuery.startsWith('/tunnel/'))) {
+      return;
+    }
     if (webrtcEnabled && urlNoQuery === webrtcPath) {
       return;
     }
@@ -421,6 +433,7 @@ export function createServer(options = {}) {
         (payEnabled && isPayRequest(request.url)) ||
         (mongoEnabled && (request.url === '/db' || request.url.startsWith('/db/'))) ||
         (webrtcEnabled && (request.url === webrtcPath || request.url.startsWith(webrtcPath + '?'))) ||
+        (tunnelEnabled && (request.url === tunnelPath || request.url.startsWith(tunnelPath + '?') || request.url.startsWith('/tunnel/'))) ||
         mashlibPaths.some(p => request.url === p || request.url.startsWith(p + '.'))) {
       return;
     }

--- a/src/tunnel/index.js
+++ b/src/tunnel/index.js
@@ -1,0 +1,216 @@
+/**
+ * Tunnel Plugin — Decentralized ngrok
+ *
+ * Tunnels HTTP traffic to a local dev server through JSS via WebSocket.
+ * A tunnel client connects over WebSocket, registers a name, and receives
+ * proxied HTTP requests which it forwards to localhost.
+ *
+ * Usage: jss start --tunnel
+ * Tunnel client connects to: wss://your.pod/.tunnel
+ * Public URL: https://your.pod/tunnel/{name}/path
+ *
+ * Tunnel client protocol (JSON over WebSocket):
+ *   → { type: "register", name: "myapp" }
+ *   ← { type: "registered", name: "myapp", url: "/tunnel/myapp/" }
+ *   ← { type: "request", id: "<uuid>", method: "GET", path: "/api/hello", headers: {...}, body: "..." }
+ *   → { type: "response", id: "<uuid>", status: 200, headers: {...}, body: "..." }
+ *   ← { type: "error", message: "..." }
+ */
+
+import websocket from '@fastify/websocket';
+import { getWebIdFromRequestAsync } from '../auth/token.js';
+import { randomUUID } from 'crypto';
+
+const REQUEST_TIMEOUT = 30000; // 30s timeout for tunnel responses
+const MAX_MESSAGE_SIZE = 10 * 1024 * 1024; // 10MB
+
+/**
+ * @param {object} fastify - Fastify instance
+ * @param {object} options - Options
+ * @param {string} options.path - WebSocket path for tunnel clients (default: '/.tunnel')
+ */
+export async function tunnelPlugin(fastify, options = {}) {
+  const wsPath = options.path || '/.tunnel';
+
+  // Instance-scoped: tunnel name → { socket, webId }
+  const tunnels = new Map();
+  // Pending HTTP requests waiting for tunnel response: id → { resolve, timer }
+  const pending = new Map();
+
+  if (!fastify.websocketServer) {
+    await fastify.register(websocket);
+  }
+
+  fastify.addHook('onClose', async () => {
+    for (const [, tunnel] of tunnels) {
+      tunnel.socket.close();
+    }
+    tunnels.clear();
+    for (const [, p] of pending) {
+      clearTimeout(p.timer);
+      p.resolve({ status: 502, headers: {}, body: 'Tunnel shutting down' });
+    }
+    pending.clear();
+  });
+
+  // WebSocket endpoint for tunnel clients
+  fastify.get(wsPath, { websocket: true }, async (connection, request) => {
+    const socket = connection.socket;
+
+    // Authenticate
+    const { webId } = await getWebIdFromRequestAsync(request);
+    if (!webId) {
+      socket.send(JSON.stringify({ type: 'error', message: 'Authentication required' }));
+      socket.close();
+      return;
+    }
+
+    let tunnelName = null;
+
+    socket.on('message', (data) => {
+      const raw = Buffer.isBuffer(data) ? data : Buffer.from(data);
+      if (raw.byteLength > MAX_MESSAGE_SIZE) {
+        socket.send(JSON.stringify({ type: 'error', message: 'Message too large' }));
+        return;
+      }
+
+      let msg;
+      try {
+        msg = JSON.parse(raw.toString());
+      } catch {
+        socket.send(JSON.stringify({ type: 'error', message: 'Invalid JSON' }));
+        return;
+      }
+
+      if (msg.type === 'register') {
+        // Register a tunnel name
+        const name = (msg.name || '').replace(/[^a-zA-Z0-9_-]/g, '');
+        if (!name) {
+          socket.send(JSON.stringify({ type: 'error', message: 'Invalid tunnel name' }));
+          return;
+        }
+
+        const existing = tunnels.get(name);
+        if (existing && existing.webId !== webId) {
+          socket.send(JSON.stringify({ type: 'error', message: 'Tunnel name taken by another user' }));
+          return;
+        }
+
+        // Close old tunnel with same name from same user
+        if (existing) {
+          existing.socket.close();
+        }
+
+        tunnelName = name;
+        tunnels.set(name, { socket, webId });
+        socket.send(JSON.stringify({ type: 'registered', name, url: `/tunnel/${name}/` }));
+
+      } else if (msg.type === 'response') {
+        // Tunnel client returning an HTTP response
+        if (!msg.id) return;
+        const p = pending.get(msg.id);
+        if (p) {
+          clearTimeout(p.timer);
+          pending.delete(msg.id);
+          p.resolve({
+            status: msg.status || 502,
+            headers: msg.headers || {},
+            body: msg.body || ''
+          });
+        }
+      }
+    });
+
+    socket.on('close', () => {
+      if (tunnelName && tunnels.get(tunnelName)?.socket === socket) {
+        tunnels.delete(tunnelName);
+      }
+    });
+
+    socket.on('error', () => {});
+  });
+
+  // HTTP proxy: /tunnel/{name}/*
+  fastify.all('/tunnel/:name/*', async (request, reply) => {
+    const { name } = request.params;
+    const tunnel = tunnels.get(name);
+
+    if (!tunnel || tunnel.socket.readyState !== 1) {
+      return reply.code(502).send({ error: 'Bad Gateway', message: 'Tunnel not connected' });
+    }
+
+    // Build the downstream path (strip /tunnel/{name} prefix)
+    const fullPath = request.url.replace(`/tunnel/${name}`, '') || '/';
+    const id = randomUUID();
+
+    // Serialize the HTTP request
+    const tunnelReq = Object.create(null);
+    tunnelReq.type = 'request';
+    tunnelReq.id = id;
+    tunnelReq.method = request.method;
+    tunnelReq.path = fullPath;
+    tunnelReq.headers = Object.create(null);
+    // Forward relevant headers (skip hop-by-hop)
+    const skipHeaders = new Set(['host', 'connection', 'upgrade', 'transfer-encoding']);
+    for (const [k, v] of Object.entries(request.headers)) {
+      if (!skipHeaders.has(k.toLowerCase())) {
+        tunnelReq.headers[k] = v;
+      }
+    }
+    // Forward body if present
+    if (request.body) {
+      tunnelReq.body = Buffer.isBuffer(request.body)
+        ? request.body.toString('base64')
+        : typeof request.body === 'string' ? request.body : JSON.stringify(request.body);
+      tunnelReq.bodyEncoding = Buffer.isBuffer(request.body) ? 'base64' : 'utf8';
+    }
+
+    // Send to tunnel client and wait for response
+    const responsePromise = new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        resolve({ status: 504, headers: {}, body: 'Gateway Timeout' });
+      }, REQUEST_TIMEOUT);
+      pending.set(id, { resolve, timer });
+    });
+
+    try {
+      tunnel.socket.send(JSON.stringify(tunnelReq));
+    } catch {
+      pending.delete(id);
+      return reply.code(502).send({ error: 'Bad Gateway', message: 'Failed to reach tunnel client' });
+    }
+
+    const res = await responsePromise;
+
+    // Set response headers
+    const hopHeaders = new Set(['connection', 'transfer-encoding', 'keep-alive']);
+    for (const [k, v] of Object.entries(res.headers)) {
+      if (!hopHeaders.has(k.toLowerCase())) {
+        reply.header(k, v);
+      }
+    }
+
+    // Decode body if base64
+    const body = res.bodyEncoding === 'base64' && res.body
+      ? Buffer.from(res.body, 'base64')
+      : res.body || '';
+
+    return reply.code(res.status).send(body);
+  });
+
+  // Also handle /tunnel/{name} without trailing path
+  fastify.all('/tunnel/:name', async (request, reply) => {
+    // Redirect to add trailing slash, or proxy as root
+    const { name } = request.params;
+    const tunnel = tunnels.get(name);
+
+    if (!tunnel || tunnel.socket.readyState !== 1) {
+      return reply.code(502).send({ error: 'Bad Gateway', message: 'Tunnel not connected' });
+    }
+
+    return reply.redirect(`/tunnel/${name}/`);
+  });
+}
+
+export default tunnelPlugin;

--- a/src/tunnel/index.js
+++ b/src/tunnel/index.js
@@ -125,11 +125,13 @@ export async function tunnelPlugin(fastify, options = {}) {
     socket.on('close', () => {
       if (tunnelName && tunnels.get(tunnelName)?.socket === socket) {
         tunnels.delete(tunnelName);
-        // Resolve any pending requests for this tunnel with 502
+        // Resolve pending requests for this tunnel only with 502
         for (const [id, p] of pending) {
-          clearTimeout(p.timer);
-          pending.delete(id);
-          p.resolve({ status: 502, headers: {}, body: 'Tunnel disconnected' });
+          if (p.tunnelName === tunnelName) {
+            clearTimeout(p.timer);
+            pending.delete(id);
+            p.resolve({ status: 502, headers: {}, body: 'Tunnel disconnected' });
+          }
         }
       }
     });
@@ -158,7 +160,7 @@ export async function tunnelPlugin(fastify, options = {}) {
     tunnelReq.path = fullPath;
     tunnelReq.headers = Object.create(null);
     // Forward relevant headers (skip hop-by-hop)
-    const skipHeaders = new Set(['host', 'connection', 'upgrade', 'transfer-encoding']);
+    const skipHeaders = new Set(['host', 'connection', 'upgrade', 'transfer-encoding', 'cookie', 'authorization', 'proxy-authorization']);
     for (const [k, v] of Object.entries(request.headers)) {
       if (!skipHeaders.has(k.toLowerCase())) {
         tunnelReq.headers[k] = v;
@@ -178,7 +180,7 @@ export async function tunnelPlugin(fastify, options = {}) {
         pending.delete(id);
         resolve({ status: 504, headers: {}, body: 'Gateway Timeout' });
       }, REQUEST_TIMEOUT);
-      pending.set(id, { resolve, timer });
+      pending.set(id, { resolve, timer, tunnelName: name });
     });
 
     try {
@@ -192,7 +194,7 @@ export async function tunnelPlugin(fastify, options = {}) {
     const res = await responsePromise;
 
     // Set response headers
-    const hopHeaders = new Set(['connection', 'transfer-encoding', 'keep-alive']);
+    const hopHeaders = new Set(['connection', 'transfer-encoding', 'keep-alive', 'set-cookie']);
     for (const [k, v] of Object.entries(res.headers)) {
       if (!hopHeaders.has(k.toLowerCase())) {
         reply.header(k, v);

--- a/src/tunnel/index.js
+++ b/src/tunnel/index.js
@@ -115,7 +115,8 @@ export async function tunnelPlugin(fastify, options = {}) {
           p.resolve({
             status: msg.status || 502,
             headers: msg.headers || {},
-            body: msg.body || ''
+            body: msg.body || '',
+            bodyEncoding: msg.bodyEncoding
           });
         }
       }
@@ -124,6 +125,12 @@ export async function tunnelPlugin(fastify, options = {}) {
     socket.on('close', () => {
       if (tunnelName && tunnels.get(tunnelName)?.socket === socket) {
         tunnels.delete(tunnelName);
+        // Resolve any pending requests for this tunnel with 502
+        for (const [id, p] of pending) {
+          clearTimeout(p.timer);
+          pending.delete(id);
+          p.resolve({ status: 502, headers: {}, body: 'Tunnel disconnected' });
+        }
       }
     });
 
@@ -177,7 +184,8 @@ export async function tunnelPlugin(fastify, options = {}) {
     try {
       tunnel.socket.send(JSON.stringify(tunnelReq));
     } catch {
-      pending.delete(id);
+      const p = pending.get(id);
+      if (p) { clearTimeout(p.timer); pending.delete(id); }
       return reply.code(502).send({ error: 'Bad Gateway', message: 'Failed to reach tunnel client' });
     }
 
@@ -209,7 +217,7 @@ export async function tunnelPlugin(fastify, options = {}) {
       return reply.code(502).send({ error: 'Bad Gateway', message: 'Tunnel not connected' });
     }
 
-    return reply.redirect(`/tunnel/${name}/`);
+    return reply.redirect(308, `/tunnel/${name}/`);
   });
 }
 

--- a/test/tunnel.test.js
+++ b/test/tunnel.test.js
@@ -1,0 +1,202 @@
+/**
+ * Tunnel Proxy Tests
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { WebSocket } from 'ws';
+import {
+  startTestServer,
+  stopTestServer,
+  createTestPod,
+  getBaseUrl,
+  getPodToken
+} from './helpers.js';
+
+describe('Tunnel Proxy', () => {
+  let wsUrl, baseUrl;
+
+  before(async () => {
+    await startTestServer({ tunnel: true });
+    await createTestPod('tunneler');
+    baseUrl = getBaseUrl();
+    wsUrl = baseUrl.replace('http', 'ws') + '/.tunnel';
+  });
+
+  after(async () => {
+    await stopTestServer();
+  });
+
+  function connectTunnel() {
+    const token = getPodToken('tunneler');
+    return new WebSocket(wsUrl, {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+  }
+
+  function waitMsg(ws, type, timeout = 5000) {
+    return new Promise((resolve, reject) => {
+      function handler(data) {
+        const msg = JSON.parse(data.toString());
+        if (msg.type === type) {
+          clearTimeout(timer);
+          ws.removeListener('message', handler);
+          ws.removeListener('close', onClose);
+          resolve(msg);
+        }
+      }
+      function onClose() {
+        clearTimeout(timer);
+        ws.removeListener('message', handler);
+        reject(new Error(`WebSocket closed while waiting for "${type}"`));
+      }
+      const timer = setTimeout(() => {
+        ws.removeListener('message', handler);
+        ws.removeListener('close', onClose);
+        reject(new Error(`Timeout waiting for "${type}"`));
+      }, timeout);
+      ws.on('message', handler);
+      ws.on('close', onClose);
+    });
+  }
+
+  describe('Registration', () => {
+    it('should reject unauthenticated connections', async () => {
+      const ws = new WebSocket(wsUrl);
+      const msg = await waitMsg(ws, 'error');
+      assert.ok(msg.message.includes('Authentication'));
+      ws.close();
+    });
+
+    it('should register a tunnel name', async () => {
+      const ws = connectTunnel();
+      await new Promise(r => ws.on('open', r));
+
+      ws.send(JSON.stringify({ type: 'register', name: 'myapp' }));
+      const msg = await waitMsg(ws, 'registered');
+      assert.strictEqual(msg.name, 'myapp');
+      assert.strictEqual(msg.url, '/tunnel/myapp/');
+
+      ws.close();
+      await new Promise(r => setTimeout(r, 50));
+    });
+
+    it('should reject invalid tunnel names', async () => {
+      const ws = connectTunnel();
+      await new Promise(r => ws.on('open', r));
+
+      ws.send(JSON.stringify({ type: 'register', name: '...' }));
+      const msg = await waitMsg(ws, 'error');
+      assert.ok(msg.message.includes('Invalid'));
+
+      ws.close();
+      await new Promise(r => setTimeout(r, 50));
+    });
+  });
+
+  describe('HTTP Proxying', () => {
+    it('should proxy GET requests through the tunnel', async () => {
+      const ws = connectTunnel();
+      await new Promise(r => ws.on('open', r));
+
+      // Register tunnel
+      ws.send(JSON.stringify({ type: 'register', name: 'testapp' }));
+      await waitMsg(ws, 'registered');
+
+      // Listen for tunnel requests and respond
+      ws.on('message', (data) => {
+        const msg = JSON.parse(data.toString());
+        if (msg.type === 'request') {
+          ws.send(JSON.stringify({
+            type: 'response',
+            id: msg.id,
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ hello: 'world', path: msg.path })
+          }));
+        }
+      });
+
+      // Make HTTP request through the tunnel
+      const res = await fetch(`${baseUrl}/tunnel/testapp/api/hello`);
+      assert.strictEqual(res.status, 200);
+      const body = await res.json();
+      assert.strictEqual(body.hello, 'world');
+      assert.strictEqual(body.path, '/api/hello');
+
+      ws.close();
+      await new Promise(r => setTimeout(r, 50));
+    });
+
+    it('should proxy POST requests with body', async () => {
+      const ws = connectTunnel();
+      await new Promise(r => ws.on('open', r));
+
+      ws.send(JSON.stringify({ type: 'register', name: 'postapp' }));
+      await waitMsg(ws, 'registered');
+
+      ws.on('message', (data) => {
+        const msg = JSON.parse(data.toString());
+        if (msg.type === 'request') {
+          assert.strictEqual(msg.method, 'POST');
+          ws.send(JSON.stringify({
+            type: 'response',
+            id: msg.id,
+            status: 201,
+            headers: { 'content-type': 'text/plain' },
+            body: 'Created'
+          }));
+        }
+      });
+
+      const res = await fetch(`${baseUrl}/tunnel/postapp/items`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'test' })
+      });
+      assert.strictEqual(res.status, 201);
+      assert.strictEqual(await res.text(), 'Created');
+
+      ws.close();
+      await new Promise(r => setTimeout(r, 50));
+    });
+
+    it('should return 502 for unregistered tunnel', async () => {
+      const res = await fetch(`${baseUrl}/tunnel/nonexistent/path`);
+      assert.strictEqual(res.status, 502);
+    });
+
+    it('should forward custom headers', async () => {
+      const ws = connectTunnel();
+      await new Promise(r => ws.on('open', r));
+
+      ws.send(JSON.stringify({ type: 'register', name: 'headerapp' }));
+      await waitMsg(ws, 'registered');
+
+      let receivedHeaders;
+      ws.on('message', (data) => {
+        const msg = JSON.parse(data.toString());
+        if (msg.type === 'request') {
+          receivedHeaders = msg.headers;
+          ws.send(JSON.stringify({
+            type: 'response',
+            id: msg.id,
+            status: 200,
+            headers: { 'x-custom-response': 'from-tunnel' },
+            body: 'ok'
+          }));
+        }
+      });
+
+      const res = await fetch(`${baseUrl}/tunnel/headerapp/`, {
+        headers: { 'X-Custom-Request': 'to-tunnel' }
+      });
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(res.headers.get('x-custom-response'), 'from-tunnel');
+      assert.strictEqual(receivedHeaders['x-custom-request'], 'to-tunnel');
+
+      ws.close();
+      await new Promise(r => setTimeout(r, 50));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Tunnel HTTP traffic to a local dev server through JSS via WebSocket
- Tunnel client connects to `/.tunnel`, registers a name, receives proxied requests
- Public URL at `/tunnel/{name}/*` — like ngrok but through your Solid pod
- WebID authentication required, ~200 lines, no new dependencies

## Test plan
- [x] 340 tests pass (7 new tunnel tests)
- [x] Auth: reject unauthenticated, accept authenticated
- [x] Registration: valid name, invalid name
- [x] Proxying: GET, POST with body, custom headers, 502 for missing tunnel

Fixes #209