### PR TITLE
docs: add missing feature documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,18 @@ Full options: [docs/configuration.md](docs/configuration.md)
 |-------|------|
 | Configuration & Options | [docs/configuration.md](docs/configuration.md) |
 | Authentication | [docs/authentication.md](docs/authentication.md) |
+| Mashlib / SolidOS UI | [docs/mashlib.md](docs/mashlib.md) |
+| WebSocket Notifications | [docs/notifications.md](docs/notifications.md) |
 | Git Support | [docs/git-support.md](docs/git-support.md) |
+| Nostr Relay | [docs/nostr.md](docs/nostr.md) |
 | ActivityPub & Mastodon API | [docs/activitypub.md](docs/activitypub.md) |
 | remoteStorage | [docs/remotestorage.md](docs/remotestorage.md) |
-| Security & Subdomain Mode | [docs/security.md](docs/security.md) |
-| HTTP 402 Payments | [docs/payments.md](docs/payments.md) |
 | WebRTC & Tunnel | [docs/webrtc.md](docs/webrtc.md) |
 | MongoDB `/db/` Route | [docs/mongodb.md](docs/mongodb.md) |
+| HTTP 402 Payments | [docs/payments.md](docs/payments.md) |
+| Storage Quotas | [docs/quotas.md](docs/quotas.md) |
+| Invite-Only Registration | [docs/invites.md](docs/invites.md) |
+| Security & Subdomain Mode | [docs/security.md](docs/security.md) |
 | Architecture & Structure | [docs/architecture.md](docs/architecture.md) |
 
 ## Comparison

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -355,43 +355,6 @@ jss quota reconcile alice
 
 Supported formats: `50MB`, `1GB`, `500KB`, `1TB`
 
