### PR TITLE
fix: pass currency from PaymentCondition to getBalance and debit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-solid-server",
-  "version": "0.0.125",
+  "version": "0.0.126",
   "description": "A minimal, fast Solid server",
   "main": "src/index.js",
   "type": "module",

--- a/src/wac/checker.js
+++ b/src/wac/checker.js
@@ -181,9 +181,9 @@ async function checkAuthorizations(authorizations, targetUrl, agentWebId, requir
             }
 
             // Paid access: check balance and deduct
-            const balance = getBalance(ledger, agentWebId);
+            const balance = getBalance(ledger, agentWebId, currency);
             if (cost > 0 && balance >= cost) {
-              debit(ledger, agentWebId, cost, currency === 'sats' ? 'sat' : currency);
+              debit(ledger, agentWebId, cost, currency);
               const { writeLedger } = await import('../webledger.js');
               await writeLedger(ledger);
               return { allowed: true, paid: cost };


### PR DESCRIPTION
## Summary

`getBalance` was called without a currency argument, so it only found default "satoshi"/"sat" entries. Deposits to specific chains (tbtc4, tbtc3) were invisible to the payment condition checker.

Now the condition's `currency` field is passed through to both `getBalance` and `debit`.

## Tested

Full flow on local server:
1. Deposit tbtc4 sats → 416587 balance
2. PaymentCondition with `currency: "tbtc4"`, `amount: "10"` → 200 OK
3. Balance drops to 416577 (10 deducted)

353 tests pass.

Fixes #243