### PR TITLE
fix: add X-Cost and X-Balance headers for ACL-gated paid resources

### DIFF
--- a/src/auth/middleware.js
+++ b/src/auth/middleware.js
@@ -104,7 +104,7 @@ export async function authorize(request, reply, options = {}) {
   }
 
   // Check WAC permissions
-  const { allowed, wacAllow, paymentRequired } = await checkAccess({
+  const { allowed, wacAllow, paymentRequired, paid, balance, currency } = await checkAccess({
     resourceUrl: checkUrl,
     resourcePath: checkPath,
     isContainer: checkIsContainer,
@@ -112,7 +112,7 @@ export async function authorize(request, reply, options = {}) {
     requiredMode
   });
 
-  return { authorized: allowed, webId, wacAllow, authError, paymentRequired };
+  return { authorized: allowed, webId, wacAllow, authError, paymentRequired, paid, balance, currency };
 }
 
 /**

--- a/src/ldp/headers.js
+++ b/src/ldp/headers.js
@@ -96,7 +96,7 @@ export function getCorsHeaders(origin) {
     'Access-Control-Allow-Origin': origin || '*',
     'Access-Control-Allow-Methods': 'GET, HEAD, POST, PUT, DELETE, PATCH, OPTIONS',
     'Access-Control-Allow-Headers': 'Accept, Authorization, Content-Type, DPoP, If-Match, If-None-Match, Link, Range, Slug, Origin',
-    'Access-Control-Expose-Headers': 'Accept-Patch, Accept-Post, Accept-Ranges, Allow, Content-Length, Content-Range, Content-Type, ETag, Link, Location, Updates-Via, WAC-Allow',
+    'Access-Control-Expose-Headers': 'Accept-Patch, Accept-Post, Accept-Ranges, Allow, Content-Length, Content-Range, Content-Type, ETag, Link, Location, Updates-Via, WAC-Allow, X-Cost, X-Balance, X-Pay-Currency',
     'Access-Control-Allow-Credentials': 'true',
     'Access-Control-Max-Age': '86400'
   };

--- a/src/server.js
+++ b/src/server.js
@@ -448,7 +448,7 @@ export function createServer(options = {}) {
       return;
     }
 
-    const { authorized, webId, wacAllow, authError, paymentRequired } = await authorize(request, reply);
+    const { authorized, webId, wacAllow, authError, paymentRequired, paid, balance, currency } = await authorize(request, reply);
 
     // Store webId and wacAllow on request for handlers to use
     request.webId = webId;
@@ -456,6 +456,13 @@ export function createServer(options = {}) {
 
     // Set WAC-Allow header for all responses (handlers may override)
     reply.header('WAC-Allow', wacAllow);
+
+    // Set payment headers for paid access
+    if (paid !== undefined) {
+      reply.header('X-Cost', String(paid));
+      reply.header('X-Balance', String(balance));
+      if (currency) reply.header('X-Pay-Currency', currency);
+    }
 
     // Handle payment-gated resources
     if (paymentRequired) {

--- a/src/wac/checker.js
+++ b/src/wac/checker.js
@@ -49,7 +49,7 @@ export async function checkAccess({
   // Calculate WAC-Allow header
   const wacAllow = calculateWacAllow(authorizations, resourceUrl, agentWebId, isDefault);
 
-  return { allowed: result.allowed, wacAllow, paymentRequired: result.paymentRequired || null };
+  return { allowed: result.allowed, wacAllow, paymentRequired: result.paymentRequired || null, paid: result.paid, balance: result.balance, currency: result.currency };
 }
 
 /**
@@ -186,7 +186,7 @@ async function checkAuthorizations(authorizations, targetUrl, agentWebId, requir
               debit(ledger, agentWebId, cost, currency);
               const { writeLedger } = await import('../webledger.js');
               await writeLedger(ledger);
-              return { allowed: true, paid: cost };
+              return { allowed: true, paid: cost, balance: balance - cost, currency };
             }
           } catch (e) {
             // Ledger read failed — fall through to payment required

--- a/src/wac/checker.js
+++ b/src/wac/checker.js
@@ -183,10 +183,10 @@ async function checkAuthorizations(authorizations, targetUrl, agentWebId, requir
             // Paid access: check balance and deduct
             const balance = getBalance(ledger, agentWebId, currency);
             if (cost > 0 && balance >= cost) {
-              debit(ledger, agentWebId, cost, currency);
+              const result = debit(ledger, agentWebId, cost, currency);
               const { writeLedger } = await import('../webledger.js');
               await writeLedger(ledger);
-              return { allowed: true, paid: cost, balance: balance - cost, currency };
+              return { allowed: true, paid: cost, balance: result.balance, currency };
             }
           } catch (e) {
             // Ledger read failed — fall through to payment required


### PR DESCRIPTION
## Summary
- PaymentCondition debit now returns balance and currency from WAC checker
- Server preHandler sets X-Cost, X-Balance, X-Pay-Currency headers on paid reads
- Previously these headers were only set for `/pay/*` direct routes, not ACL-gated resources

Closes #259

## Test plan
- [x] All 353 tests pass
- [x] Paid reads through PaymentCondition ACLs now include payment headers