### PR TITLE
Add M3U/M3U8/PLS playlist content type support

### DIFF
--- a/src/mashlib/index.js
+++ b/src/mashlib/index.js
@@ -105,7 +105,10 @@ export function shouldServeMashlib(request, mashlibEnabled, contentType) {
     'text/n3',
     'application/n-triples',
     'application/rdf+xml',
-    'text/markdown'
+    'text/markdown',
+    'audio/mpegurl',
+    'application/vnd.apple.mpegurl',
+    'audio/x-scpls'
   ];
 
   const baseType = contentType.split(';')[0].trim().toLowerCase();

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -211,7 +211,10 @@ export function getContentType(filePath) {
     '.rdf': 'application/rdf+xml',
     '.nq': 'application/n-quads',
     '.trig': 'application/trig',
-    '.md': 'text/markdown'
+    '.md': 'text/markdown',
+    '.m3u': 'audio/mpegurl',
+    '.m3u8': 'application/vnd.apple.mpegurl',
+    '.pls': 'audio/x-scpls'
   };
   return types[ext] || 'application/octet-stream';
 }


### PR DESCRIPTION
## Summary
- Add `.m3u` (`audio/mpegurl`), `.m3u8` (`application/vnd.apple.mpegurl`), and `.pls` (`audio/x-scpls`) to the content type map in `src/utils/url.js`
- Add the corresponding MIME types to the mashlib `rdfTypes` array in `src/mashlib/index.js` so the data browser serves them

Fixes #228

## Test plan
- [ ] Verify `.m3u` files are served with `audio/mpegurl` content type
- [ ] Verify `.m3u8` files are served with `application/vnd.apple.mpegurl` content type
- [ ] Verify `.pls` files are served with `audio/x-scpls` content type
- [ ] Verify mashlib renders these content types when browsing with `Accept: text/html`