### PR TITLE
fix: withdraw endpoint now respects currency parameter

### DIFF
--- a/src/handlers/pay.js
+++ b/src/handlers/pay.js
@@ -507,7 +507,10 @@ export function createPayHandler(options = {}) {
 
       const didUri = pubkeyToDidNostr(pubkey);
       const ledger = await readLedger();
-      const currency = body?.currency && payChains?.includes(body.currency) ? body.currency : null;
+      if (body?.currency && (!payChains || !payChains.includes(body.currency))) {
+        return reply.code(400).send({ error: `Unsupported currency: ${body.currency}`, enabledChains: payChains || [] });
+      }
+      const currency = body?.currency || null;
       const balance = getBalance(ledger, didUri, currency);
 
       // Calculate withdrawal amount
@@ -572,7 +575,7 @@ export function createPayHandler(options = {}) {
         cost: satCost,
         rate: payRate,
         balance: getBalance(ledger, didUri, currency),
-        unit: 'sat',
+        unit: currency || 'sat',
         txid: result.txid,
         proof: {
           state: result.state,

--- a/src/handlers/pay.js
+++ b/src/handlers/pay.js
@@ -507,7 +507,8 @@ export function createPayHandler(options = {}) {
 
       const didUri = pubkeyToDidNostr(pubkey);
       const ledger = await readLedger();
-      const balance = getBalance(ledger, didUri);
+      const currency = body?.currency && payChains?.includes(body.currency) ? body.currency : null;
+      const balance = getBalance(ledger, didUri, currency);
 
       // Calculate withdrawal amount
       let satCost, tokenAmount;
@@ -562,7 +563,7 @@ export function createPayHandler(options = {}) {
       }
 
       // Debit balance
-      debit(ledger, didUri, satCost);
+      debit(ledger, didUri, satCost, currency);
       await writeLedger(ledger);
 
       return reply.send({
@@ -570,7 +571,7 @@ export function createPayHandler(options = {}) {
         ticker: payToken,
         cost: satCost,
         rate: payRate,
-        balance: getBalance(ledger, didUri),
+        balance: getBalance(ledger, didUri, currency),
         unit: 'sat',
         txid: result.txid,
         proof: {


### PR DESCRIPTION
## Summary
- `POST /pay/.withdraw` now accepts `currency` in the request body
- Passes it to `getBalance()` and `debit()` so chain-specific balances work

Closes #263

## Test plan
- [x] All 353 tests pass
- [x] Withdraw with `{"tokens": 5, "currency": "tbtc4"}` uses tbtc4 balance