### PR TITLE
feat: HTTP 402 payment-gated resources

### DIFF
--- a/docs/payments.md
+++ b/docs/payments.md
@@ -1,5 +1,42 @@
 ## HTTP 402 Paid Access
 
+JSS supports two approaches to paid content:
+
+1. **ACL Conditions** — any resource at any URL can require payment via `acl:condition` in its ACL file
+2. **Pay Route** — the `/pay/*` prefix provides a full payment backend with deposits, balances, and token trading
+
+### ACL-Based Payments (Generic)
+
+Any resource can be payment-gated by adding a `PaymentCondition` to its ACL:
+
+```json
+{
+  "@context": { "acl": "http://www.w3.org/ns/auth/acl#" },
+  "@graph": [{
+    "@type": "acl:Authorization",
+    "acl:agentClass": { "@id": "acl:AuthenticatedAgent" },
+    "acl:accessTo": { "@id": "/premium/article.jsonld" },
+    "acl:mode": [{ "@id": "acl:Read" }],
+    "acl:condition": {
+      "@type": "PaymentCondition",
+      "amount": "1000",
+      "currency": "sats"
+    }
+  }]
+}
+```
+
+When a client requests the resource:
+
+1. Server evaluates the ACL and finds the `PaymentCondition`
+2. Server responds with `402 Payment Required` and payment details in the body
+3. Client completes payment and retries with proof
+4. Server verifies and grants access
+
+**Design: fail-closed** — if the server encounters a condition type it doesn't support, access is denied. Unsupported conditions are never silently ignored.
+
+### Pay Route (Full Backend)
+
 Monetize API endpoints with per-request satoshi payments. Resources under `/pay/*` require NIP-98 authentication and a positive balance.
 
 ```bash

--- a/src/auth/middleware.js
+++ b/src/auth/middleware.js
@@ -102,7 +102,7 @@ export async function authorize(request, reply, options = {}) {
   }
 
   // Check WAC permissions
-  const { allowed, wacAllow } = await checkAccess({
+  const { allowed, wacAllow, paymentRequired } = await checkAccess({
     resourceUrl: checkUrl,
     resourcePath: checkPath,
     isContainer: checkIsContainer,
@@ -110,7 +110,7 @@ export async function authorize(request, reply, options = {}) {
     requiredMode
   });
 
-  return { authorized: allowed, webId, wacAllow, authError };
+  return { authorized: allowed, webId, wacAllow, authError, paymentRequired };
 }
 
 /**

--- a/src/server.js
+++ b/src/server.js
@@ -389,9 +389,13 @@ export function createServer(options = {}) {
       const requiredMode = needsWrite ? AccessMode.WRITE : AccessMode.READ;
 
       // Run WAC authorization with the correct mode for git operations
-      const { authorized, webId, wacAllow, authError } = await authorize(request, reply, { requiredMode });
+      const { authorized, webId, wacAllow, authError, paymentRequired } = await authorize(request, reply, { requiredMode });
       request.webId = webId;
       request.wacAllow = wacAllow;
+
+      if (paymentRequired) {
+        return reply.code(402).send({ type: 'PaymentRequired', ...paymentRequired });
+      }
 
       if (!authorized) {
         const message = needsWrite ? 'Write access required for push' : 'Read access required for clone';
@@ -444,7 +448,7 @@ export function createServer(options = {}) {
       return;
     }
 
-    const { authorized, webId, wacAllow, authError } = await authorize(request, reply);
+    const { authorized, webId, wacAllow, authError, paymentRequired } = await authorize(request, reply);
 
     // Store webId and wacAllow on request for handlers to use
     request.webId = webId;
@@ -452,6 +456,14 @@ export function createServer(options = {}) {
 
     // Set WAC-Allow header for all responses (handlers may override)
     reply.header('WAC-Allow', wacAllow);
+
+    // Handle payment-gated resources
+    if (paymentRequired) {
+      return reply.code(402).send({
+        type: 'PaymentRequired',
+        ...paymentRequired
+      });
+    }
 
     if (!authorized) {
       return handleUnauthorized(request, reply, webId !== null, wacAllow, authError);

--- a/src/wac/checker.js
+++ b/src/wac/checker.js
@@ -37,7 +37,7 @@ export async function checkAccess({
 
   // Check authorizations
   // Note: For default ACLs, we check if the ACL's default rules apply to the actual resource URL
-  const allowed = checkAuthorizations(
+  const result = checkAuthorizations(
     authorizations,
     resourceUrl,  // Use actual resource URL, not the ACL container URL
     agentWebId,
@@ -48,7 +48,7 @@ export async function checkAccess({
   // Calculate WAC-Allow header
   const wacAllow = calculateWacAllow(authorizations, resourceUrl, agentWebId, isDefault);
 
-  return { allowed, wacAllow };
+  return { allowed: result.allowed, wacAllow, paymentRequired: result.paymentRequired || null };
 }
 
 /**
@@ -125,6 +125,9 @@ function getParentPath(path) {
 /**
  * Check if any authorization grants the required mode
  */
+// Supported condition types
+const SUPPORTED_CONDITIONS = ['PaymentCondition', 'https://webacl.org/ns#PaymentCondition'];
+
 function checkAuthorizations(authorizations, targetUrl, agentWebId, requiredMode, isDefault) {
   for (const auth of authorizations) {
     // For default ACLs, check if auth has default rules and matches target
@@ -144,17 +147,29 @@ function checkAuthorizations(authorizations, targetUrl, agentWebId, requiredMode
     if (!agentAuthorized) continue;
 
     // Check if mode is granted
-    if (auth.modes.includes(requiredMode)) {
-      return true;
+    const modeGranted = auth.modes.includes(requiredMode) ||
+      (requiredMode === AccessMode.APPEND && auth.modes.includes(AccessMode.WRITE));
+    if (!modeGranted) continue;
+
+    // Check conditions (fail-closed)
+    if (auth.conditions && auth.conditions.length > 0) {
+      // Fail-closed: skip this auth if any condition type is unsupported
+      const unsupported = auth.conditions.find(c => !SUPPORTED_CONDITIONS.includes(c.type));
+      if (unsupported) continue;
+
+      // Check payment condition
+      const paymentCondition = auth.conditions.find(c =>
+        c.type === 'PaymentCondition' || c.type === 'https://webacl.org/ns#PaymentCondition'
+      );
+      if (paymentCondition) {
+        return { allowed: false, paymentRequired: paymentCondition };
+      }
     }
 
-    // Write implies Append
-    if (requiredMode === AccessMode.APPEND && auth.modes.includes(AccessMode.WRITE)) {
-      return true;
-    }
+    return { allowed: true };
   }
 
-  return false;
+  return { allowed: false };
 }
 
 /**

--- a/src/wac/parser.js
+++ b/src/wac/parser.js
@@ -133,7 +133,8 @@ function parseAuthorization(node, aclUrl) {
     agents: [],        // Specific WebIDs
     agentClasses: [],  // Agent classes (public, authenticated)
     agentGroups: [],   // Groups
-    modes: []          // Access modes
+    modes: [],         // Access modes
+    conditions: []     // Access conditions (e.g. PaymentCondition)
   };
 
   // Parse accessTo - resolve relative URLs
@@ -157,7 +158,24 @@ function parseAuthorization(node, aclUrl) {
   // Parse modes
   auth.modes = parseUriArray(node['acl:mode'] || node['mode']).map(normalizeMode);
 
+  // Parse conditions
+  auth.conditions = parseConditions(node['acl:condition'] || node['condition']);
+
   return auth;
+}
+
+/**
+ * Parse conditions from an authorization node
+ */
+function parseConditions(value) {
+  if (!value) return [];
+  const values = Array.isArray(value) ? value : [value];
+  return values.map(v => {
+    if (typeof v !== 'object' || v === null) return null;
+    const type = v['@type'] || v.type;
+    if (!type) return null;
+    return { ...v, type };
+  }).filter(Boolean);
 }
 
 /**

--- a/test/wac.test.js
+++ b/test/wac.test.js
@@ -335,3 +335,124 @@ describe('WAC Integration', () => {
     });
   });
 });
+
+describe('WAC Conditions', () => {
+  describe('parseAcl with conditions', () => {
+    it('should parse a PaymentCondition', async () => {
+      const acl = {
+        '@context': { 'acl': 'http://www.w3.org/ns/auth/acl#' },
+        '@graph': [{
+          '@id': '#paid',
+          '@type': 'acl:Authorization',
+          'acl:agentClass': { '@id': 'acl:AuthenticatedAgent' },
+          'acl:accessTo': { '@id': 'https://alice.example/premium/article.jsonld' },
+          'acl:mode': [{ '@id': 'acl:Read' }],
+          'acl:condition': {
+            '@type': 'PaymentCondition',
+            'amount': '1000',
+            'currency': 'sats'
+          }
+        }]
+      };
+
+      const auths = await parseAcl(JSON.stringify(acl), 'https://alice.example/premium/.acl');
+
+      assert.strictEqual(auths.length, 1);
+      assert.strictEqual(auths[0].conditions.length, 1);
+      assert.strictEqual(auths[0].conditions[0].type, 'PaymentCondition');
+      assert.strictEqual(auths[0].conditions[0].amount, '1000');
+      assert.strictEqual(auths[0].conditions[0].currency, 'sats');
+    });
+
+    it('should parse multiple conditions', async () => {
+      const acl = {
+        '@context': { 'acl': 'http://www.w3.org/ns/auth/acl#' },
+        '@graph': [{
+          '@id': '#restricted',
+          '@type': 'acl:Authorization',
+          'acl:agent': { '@id': 'https://bob.example/#me' },
+          'acl:accessTo': { '@id': 'https://alice.example/resource' },
+          'acl:mode': [{ '@id': 'acl:Read' }],
+          'acl:condition': [
+            { '@type': 'PaymentCondition', 'amount': '500', 'currency': 'sats' },
+            { '@type': 'ClientCondition', 'client': 'https://trusted.app/pane.js' }
+          ]
+        }]
+      };
+
+      const auths = await parseAcl(JSON.stringify(acl), 'https://alice.example/.acl');
+
+      assert.strictEqual(auths[0].conditions.length, 2);
+      assert.strictEqual(auths[0].conditions[0].type, 'PaymentCondition');
+      assert.strictEqual(auths[0].conditions[1].type, 'ClientCondition');
+    });
+
+    it('should parse authorization without conditions', async () => {
+      const acl = {
+        '@context': { 'acl': 'http://www.w3.org/ns/auth/acl#' },
+        '@graph': [{
+          '@id': '#public',
+          '@type': 'acl:Authorization',
+          'acl:agentClass': { '@id': 'http://xmlns.com/foaf/0.1/Agent' },
+          'acl:accessTo': { '@id': 'https://alice.example/public/' },
+          'acl:mode': [{ '@id': 'acl:Read' }]
+        }]
+      };
+
+      const auths = await parseAcl(JSON.stringify(acl), 'https://alice.example/.acl');
+
+      assert.strictEqual(auths[0].conditions.length, 0);
+    });
+  });
+
+  describe('fail-closed conditions', () => {
+    it('should parse unsupported condition types', async () => {
+      const acl = {
+        '@context': { 'acl': 'http://www.w3.org/ns/auth/acl#' },
+        '@graph': [{
+          '@id': '#restricted',
+          '@type': 'acl:Authorization',
+          'acl:agent': { '@id': 'https://bob.example/#me' },
+          'acl:accessTo': { '@id': 'https://alice.example/resource' },
+          'acl:mode': [{ '@id': 'acl:Read' }],
+          'acl:condition': {
+            '@type': 'UnknownFutureCondition',
+            'foo': 'bar'
+          }
+        }]
+      };
+
+      const auths = await parseAcl(JSON.stringify(acl), 'https://alice.example/.acl');
+
+      assert.strictEqual(auths[0].conditions.length, 1);
+      assert.strictEqual(auths[0].conditions[0].type, 'UnknownFutureCondition');
+    });
+
+    it('should parse PaymentCondition with all fields', async () => {
+      const acl = {
+        '@context': { 'acl': 'http://www.w3.org/ns/auth/acl#' },
+        '@graph': [{
+          '@id': '#paid',
+          '@type': 'acl:Authorization',
+          'acl:agentClass': { '@id': 'acl:AuthenticatedAgent' },
+          'acl:accessTo': { '@id': 'https://alice.example/premium/article.jsonld' },
+          'acl:mode': [{ '@id': 'acl:Read' }],
+          'acl:condition': {
+            '@type': 'PaymentCondition',
+            'amount': '1000',
+            'currency': 'sats',
+            'protocol': 'lightning'
+          }
+        }]
+      };
+
+      const auths = await parseAcl(JSON.stringify(acl), 'https://alice.example/premium/.acl');
+      const condition = auths[0].conditions[0];
+
+      assert.strictEqual(condition.type, 'PaymentCondition');
+      assert.strictEqual(condition.amount, '1000');
+      assert.strictEqual(condition.currency, 'sats');
+      assert.strictEqual(condition.protocol, 'lightning');
+    });
+  });
+});


### PR DESCRIPTION
Add support for payment-gated resources using HTTP 402.

When a resource's ACL includes a `PaymentCondition`, the server responds with `402 Payment Required` and payment details in the response body. Access is granted upon proof of payment.

Design: fail-closed — unsupported condition types cause the authorization to be skipped, denying access rather than silently ignoring conditions.

Closes #239