-## Storage Quotas
-
-Limit storage per pod to prevent abuse and manage resources:
-
-```bash
-jss start --default-quota 50MB
-```
-
-### Managing Quotas
-
-```bash
-# Set quota for a user (overrides default)
-jss quota set alice 100MB
-
-# Show quota info
-jss quota show alice
-#   alice:
-#     Used:  12.5 MB
-#     Limit: 100 MB
-#     Free:  87.5 MB
-#     Usage: 12%
-
-# Recalculate from actual disk usage
-jss quota reconcile alice
-```
-
-### How It Works
-
-- Quotas are tracked incrementally on PUT, POST, and DELETE operations
-- When quota is exceeded, the server returns HTTP 507 Insufficient Storage
-- Each pod stores its quota in `/{pod}/.quota.json`
-- Use `reconcile` to fix quota drift from manual file changes
-
-### Size Formats
-
-Supported formats: `50MB`, `1GB`, `500KB`, `1TB`
-
 ### Mashlib Data Browser
 
 Enable the [SolidOS Mashlib](https://github.com/SolidOS/mashlib) data browser for RDF resources. Two modes are available:

--- a/docs/invites.md
+++ b/docs/invites.md
@@ -1,0 +1,43 @@
+# Invite-Only Registration
+
+Control who can create accounts by requiring invite codes.
+
+```bash
+jss start --idp --invite-only
+```
+
+## Managing Invite Codes
+
+```bash
+# Create a single-use invite
+jss invite create
+# Created invite code: ABCD1234
+
+# Create multi-use invite with note
+jss invite create -u 5 -n "For team members"
+
+# List all active invites
+jss invite list
+#   CODE        USES     CREATED      NOTE
+#   -------------------------------------------------------
+#   ABCD1234    0/1      2026-01-03
+#   EFGH5678    2/5      2026-01-03   For team members
+
+# Revoke an invite
+jss invite revoke ABCD1234
+```
+
+## How It Works
+
+| Mode | Registration | Pod Creation |
+|------|--------------|--------------|
+| Open (default) | Anyone can register | Anyone can create pods |
+| Invite-only | Requires valid invite code | Via registration only |
+
+When `--invite-only` is enabled:
+- The registration page shows an "Invite Code" field
+- Invalid or expired codes are rejected with an error
+- Each use decrements the invite's remaining uses
+- Depleted invites are automatically removed
+
+Invite codes are stored in `.server/invites.json` in your data directory.

--- a/docs/mashlib.md
+++ b/docs/mashlib.md
@@ -1,0 +1,58 @@
+# Mashlib Data Browser
+
+Enable the [SolidOS Mashlib](https://github.com/SolidOS/mashlib) data browser for RDF resources.
+
+## Modes
+
+**CDN Mode** (recommended for getting started):
+```bash
+jss start --mashlib-cdn --conneg
+```
+Loads mashlib from unpkg.com CDN. Zero footprint — no local files needed.
+
+**Local Mode** (for production/offline):
+```bash
+jss start --mashlib --conneg
+```
+Serves mashlib from `src/mashlib-local/dist/`. Requires building mashlib locally:
+```bash
+cd src/mashlib-local
+npm install && npm run build
+```
+
+**ES Module Mode** (for custom or next-gen mashlib builds):
+```bash
+jss start --mashlib-module https://example.com/mashlib.js
+```
+Loads an ES module-based data browser from any URL. Uses `<script type="module">` and `<div id="mashlib">` (self-initializing). CSS is auto-derived by replacing `.js` with `.css`. Content negotiation is auto-enabled.
+
+## How It Works
+
+1. Browser requests `/alice/public/data.ttl` with `Accept: text/html`
+2. Server returns Mashlib HTML wrapper
+3. Mashlib fetches the actual data via content negotiation
+4. Mashlib renders an interactive, editable view
+
+**Note:** Mashlib works best with `--conneg` enabled for Turtle support.
+
+## Modern UI (SolidOS UI)
+
+```bash
+jss start --mashlib --solidos-ui --conneg
+```
+
+Serves a modern Nextcloud-style UI shell while reusing mashlib's data layer:
+- Modern file browser with breadcrumb navigation
+- Profile, Contacts, Sharing, and Settings views
+- Path-based URLs (browser URL reflects current resource)
+- Responsive design for mobile devices
+
+Requires solidos-ui dist files in `src/mashlib-local/dist/solidos-ui/`. See [solidos-ui](https://github.com/solidos/solidos/tree/main/workspaces/solidos-ui) for details.
+
+## Profile Pages
+
+Pod profiles (`/alice/`) use HTML with embedded JSON-LD data islands and are rendered using:
+- [mashlib-jss](https://github.com/JavaScriptSolidServer/mashlib-jss) — A fork of mashlib with `getPod()` fix for path-based pods
+- [solidos-lite](https://github.com/SolidOS/solidos-lite) — Parses JSON-LD data islands into the RDF store
+
+This allows profiles to work without server-side content negotiation while still providing full SolidOS editing capabilities.

--- a/docs/nostr.md
+++ b/docs/nostr.md
@@ -1,0 +1,56 @@
+# Nostr Relay
+
+Integrated NIP-01/NIP-11/NIP-16 Nostr relay running on the same port as the Solid server.
+
+```bash
+jss start --nostr
+```
+
+## Endpoint
+
+`wss://your.pod/relay` (configurable via `--nostr-path`)
+
+## Supported NIPs
+
+- **NIP-01** — Basic protocol flow (EVENT, REQ, CLOSE)
+- **NIP-11** — Relay information document (`GET /relay` with `Accept: application/nostr+json`)
+- **NIP-16** — Event treatment (regular, replaceable, ephemeral)
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--nostr` | Enable Nostr relay | false |
+| `--nostr-path <path>` | WebSocket path | /relay |
+| `--nostr-max-events <n>` | Max events in memory | 1000 |
+
+## How It Works
+
+- Events are stored in memory (up to `--nostr-max-events`)
+- Replaceable events (kinds 0, 3, 10000-19999) replace previous events by the same pubkey
+- Ephemeral events (kinds 20000-29999) are broadcast but not stored
+- Parameterized replaceable events (kinds 30000-39999) use the `d` tag for deduplication
+- Rate limiting: 60 events per socket per minute
+
+## Client Usage
+
+```javascript
+import { Relay } from 'nostr-tools';
+
+const relay = await Relay.connect('wss://your.pod/relay');
+
+// Subscribe
+const sub = relay.subscribe([{ kinds: [1], limit: 10 }], {
+  onevent(event) { console.log(event); }
+});
+
+// Publish
+await relay.publish(signedEvent);
+```
+
+## Nostr Authentication (NIP-98)
+
+JSS also supports NIP-98 HTTP Auth for Solid operations. See [docs/authentication.md](authentication.md) for details on:
+- NIP-98 Schnorr signature authentication
+- `did:nostr` → WebID resolution
+- Linking Nostr identity to your WebID profile

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,50 @@
+# WebSocket Notifications
+
+Real-time notifications for resource changes using the solid-0.1 protocol (SolidOS compatible).
+
+```bash
+jss start --notifications
+```
+
+## Discovery
+
+Clients discover the WebSocket URL via the `Updates-Via` header:
+
+```bash
+curl -I http://localhost:3000/alice/public/
+# Updates-Via: ws://localhost:3000/.notifications
+```
+
+## Protocol
+
+```
+Server: protocol solid-0.1
+Client: sub http://localhost:3000/alice/public/data.json
+Server: ack http://localhost:3000/alice/public/data.json
+Server: pub http://localhost:3000/alice/public/data.json  (on change)
+```
+
+## How It Works
+
+1. Client connects to the WebSocket URL from `Updates-Via`
+2. Server sends `protocol solid-0.1` greeting
+3. Client subscribes: `sub <resource-url>`
+4. Server acknowledges: `ack <resource-url>`
+5. On any change (PUT, PATCH, DELETE), server broadcasts: `pub <resource-url>`
+6. Container subscriptions also fire when child resources change
+
+## ACL Enforcement
+
+- Anonymous clients can subscribe to public resources
+- Private resource subscriptions require authentication
+- Cross-origin subscriptions are rejected
+
+## Live Reload
+
+For development, `--live-reload` injects a script that auto-refreshes the browser when files change on disk:
+
+```bash
+jss start --live-reload --notifications
+```
+
+File system changes (editing files directly) also trigger WebSocket notifications.

--- a/docs/quotas.md
+++ b/docs/quotas.md
@@ -1,0 +1,36 @@
+# Storage Quotas
+
+Limit storage per pod to prevent abuse and manage resources.
+
+```bash
+jss start --default-quota 50MB
+```
+
+## Managing Quotas
+
+```bash
+# Set quota for a user (overrides default)
+jss quota set alice 100MB
+
+# Show quota info
+jss quota show alice
+#   alice:
+#     Used:  12.5 MB
+#     Limit: 100 MB
+#     Free:  87.5 MB
+#     Usage: 12%
+
+# Recalculate from actual disk usage
+jss quota reconcile alice
+```
+
+## How It Works
+
+- Quotas are tracked incrementally on PUT, POST, and DELETE operations
+- When quota is exceeded, the server returns HTTP 507 Insufficient Storage
+- Each pod stores its quota in `/{pod}/.quota.json`
+- Use `reconcile` to fix quota drift from manual file changes
+
+## Size Formats
+
+Supported formats: `50MB`, `1GB`, `500KB`, `1TB`


### PR DESCRIPTION
## Summary

5 new docs for features that had no standalone documentation:

- **docs/nostr.md** — relay, NIP-01/11/16, client usage, auth
- **docs/notifications.md** — WebSocket solid-0.1 protocol, live reload
- **docs/quotas.md** — storage limits, CLI management
- **docs/invites.md** — invite-only registration, invite codes
- **docs/mashlib.md** — data browser modes (CDN/local/ES module), SolidOS UI, profile pages

Also:
- README docs table updated with all 15 doc pages
- Fixed duplicate quotas section in configuration.md

Fixes #218