### PR TITLE
feat: zero-cost PaymentCondition as membership gate

### DIFF
--- a/src/wac/checker.js
+++ b/src/wac/checker.js
@@ -163,13 +163,16 @@ async function checkAuthorizations(authorizations, targetUrl, agentWebId, requir
         c.type === 'PaymentCondition' || c.type === 'https://webacl.org/ns#PaymentCondition'
       );
       if (paymentCondition) {
-        const cost = parseInt(paymentCondition.amount, 10) || 0;
+        const parsed = parseInt(paymentCondition.amount, 10);
+        const cost = Number.isNaN(parsed) ? -1 : parsed;
         const currency = paymentCondition.currency || 'sat';
+
+        // Skip invalid amounts
+        if (cost < 0) continue;
 
         if (agentWebId) {
           try {
             const ledger = await readLedger();
-            const balance = getBalance(ledger, agentWebId);
 
             // Zero-cost gate: verify they have a ledger entry (have deposited at some point)
             if (cost === 0) {
@@ -178,6 +181,7 @@ async function checkAuthorizations(authorizations, targetUrl, agentWebId, requir
             }
 
             // Paid access: check balance and deduct
+            const balance = getBalance(ledger, agentWebId);
             if (cost > 0 && balance >= cost) {
               debit(ledger, agentWebId, cost, currency === 'sats' ? 'sat' : currency);
               const { writeLedger } = await import('../webledger.js');

--- a/src/wac/checker.js
+++ b/src/wac/checker.js
@@ -163,15 +163,22 @@ async function checkAuthorizations(authorizations, targetUrl, agentWebId, requir
         c.type === 'PaymentCondition' || c.type === 'https://webacl.org/ns#PaymentCondition'
       );
       if (paymentCondition) {
-        // Check if agent has sufficient balance
         const cost = parseInt(paymentCondition.amount, 10) || 0;
         const currency = paymentCondition.currency || 'sat';
-        if (agentWebId && cost > 0) {
+
+        if (agentWebId) {
           try {
             const ledger = await readLedger();
             const balance = getBalance(ledger, agentWebId);
-            if (balance >= cost) {
-              // Deduct and grant access
+
+            // Zero-cost gate: verify they have a ledger entry (have deposited at some point)
+            if (cost === 0) {
+              const hasEntry = ledger.entries?.some(e => e.url === agentWebId);
+              if (hasEntry) return { allowed: true };
+            }
+
+            // Paid access: check balance and deduct
+            if (cost > 0 && balance >= cost) {
               debit(ledger, agentWebId, cost, currency === 'sats' ? 'sat' : currency);
               const { writeLedger } = await import('../webledger.js');
               await writeLedger(ledger);

--- a/test/wac.test.js
+++ b/test/wac.test.js
@@ -428,6 +428,30 @@ describe('WAC Conditions', () => {
       assert.strictEqual(auths[0].conditions[0].type, 'UnknownFutureCondition');
     });
 
+    it('should parse zero-cost PaymentCondition', async () => {
+      const acl = {
+        '@context': { 'acl': 'http://www.w3.org/ns/auth/acl#' },
+        '@graph': [{
+          '@id': '#gate',
+          '@type': 'acl:Authorization',
+          'acl:agentClass': { '@id': 'acl:AuthenticatedAgent' },
+          'acl:accessTo': { '@id': 'https://alice.example/members/' },
+          'acl:mode': [{ '@id': 'acl:Read' }],
+          'acl:condition': {
+            '@type': 'PaymentCondition',
+            'amount': '0',
+            'currency': 'sats'
+          }
+        }]
+      };
+
+      const auths = await parseAcl(JSON.stringify(acl), 'https://alice.example/members/.acl');
+      const condition = auths[0].conditions[0];
+
+      assert.strictEqual(condition.type, 'PaymentCondition');
+      assert.strictEqual(condition.amount, '0');
+    });
+
     it('should parse PaymentCondition with all fields', async () => {
       const acl = {
         '@context': { 'acl': 'http://www.w3.org/ns/auth/acl#' },


### PR DESCRIPTION
## Summary

`PaymentCondition` with `amount: "0"` now acts as a membership gate — grants access if the user has ever deposited (has a ledger entry), without deducting anything.

- Checks for ledger entry existence, not `balance >= 0` (which returns 0 for non-existent users too)
- No sats deducted for zero-cost conditions
- Paid conditions (amount > 0) work as before
- 353 tests pass (1 new)

Fixes #244