### PR TITLE
Fix terminal plugin bugs

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -253,7 +253,7 @@ export function createServer(options = {}) {
 
   // Register terminal (WebSocket shell) if enabled
   if (terminalEnabled) {
-    fastify.register(terminalPlugin, { path: '/.terminal' });
+    fastify.register(terminalPlugin, { path: '/.terminal', public: options.public || false });
   }
 
   // Register tunnel proxy if enabled

--- a/src/terminal/index.js
+++ b/src/terminal/index.js
@@ -64,7 +64,8 @@ export async function terminalPlugin(fastify, options = {}) {
     }
 
     // Spawn shell
-    const shell = spawn('/bin/bash', ['-i'], {
+    const shellCommand = process.env.SHELL || 'bash';
+    const shell = spawn(shellCommand, ['-i'], {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, TERM: 'xterm-256color' },
     });
@@ -74,14 +75,14 @@ export async function terminalPlugin(fastify, options = {}) {
     // Pipe shell stdout to WebSocket
     shell.stdout.on('data', (data) => {
       if (socket.readyState === 1) {
-        try { socket.send(data.toString().replace(/\n/g, '\r\n')); } catch { /* socket closed */ }
+        try { socket.send(data.toString().replace(/\r?\n/g, '\r\n')); } catch { /* socket closed */ }
       }
     });
 
     // Pipe shell stderr to WebSocket
     shell.stderr.on('data', (data) => {
       if (socket.readyState === 1) {
-        try { socket.send(data.toString().replace(/\n/g, '\r\n')); } catch { /* socket closed */ }
+        try { socket.send(data.toString().replace(/\r?\n/g, '\r\n')); } catch { /* socket closed */ }
       }
     });
 

--- a/src/terminal/index.js
+++ b/src/terminal/index.js
@@ -48,7 +48,7 @@ export async function terminalPlugin(fastify, options = {}) {
   });
 
   fastify.get(wsPath, { websocket: true }, async (connection, request) => {
-    const socket = connection.socket;
+    const socket = connection.socket || connection;
 
     // Authenticate — query param token support for browser WebSocket
     const queryToken = request.query?.token;
@@ -57,14 +57,14 @@ export async function terminalPlugin(fastify, options = {}) {
     }
     const { webId } = await getWebIdFromRequestAsync(request);
 
-    if (!webId) {
+    if (!webId && !options.public) {
       socket.send(JSON.stringify({ type: 'error', message: 'Authentication required' }));
       socket.close();
       return;
     }
 
     // Spawn shell
-    const shell = spawn('/bin/sh', [], {
+    const shell = spawn('/bin/bash', ['-i'], {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, TERM: 'xterm-256color' },
     });
@@ -74,14 +74,14 @@ export async function terminalPlugin(fastify, options = {}) {
     // Pipe shell stdout to WebSocket
     shell.stdout.on('data', (data) => {
       if (socket.readyState === 1) {
-        try { socket.send(data); } catch { /* socket closed */ }
+        try { socket.send(data.toString().replace(/\n/g, '\r\n')); } catch { /* socket closed */ }
       }
     });
 
     // Pipe shell stderr to WebSocket
     shell.stderr.on('data', (data) => {
       if (socket.readyState === 1) {
-        try { socket.send(data); } catch { /* socket closed */ }
+        try { socket.send(data.toString().replace(/\n/g, '\r\n')); } catch { /* socket closed */ }
       }
     });
 


### PR DESCRIPTION
## Summary
- **Socket reference**: Use `connection.socket || connection` fallback for @fastify/websocket compatibility across versions
- **Shell command**: Spawn `/bin/bash -i` (interactive) instead of `/bin/sh` for proper prompt and shell features
- **PTY newlines**: Convert `\n` to `\r\n` on stdout/stderr before sending to WebSocket, fixing terminal rendering
- **Public mode auth**: Skip authentication when `options.public` is true; pass `public` option from server.js to the terminal plugin

Fixes #237

## Test plan
- [ ] Start server with `--terminal --public` and connect via WebSocket — should get a shell without auth
- [ ] Start server with `--terminal` (no `--public`) without auth token — should get "Authentication required" error
- [ ] Verify terminal output renders newlines correctly (no missing carriage returns)
- [ ] Verify bash prompt appears (interactive shell)