### PR TITLE
fix: use request.headers.host (with port) in buildResourceUrl

### DIFF
--- a/src/auth/middleware.js
+++ b/src/auth/middleware.js
@@ -24,6 +24,8 @@ import { generateDatabrowserHtml, generateModuleDatabrowserHtml } from '../mashl
  * @returns {string} Normalized resource URL
  */
 function buildResourceUrl(request, urlPath) {
+  // Use request.headers.host (includes port) instead of request.hostname (strips port)
+  const host = request.headers.host || request.hostname;
   if (request.subdomainsEnabled && request.baseDomain &&
       request.hostname === request.baseDomain && !request.podName) {
     const pathMatch = urlPath.match(/^\/([^/]+)(\/.*)?$/);
@@ -33,7 +35,7 @@ function buildResourceUrl(request, urlPath) {
       return `${request.protocol}://${podName}.${request.baseDomain}${remainder}`;
     }
   }
-  return `${request.protocol}://${request.hostname}${urlPath}`;
+  return `${request.protocol}://${host}${urlPath}`;
 }
 
 /**
@@ -180,7 +182,7 @@ function getErrorPage(statusCode, isAuthenticated, request) {
     ? "This resource is protected. You'll need to sign in to continue."
     : "You're signed in, but you don't have permission to view this resource.";
 
-  const baseUrl = `${request.protocol}://${request.hostname}`;
+  const baseUrl = `${request.protocol}://${request.headers.host || request.hostname}`;
 
   return `<!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
## Summary

`buildResourceUrl` used `request.hostname` which strips the port. ACL matching failed on non-standard ports because the constructed URL `http://localhost/path` never matched the ACL's `http://localhost:4443/path`.

Fix: use `request.headers.host` which includes the port.

## Tested

Full 402 flow verified:
1. Create resource + PaymentCondition ACL → 402
2. Deposit testnet4 sats → balance credited
3. Retry → 200 OK + content

353 tests pass.

Fixes #250