### PR TITLE
fix: return token from pod creation when --idp is enabled

### DIFF
--- a/src/handlers/container.js
+++ b/src/handlers/container.js
@@ -310,7 +310,7 @@ export async function handleCreatePod(request, reply) {
 
   Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
 
-  // If IdP is enabled, create account instead of simple token
+  // If IdP is enabled, create account and return token + login URL
   if (idpEnabled) {
     try {
       const { createAccount } = await import('../idp/accounts.js');

--- a/src/handlers/container.js
+++ b/src/handlers/container.js
@@ -316,10 +316,12 @@ export async function handleCreatePod(request, reply) {
       const { createAccount } = await import('../idp/accounts.js');
       await createAccount({ username: name, email, password, webId, podName: name });
 
+      const token = createToken(webId);
       return reply.code(201).send({
         name,
         webId,
         podUri,
+        token,
         idpIssuer: issuer,
         loginUrl: `${baseUri}/idp/auth`,
       });

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -130,8 +130,8 @@ describe('Identity Provider', () => {
       assert.ok(body.podUri.includes(`idpuser${uniqueId}`));
       assert.ok(body.idpIssuer, 'should include IdP issuer');
       assert.ok(body.loginUrl, 'should include login URL');
-      // Should NOT have simple token when IdP is enabled
-      assert.ok(!body.token, 'should not have simple token');
+      // Should also return a token for curl-based workflows
+      assert.ok(body.token, 'should include token');
     });
 
     it('should reject duplicate email', async () => {

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -132,6 +132,12 @@ describe('Identity Provider', () => {
       assert.ok(body.loginUrl, 'should include login URL');
       // Should also return a token for curl-based workflows
       assert.ok(body.token, 'should include token');
+
+      // Token should work for authenticated requests
+      const privateRes = await fetch(`${baseUrl}/${body.name}/private/`, {
+        headers: { 'Authorization': `Bearer ${body.token}` },
+      });
+      assert.strictEqual(privateRes.status, 200, 'token should authenticate to private folder');
     });
 
     it('should reject duplicate email', async () => {


### PR DESCRIPTION
## Summary
- Pod creation with `--idp` now returns a JWT token alongside the OIDC login URL
- Enables curl-based workflows without needing the full OIDC flow

Closes #253

## Test plan
- [x] All 353 tests pass
- [x] IDP test updated to expect token