### PR TITLE
fix: simple auth tokens no longer expire after 1 hour

### DIFF
--- a/src/ap/routes/oauth.js
+++ b/src/ap/routes/oauth.js
@@ -123,7 +123,7 @@ export function createAuthorizePostHandler () {
     // Implicit grant (response_type=token) — return token directly in fragment (RFC 6749 §4.2.2)
     // Used by remoteStorage clients
     if (response_type === 'token') {
-      const accessToken = createToken(account.webId)
+      const accessToken = createToken(account.webId, 3600)
 
       // Handle OOB — display token
       if (redirect_uri === OOB_REDIRECT) {
@@ -208,7 +208,7 @@ export function createTokenHandler () {
     }
 
     // Generate Bearer token using existing token infrastructure
-    const accessToken = createToken(authCode.webId)
+    const accessToken = createToken(authCode.webId, 3600)
 
     return reply.send({
       access_token: accessToken,

--- a/src/auth/token.js
+++ b/src/auth/token.js
@@ -39,15 +39,17 @@ const SECRET = getSecret();
 /**
  * Create a simple token for a WebID
  * @param {string} webId - The WebID to create token for
- * @param {number} expiresIn - Expiration time in seconds (default 1 hour)
+ * @param {number} [expiresIn] - Expiration time in seconds (default: no expiry)
  * @returns {string} Token string
  */
-export function createToken(webId, expiresIn = 3600) {
+export function createToken(webId, expiresIn) {
   const payload = {
     webId,
     iat: Math.floor(Date.now() / 1000),
-    exp: Math.floor(Date.now() / 1000) + expiresIn
   };
+  if (expiresIn) {
+    payload.exp = Math.floor(Date.now() / 1000) + expiresIn;
+  }
 
   const data = Buffer.from(JSON.stringify(payload)).toString('base64url');
   const signature = crypto

--- a/src/auth/token.js
+++ b/src/auth/token.js
@@ -67,7 +67,7 @@ export function createToken(webId, expiresIn) {
  * JWT tokens (3-part) require async verification via verifyTokenAsync().
  *
  * @param {string} token - The token to verify
- * @returns {{webId: string, iat: number, exp: number} | null} Decoded payload or null
+ * @returns {{webId: string, iat: number, exp?: number} | null} Decoded payload or null
  */
 export function verifyToken(token) {
   if (!token || typeof token !== 'string') {

--- a/src/auth/token.js
+++ b/src/auth/token.js
@@ -47,7 +47,7 @@ export function createToken(webId, expiresIn) {
     webId,
     iat: Math.floor(Date.now() / 1000),
   };
-  if (expiresIn) {
+  if (expiresIn !== undefined && expiresIn > 0) {
     payload.exp = Math.floor(Date.now() / 1000) + expiresIn;
   }
 


### PR DESCRIPTION
## Summary
- Pod creation tokens now have no expiry — no refresh path exists in simple auth mode
- OAuth tokens (AP) keep 1-hour expiry since they have a proper grant flow
- Verify side already handles missing `exp` gracefully

Closes #255

## Test plan
- [x] All 353 tests pass
- [x] createToken() with no expiresIn omits exp from payload
- [x] OAuth callers pass explicit 3600