### PR TITLE
fix: rename Settings/ to settings/ for consistency

### DIFF
--- a/src/handlers/container.js
+++ b/src/handlers/container.js
@@ -165,12 +165,12 @@ export async function createPodStructure(name, webId, podUri, issuer, defaultQuo
   const podPath = `/${name}/`;
 
   // Create pod directory structure
-  // Uses 'Settings' (capital S) for mashlib compatibility
+  // Pod settings directory
   await storage.createContainer(podPath);
   await storage.createContainer(`${podPath}inbox/`);
   await storage.createContainer(`${podPath}public/`);
   await storage.createContainer(`${podPath}private/`);
-  await storage.createContainer(`${podPath}Settings/`);
+  await storage.createContainer(`${podPath}settings/`);
   await storage.createContainer(`${podPath}profile/`);
 
   // Generate and write WebID profile at /profile/card (standard Solid location)
@@ -179,14 +179,14 @@ export async function createPodStructure(name, webId, podUri, issuer, defaultQuo
 
   // Generate and write preferences (mashlib-compatible paths)
   const prefs = generatePreferences({ webId, podUri });
-  await storage.write(`${podPath}Settings/Preferences.ttl`, serialize(prefs));
+  await storage.write(`${podPath}settings/Preferences.ttl`, serialize(prefs));
 
   // Generate and write type indexes with .ttl extension for mashlib
-  const publicTypeIndex = generateTypeIndex(`${podUri}Settings/publicTypeIndex.ttl`);
-  await storage.write(`${podPath}Settings/publicTypeIndex.ttl`, serialize(publicTypeIndex));
+  const publicTypeIndex = generateTypeIndex(`${podUri}settings/publicTypeIndex.ttl`);
+  await storage.write(`${podPath}settings/publicTypeIndex.ttl`, serialize(publicTypeIndex));
 
-  const privateTypeIndex = generateTypeIndex(`${podUri}Settings/privateTypeIndex.ttl`);
-  await storage.write(`${podPath}Settings/privateTypeIndex.ttl`, serialize(privateTypeIndex));
+  const privateTypeIndex = generateTypeIndex(`${podUri}settings/privateTypeIndex.ttl`);
+  await storage.write(`${podPath}settings/privateTypeIndex.ttl`, serialize(privateTypeIndex));
 
   // Create default ACL files
   // Pod root: owner full control, public read
@@ -197,9 +197,9 @@ export async function createPodStructure(name, webId, podUri, issuer, defaultQuo
   const privateAcl = generatePrivateAcl(`${podUri}private/`, webId);
   await storage.write(`${podPath}private/.acl`, serializeAcl(privateAcl));
 
-  // Settings folder: owner only
-  const settingsAcl = generatePrivateAcl(`${podUri}Settings/`, webId);
-  await storage.write(`${podPath}Settings/.acl`, serializeAcl(settingsAcl));
+  // settings folder: owner only
+  const settingsAcl = generatePrivateAcl(`${podUri}settings/`, webId);
+  await storage.write(`${podPath}settings/.acl`, serializeAcl(settingsAcl));
 
   // Inbox: owner full, public append
   const inboxAcl = generateInboxAcl(`${podUri}inbox/`, webId);

--- a/src/server.js
+++ b/src/server.js
@@ -571,7 +571,7 @@ export function createServer(options = {}) {
     await storage.createContainer('/inbox/');
     await storage.createContainer('/public/');
     await storage.createContainer('/private/');
-    await storage.createContainer('/Settings/');
+    await storage.createContainer('/settings/');
     await storage.createContainer('/profile/');
 
     // Generate profile
@@ -580,13 +580,13 @@ export function createServer(options = {}) {
 
     // Preferences and type indexes
     const prefs = generatePreferences({ webId, podUri });
-    await storage.write('/Settings/Preferences.ttl', serialize(prefs));
+    await storage.write('/settings/Preferences.ttl', serialize(prefs));
 
-    const publicTypeIndex = generateTypeIndex(`${podUri}Settings/publicTypeIndex.ttl`);
-    await storage.write('/Settings/publicTypeIndex.ttl', serialize(publicTypeIndex));
+    const publicTypeIndex = generateTypeIndex(`${podUri}settings/publicTypeIndex.ttl`);
+    await storage.write('/settings/publicTypeIndex.ttl', serialize(publicTypeIndex));
 
-    const privateTypeIndex = generateTypeIndex(`${podUri}Settings/privateTypeIndex.ttl`);
-    await storage.write('/Settings/privateTypeIndex.ttl', serialize(privateTypeIndex));
+    const privateTypeIndex = generateTypeIndex(`${podUri}settings/privateTypeIndex.ttl`);
+    await storage.write('/settings/privateTypeIndex.ttl', serialize(privateTypeIndex));
 
     // ACL files
     const rootAcl = generateOwnerAcl(podUri, webId, true);
@@ -595,8 +595,8 @@ export function createServer(options = {}) {
     const privateAcl = generatePrivateAcl(`${podUri}private/`, webId);
     await storage.write('/private/.acl', serializeAcl(privateAcl));
 
-    const settingsAcl = generatePrivateAcl(`${podUri}Settings/`, webId);
-    await storage.write('/Settings/.acl', serializeAcl(settingsAcl));
+    const settingsAcl = generatePrivateAcl(`${podUri}settings/`, webId);
+    await storage.write('/settings/.acl', serializeAcl(settingsAcl));
 
     const inboxAcl = generateInboxAcl(`${podUri}inbox/`, webId);
     await storage.write('/inbox/.acl', serializeAcl(inboxAcl));

--- a/src/webid/profile.js
+++ b/src/webid/profile.js
@@ -45,9 +45,9 @@ export function generateProfileJsonLd({ webId, name, podUri, issuer }) {
     'inbox': `${pod}inbox/`,
     'storage': pod,
     'oidcIssuer': issuer,
-    'preferencesFile': `${pod}Settings/Preferences.ttl`,
-    'publicTypeIndex': `${pod}Settings/publicTypeIndex.ttl`,
-    'privateTypeIndex': `${pod}Settings/privateTypeIndex.ttl`
+    'preferencesFile': `${pod}settings/Preferences.ttl`,
+    'publicTypeIndex': `${pod}settings/publicTypeIndex.ttl`,
+    'privateTypeIndex': `${pod}settings/privateTypeIndex.ttl`
   };
 }
 
@@ -133,7 +133,7 @@ function escapeHtml(str) {
 
 /**
  * Generate preferences file as JSON-LD
- * Uses mashlib-compatible paths (Settings/Preferences.ttl)
+ * Uses mashlib-compatible paths (settings/Preferences.ttl)
  * @param {object} options
  * @param {string} options.webId - Full WebID URI
  * @param {string} options.podUri - Pod root URI
@@ -149,9 +149,9 @@ export function generatePreferences({ webId, podUri }) {
       'publicTypeIndex': { '@id': 'solid:publicTypeIndex', '@type': '@id' },
       'privateTypeIndex': { '@id': 'solid:privateTypeIndex', '@type': '@id' }
     },
-    '@id': `${pod}Settings/Preferences.ttl`,
-    'publicTypeIndex': `${pod}Settings/publicTypeIndex.ttl`,
-    'privateTypeIndex': `${pod}Settings/privateTypeIndex.ttl`
+    '@id': `${pod}settings/Preferences.ttl`,
+    'publicTypeIndex': `${pod}settings/publicTypeIndex.ttl`,
+    'privateTypeIndex': `${pod}settings/privateTypeIndex.ttl`
   };
 }
 

--- a/test/pod.test.js
+++ b/test/pod.test.js
@@ -96,7 +96,7 @@ describe('Pod Lifecycle', () => {
       assertStatus(priv, 200);
 
       // Check Settings exists (needs auth)
-      const settings = await request('/carol/Settings/', { auth: 'carol' });
+      const settings = await request('/carol/settings/', { auth: 'carol' });
       assertStatus(settings, 200);
     });
 
@@ -104,15 +104,15 @@ describe('Pod Lifecycle', () => {
       await createTestPod('dan');
 
       // Check Preferences.ttl (needs auth - Settings is private)
-      const prefs = await request('/dan/Settings/Preferences.ttl', { auth: 'dan' });
+      const prefs = await request('/dan/settings/Preferences.ttl', { auth: 'dan' });
       assertStatus(prefs, 200);
 
       // Check public type index (needs auth)
-      const pubIndex = await request('/dan/Settings/publicTypeIndex.ttl', { auth: 'dan' });
+      const pubIndex = await request('/dan/settings/publicTypeIndex.ttl', { auth: 'dan' });
       assertStatus(pubIndex, 200);
 
       // Check private type index (needs auth)
-      const privIndex = await request('/dan/Settings/privateTypeIndex.ttl', { auth: 'dan' });
+      const privIndex = await request('/dan/settings/privateTypeIndex.ttl', { auth: 'dan' });
       assertStatus(privIndex, 200);
     });
   });


### PR DESCRIPTION
## Summary

All pod directories are lowercase except `Settings/`. Renamed to `settings/` for consistency.

Related: https://github.com/SolidOS/solid-logic/issues/244

352 tests pass.

Fixes #247