### PR TITLE
Add text/markdown support

### DIFF
--- a/src/mashlib/index.js
+++ b/src/mashlib/index.js
@@ -104,7 +104,8 @@ export function shouldServeMashlib(request, mashlibEnabled, contentType) {
     'application/json',
     'text/n3',
     'application/n-triples',
-    'application/rdf+xml'
+    'application/rdf+xml',
+    'text/markdown'
   ];
 
   const baseType = contentType.split(';')[0].trim().toLowerCase();

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -210,7 +210,8 @@ export function getContentType(filePath) {
     '.nt': 'application/n-triples',
     '.rdf': 'application/rdf+xml',
     '.nq': 'application/n-quads',
-    '.trig': 'application/trig'
+    '.trig': 'application/trig',
+    '.md': 'text/markdown'
   };
   return types[ext] || 'application/octet-stream';
 }


### PR DESCRIPTION
## Summary
- Add `.md` -> `text/markdown` mapping to `getContentType()` in `src/utils/url.js` so `.md` files are served with the correct MIME type
- Add `text/markdown` to the `rdfTypes` array in `shouldServeMashlib()` in `src/mashlib/index.js` so Mashlib renders markdown resources when accessed via browser

Fixes #226

## Test plan
- [ ] Verify `.md` files are served with `Content-Type: text/markdown`
- [ ] Verify Mashlib intercepts and renders `.md` resources when browsing with `Accept: text/html`
- [ ] Verify existing content type mappings and mashlib behavior are unchanged