### PR TITLE
fix: N3 PATCH semicolon shorthand and 'a' keyword

### DIFF
--- a/src/patch/n3-patch.js
+++ b/src/patch/n3-patch.js
@@ -113,11 +113,18 @@ function splitStatements(content) {
   let current = '';
   let inString = false;
   let stringChar = null;
+  let inIri = false;
 
   for (let i = 0; i < content.length; i++) {
     const char = content[i];
 
-    if (!inString && (char === '"' || char === "'")) {
+    if (!inString && !inIri && char === '<') {
+      inIri = true;
+      current += char;
+    } else if (inIri && char === '>') {
+      inIri = false;
+      current += char;
+    } else if (!inIri && !inString && (char === '"' || char === "'")) {
       inString = true;
       stringChar = char;
       current += char;
@@ -125,12 +132,12 @@ function splitStatements(content) {
       inString = false;
       stringChar = null;
       current += char;
-    } else if (!inString && char === '.') {
+    } else if (!inString && !inIri && char === '.') {
       if (current.trim()) {
         statements.push(current);
       }
       current = '';
-    } else if (!inString && char === ';') {
+    } else if (!inString && !inIri && char === ';') {
       // Turtle shorthand - same subject, different predicate
       if (current.trim()) {
         statements.push(current);
@@ -440,7 +447,6 @@ function convertToJsonLd(object) {
  * Expand a potentially prefixed predicate to full URI
  */
 function expandPredicate(predicate) {
-  if (predicate === 'a') return 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
   const commonPrefixes = {
     'solid': SOLID_NS,
     'rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',

--- a/src/patch/n3-patch.js
+++ b/src/patch/n3-patch.js
@@ -57,6 +57,7 @@ export function parseN3Patch(patchText, baseUri) {
 
 /**
  * Parse triples from N3 block content
+ * Handles Turtle semicolon shorthand (same subject, different predicate-object)
  */
 function parseTriples(content, prefixes, baseUri) {
   const triples = [];
@@ -68,11 +69,37 @@ function parseTriples(content, prefixes, baseUri) {
   // Split by '.' but be careful with strings containing '.'
   const statements = splitStatements(content);
 
+  let lastSubject = null;
   for (const stmt of statements) {
-    const triple = parseStatement(stmt.trim(), prefixes, baseUri);
-    if (triple) {
-      triples.push(triple);
+    const trimmed = stmt.trim();
+    if (!trimmed) continue;
+
+    const tokens = tokenize(trimmed);
+    if (tokens.length < 2) continue;
+
+    let subject, predicate, object;
+
+    if (tokens.length >= 3) {
+      // Full triple: subject predicate object
+      subject = resolveValue(tokens[0], prefixes, baseUri);
+      predicate = resolveValue(tokens[1], prefixes, baseUri);
+      object = resolveValue(tokens.slice(2).join(' '), prefixes, baseUri);
+      lastSubject = subject;
+    } else if (tokens.length === 2 && lastSubject) {
+      // Semicolon continuation: predicate object (reuse last subject)
+      subject = lastSubject;
+      predicate = resolveValue(tokens[0], prefixes, baseUri);
+      object = resolveValue(tokens[1], prefixes, baseUri);
+    } else {
+      continue;
     }
+
+    // Handle 'a' as rdf:type
+    if (predicate === 'a') {
+      predicate = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+    }
+
+    triples.push({ subject, predicate, object });
   }
 
   return triples;
@@ -119,23 +146,6 @@ function splitStatements(content) {
   }
 
   return statements;
-}
-
-/**
- * Parse a single N3 statement into a triple
- */
-function parseStatement(stmt, prefixes, baseUri) {
-  if (!stmt) return null;
-
-  // Tokenize - split by whitespace but respect quotes
-  const tokens = tokenize(stmt);
-  if (tokens.length < 3) return null;
-
-  const subject = resolveValue(tokens[0], prefixes, baseUri);
-  const predicate = resolveValue(tokens[1], prefixes, baseUri);
-  const object = resolveValue(tokens.slice(2).join(' '), prefixes, baseUri);
-
-  return { subject, predicate, object };
 }
 
 /**
@@ -430,6 +440,7 @@ function convertToJsonLd(object) {
  * Expand a potentially prefixed predicate to full URI
  */
 function expandPredicate(predicate) {
+  if (predicate === 'a') return 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
   const commonPrefixes = {
     'solid': SOLID_NS,
     'rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -185,6 +185,52 @@ describe('PATCH Operations', () => {
       assert.ok(data['@graph'], 'Should have @graph');
       assert.strictEqual(data['@graph'].length, 2, 'Should have 2 nodes');
     });
+
+    it('should handle semicolon shorthand and rdf:type "a" keyword', async () => {
+      // Create initial resource with @graph
+      const initial = {
+        '@context': { 'solid': 'http://www.w3.org/ns/solid/terms#' },
+        '@graph': []
+      };
+
+      await request('/patchtest/public/patch-semicolon.json', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/ld+json' },
+        body: JSON.stringify(initial),
+        auth: 'patchtest'
+      });
+
+      // Use semicolons and 'a' keyword (Turtle shorthand)
+      const patch = `
+        @prefix solid: <http://www.w3.org/ns/solid/terms#>.
+        @prefix wf: <http://www.w3.org/2005/01/wf/flow#>.
+        _:patch a solid:InsertDeletePatch;
+          solid:inserts {
+            <#reg1> a solid:TypeRegistration;
+              solid:forClass wf:Tracker;
+              solid:instance <https://example.com/todo/data.jsonld#this>.
+          }.
+      `;
+
+      const res = await request('/patchtest/public/patch-semicolon.json', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'text/n3' },
+        body: patch,
+        auth: 'patchtest'
+      });
+
+      assertStatus(res, 204);
+
+      // Verify all three triples were inserted
+      const verify = await request('/patchtest/public/patch-semicolon.json');
+      const data = await verify.json();
+      const node = data['@graph'].find(n => n['@id'] && n['@id'].includes('#reg1'));
+      assert.ok(node, 'Should have the reg1 node');
+      assert.ok(node['rdf:type'] || node['http://www.w3.org/1999/02/22-rdf-syntax-ns#type'],
+        'Should have rdf:type (from "a" keyword)');
+      assert.ok(node['solid:forClass'], 'Should have solid:forClass');
+      assert.ok(node['solid:instance'], 'Should have solid:instance');
+    });
   });
 
   describe('PATCH Error Handling', () => {

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -226,10 +226,25 @@ describe('PATCH Operations', () => {
       const data = await verify.json();
       const node = data['@graph'].find(n => n['@id'] && n['@id'].includes('#reg1'));
       assert.ok(node, 'Should have the reg1 node');
-      assert.ok(node['rdf:type'] || node['http://www.w3.org/1999/02/22-rdf-syntax-ns#type'],
-        'Should have rdf:type (from "a" keyword)');
-      assert.ok(node['solid:forClass'], 'Should have solid:forClass');
-      assert.ok(node['solid:instance'], 'Should have solid:instance');
+
+      // Check rdf:type value (from 'a' keyword)
+      const rdfType = node['rdf:type'] || node['http://www.w3.org/1999/02/22-rdf-syntax-ns#type'];
+      assert.ok(rdfType, 'Should have rdf:type (from "a" keyword)');
+      const typeId = rdfType['@id'] || rdfType;
+      assert.ok(String(typeId).includes('TypeRegistration'), `rdf:type should be TypeRegistration, got ${typeId}`);
+
+      // Check solid:forClass value
+      const forClass = node['solid:forClass'];
+      assert.ok(forClass, 'Should have solid:forClass');
+      const forClassId = forClass['@id'] || forClass;
+      assert.ok(String(forClassId).includes('Tracker'), `solid:forClass should be Tracker, got ${forClassId}`);
+
+      // Check solid:instance value (contains a dot in the IRI - tests IRI splitting)
+      const instance = node['solid:instance'];
+      assert.ok(instance, 'Should have solid:instance');
+      const instanceId = instance['@id'] || instance;
+      assert.strictEqual(instanceId, 'https://example.com/todo/data.jsonld#this',
+        'solid:instance should have full IRI preserved');
     });
   });
 


### PR DESCRIPTION
## Summary
Two bugs in the N3 PATCH parser:

1. **Semicolon shorthand broken** — Turtle's `;` syntax (same subject, different predicate-object) split statements but dropped the subject. Continuation statements had only 2 tokens and were silently discarded.

2. **`a` keyword not recognized** — `a` is Turtle shorthand for `rdf:type` but was treated as a literal value.

## Fix
- Carry `lastSubject` forward across semicolon-separated statements
- Handle 2-token statements as predicate-object continuations
- Map `a` to `http://www.w3.org/1999/02/22-rdf-syntax-ns#type`

## Test
New test verifies the exact scenario from the bug report — TypeRegistration with semicolon shorthand and `a` keyword.

Fixes #212