### PR TITLE
Fix WebSocket notifications not reaching ancestor container subscribers

### DIFF
--- a/src/notifications/websocket.js
+++ b/src/notifications/websocket.js
@@ -206,11 +206,16 @@ export function broadcast(url) {
 
   // Walk up all ancestor containers so subscribing to a root
   // catches changes in nested paths (e.g. /db/mydata/ catches /db/mydata/issues/1)
-  var containerUrl = getParentContainer(url);
-  while (containerUrl && containerUrl !== url) {
+  // Stop at the origin root to avoid climbing past the hostname
+  let originRoot;
+  try { originRoot = new URL(url).origin + '/'; } catch (e) { return; }
+
+  let currentUrl = url;
+  let containerUrl = getParentContainer(currentUrl);
+  while (containerUrl && containerUrl !== currentUrl && containerUrl.length >= originRoot.length) {
     notifySubscribers(containerUrl);
-    url = containerUrl;
-    containerUrl = getParentContainer(containerUrl);
+    currentUrl = containerUrl;
+    containerUrl = getParentContainer(currentUrl);
   }
 }
 

--- a/src/notifications/websocket.js
+++ b/src/notifications/websocket.js
@@ -204,11 +204,13 @@ export function broadcast(url) {
   // Notify direct subscribers
   notifySubscribers(url);
 
-  // Also notify container subscribers (parent directory)
-  // This allows subscribing to a container and getting notified of all child changes
-  const containerUrl = getParentContainer(url);
-  if (containerUrl && containerUrl !== url) {
+  // Walk up all ancestor containers so subscribing to a root
+  // catches changes in nested paths (e.g. /db/mydata/ catches /db/mydata/issues/1)
+  var containerUrl = getParentContainer(url);
+  while (containerUrl && containerUrl !== url) {
     notifySubscribers(containerUrl);
+    url = containerUrl;
+    containerUrl = getParentContainer(containerUrl);
   }
 }
 


### PR DESCRIPTION
## Summary

- `broadcast()` only walked up one parent container level
- Subscribing to `/db/mydata/` would not receive notifications for `/db/mydata/issues/1` (two levels deep)
- Now walks up all ancestor containers using a while loop

## The bug

```
sub http://localhost/db/mydata/          ← subscriber
PUT http://localhost/db/mydata/issues/1  ← change

Parent of /db/mydata/issues/1 is /db/mydata/issues/  ← only this was notified
Grandparent is /db/mydata/                            ← subscriber never reached
```

## The fix

```js
// Before: only one level up
const containerUrl = getParentContainer(url);
if (containerUrl && containerUrl !== url) {
  notifySubscribers(containerUrl);
}

// After: walk all ancestors
var containerUrl = getParentContainer(url);
while (containerUrl && containerUrl !== url) {
  notifySubscribers(containerUrl);
  url = containerUrl;
  containerUrl = getParentContainer(containerUrl);
}
```

## Test plan

- [x] Subscribe to `/db/mydata/`, PUT to `/db/mydata/issues/1` → `pub` received
- [x] Subscribe to `/db/mydata/issues/` → still works (direct parent)
- [x] Subscribe to specific resource → still works (direct match)
- [x] Filesystem notifications unaffected

Fixes #272