### PR TITLE
fix: disable pod creation in single-user mode

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -472,15 +472,22 @@ export function createServer(options = {}) {
 
   // Pod creation endpoint with rate limiting
   // Limit: 1 pod per IP per day to prevent resource exhaustion and namespace squatting
-  fastify.post('/.pods', {
-    config: {
-      rateLimit: {
-        max: 1,
-        timeWindow: '1 day',
-        keyGenerator: (request) => request.ip
+  // Disabled in single-user mode
+  if (singleUser) {
+    fastify.post('/.pods', async (request, reply) => {
+      return reply.code(403).send({ error: 'Pod creation disabled in single-user mode' });
+    });
+  } else {
+    fastify.post('/.pods', {
+      config: {
+        rateLimit: {
+          max: 1,
+          timeWindow: '1 day',
+          keyGenerator: (request) => request.ip
+        }
       }
-    }
-  }, handleCreatePod);
+    }, handleCreatePod);
+  }
 
   // Mashlib CDN mode: redirect chunk requests to CDN
   if (mashlibEnabled && mashlibCdn) {

--- a/src/server.js
+++ b/src/server.js
@@ -475,7 +475,7 @@ export function createServer(options = {}) {
   // Disabled in single-user mode
   if (singleUser) {
     fastify.post('/.pods', async (request, reply) => {
-      return reply.code(403).send({ error: 'Pod creation disabled in single-user mode' });
+      return reply.code(403).send({ error: 'Forbidden', message: 'Pod creation disabled in single-user mode' });
     });
   } else {
     fastify.post('/.pods', {


### PR DESCRIPTION
## Summary
- `POST /.pods` now returns 403 when `--single-user` is enabled
- Prevents unauthorized pod creation on single-user servers

Closes #257

## Test plan
- [x] All 353 tests pass
- [x] Single-user servers reject pod creation with 403