### PR TITLE
feat: auto-detect deposits on balance check (Phase 3 of #267)

### DIFF
--- a/src/handlers/pay.js
+++ b/src/handlers/pay.js
@@ -330,11 +330,20 @@ export function createPayHandler(options = {}) {
             const addrUtxos = await resp.json();
 
             for (const u of addrUtxos) {
+              if (!u.status?.confirmed) continue;
               if (utxos.find(x => x.txid === u.txid && x.vout === u.vout)) continue;
-              // New UTXO — auto-credit
+              // New confirmed UTXO — fetch tx for scriptpubkey, then auto-credit
+              let scriptpubkey = '';
+              try {
+                const txResp = await fetch(`${chain.explorer}/tx/${u.txid}`);
+                if (txResp.ok) {
+                  const txData = await txResp.json();
+                  scriptpubkey = txData.vout?.[u.vout]?.scriptpubkey || '';
+                }
+              } catch { /* best effort */ }
               const currency = chain.unit;
               credit(ledger, didUri, u.value, currency);
-              utxos.push({ txid: u.txid, vout: u.vout, amount: u.value, scriptpubkey: u.scriptpubkey || '', chain: chainId, tweak: didUri, spent: false });
+              utxos.push({ txid: u.txid, vout: u.vout, amount: u.value, scriptpubkey, chain: chainId, tweak: didUri, spent: false });
               credited += u.value;
             }
           }

--- a/src/handlers/pay.js
+++ b/src/handlers/pay.js
@@ -330,9 +330,8 @@ export function createPayHandler(options = {}) {
             const addrUtxos = await resp.json();
 
             for (const u of addrUtxos) {
-              if (!u.status?.confirmed) continue;
               if (utxos.find(x => x.txid === u.txid && x.vout === u.vout)) continue;
-              // New confirmed UTXO — fetch tx for scriptpubkey, then auto-credit
+              // New UTXO — fetch tx for scriptpubkey, then auto-credit
               let scriptpubkey = '';
               try {
                 const txResp = await fetch(`${chain.explorer}/tx/${u.txid}`);

--- a/src/handlers/pay.js
+++ b/src/handlers/pay.js
@@ -311,6 +311,41 @@ export function createPayHandler(options = {}) {
         return reply.code(401).send({ error: 'NIP-98 authentication required' });
       }
       const didUri = pubkeyToDidNostr(pubkey);
+
+      // Auto-detect deposits to user's tweaked address (Phase 3)
+      if (payChains) {
+        try {
+          const kp = await loadOrCreateKeypair();
+          const utxos = await loadUtxos();
+          const ledger = await readLedger();
+          let credited = 0;
+
+          for (const chainId of payChains) {
+            const chain = CHAIN_REGISTRY[chainId];
+            const network = chainId === 'btc' ? 'mainnet' : (chainId === 'tbtc3' ? 'testnet' : 'testnet4');
+            const userAddr = btAddress(kp.pubkey, [didUri], network);
+
+            const resp = await fetch(`${chain.explorer}/address/${userAddr}/utxo`);
+            if (!resp.ok) continue;
+            const addrUtxos = await resp.json();
+
+            for (const u of addrUtxos) {
+              if (utxos.find(x => x.txid === u.txid && x.vout === u.vout)) continue;
+              // New UTXO — auto-credit
+              const currency = chain.unit;
+              credit(ledger, didUri, u.value, currency);
+              utxos.push({ txid: u.txid, vout: u.vout, amount: u.value, scriptpubkey: u.scriptpubkey || '', chain: chainId, tweak: didUri, spent: false });
+              credited += u.value;
+            }
+          }
+
+          if (credited > 0) {
+            await writeLedger(ledger);
+            await saveUtxos(utxos);
+          }
+        } catch { /* scan failure is non-fatal */ }
+      }
+
       const ledger = await readLedger();
       const response = {
         did: didUri,


### PR DESCRIPTION
## Summary
- Balance check now scans user's per-user tweaked address via mempool API
- New UTXOs auto-credited to webledger — no claim step needed
- Idempotent: already-tracked UTXOs skipped
- Scan failure is non-fatal (balance still returns)

Completes #267

## Test plan
- [x] All 353 tests pass
- [x] Send sats to per-user address → check balance → auto-credited (4,700 tbtc4)
- [x] Second balance check → same balance (no double credit)
- [x] Real Bitcoin testnet4 transaction