### PR TITLE
Fix getPodName for single-pod mode (#278)

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -182,6 +182,8 @@ export function createServer(options = {}) {
   fastify.decorateRequest('defaultQuota', null);
   fastify.decorateRequest('config', null);
   fastify.decorateRequest('liveReloadEnabled', null);
+  fastify.decorateRequest('singleUser', null);
+  fastify.decorateRequest('singleUserName', null);
   fastify.addHook('onRequest', async (request) => {
     request.connegEnabled = connegEnabled;
     request.notificationsEnabled = notificationsEnabled || liveReloadEnabled;
@@ -195,6 +197,8 @@ export function createServer(options = {}) {
     request.defaultQuota = defaultQuota;
     request.config = { public: options.public, readOnly: options.readOnly };
     request.liveReloadEnabled = liveReloadEnabled;
+    request.singleUser = singleUser;
+    request.singleUserName = singleUserName;
 
     // Extract pod name from subdomain if enabled
     if (subdomainsEnabled && baseDomain) {

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -151,15 +151,15 @@ export function getResourceName(urlPath) {
 /**
  * Extract pod name from URL path or request
  *
- * In subdomain mode the pod name comes from the hostname. Otherwise JSS is a
- * single-pod server: `dataRoot` itself is the one and only pod and there is
+ * In subdomain mode the pod name comes from the hostname. Otherwise JSS is in
+ * single-user mode: `dataRoot` itself is the one and only pod and there is
  * no per-pod subdirectory. We return '.' so callers that build pod-scoped
  * paths (e.g. the quota sidecar) resolve to `<dataRoot>/.quota.json` via
  * `path.join` rather than mistaking the first URL segment for a pod name
  * (which produced `<dataRoot>/index.html/.quota.json` → ENOTDIR on `PUT /index.html`).
  *
  * @param {string|object} pathOrRequest - URL path string or Fastify request object
- * @returns {string} - Pod name, or '.' for single-pod mode
+ * @returns {string} - Pod name, or '.' in single-user mode
  */
 export function getPodName(pathOrRequest) {
   // If it's a request object

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -151,29 +151,45 @@ export function getResourceName(urlPath) {
 /**
  * Extract pod name from URL path or request
  *
- * In subdomain mode the pod name comes from the hostname. Otherwise JSS is in
- * single-user mode: `dataRoot` itself is the one and only pod and there is
- * no per-pod subdirectory. We return '.' so callers that build pod-scoped
- * paths (e.g. the quota sidecar) resolve to `<dataRoot>/.quota.json` via
- * `path.join` rather than mistaking the first URL segment for a pod name
- * (which produced `<dataRoot>/index.html/.quota.json` → ENOTDIR on `PUT /index.html`).
+ * Resolves to one of four shapes, by deployment mode:
+ *
+ * - Subdomain mode with a recognized subdomain → `request.podName` (from hostname).
+ * - Subdomain mode with no recognized subdomain → `null` (base-domain access;
+ *   callers guard with `if (podName)` and skip pod-scoped side effects).
+ * - Single-user, root-pod (`singleUserName` empty or '/') → `'.'` so
+ *   `path.join(dataRoot, '.', QUOTA_FILE)` collapses to `<dataRoot>/QUOTA_FILE`.
+ * - Single-user, named pod → `singleUserName` (all requests share the one pod,
+ *   independent of URL — avoids mistaking a URL segment like `index.html`
+ *   for a pod name).
+ * - Path-based multi-pod (default, no flags) → first URL segment, or `null`
+ *   for requests at `/` that aren't inside any pod.
+ *
+ * Background: before this function knew about single-user mode, a
+ * `PUT /index.html` on a single-user root-pod deployment produced a pod name
+ * of `"index.html"`, and the quota sidecar landed at
+ * `<dataRoot>/index.html/.quota.json` → `ENOTDIR` (index.html is a file).
  *
  * @param {string|object} pathOrRequest - URL path string or Fastify request object
- * @returns {string} - Pod name, or '.' in single-user mode
+ * @returns {string|null} - Pod name, `'.'` for root-pod, or `null` when no pod applies
  */
 export function getPodName(pathOrRequest) {
-  // If it's a request object
-  if (typeof pathOrRequest === 'object') {
-    // Subdomain mode: pod name from hostname
-    if (pathOrRequest.subdomainsEnabled && pathOrRequest.podName) {
-      return pathOrRequest.podName;
+  if (typeof pathOrRequest === 'object' && pathOrRequest !== null) {
+    // Subdomain mode: hostname drives it. Unrecognized host → no pod.
+    if (pathOrRequest.subdomainsEnabled) {
+      return pathOrRequest.podName || null;
     }
-    // Single-pod mode: the whole dataRoot is the pod.
-    return '.';
+    // Single-user mode: always the one pod, regardless of URL path.
+    if (pathOrRequest.singleUser) {
+      const name = pathOrRequest.singleUserName;
+      return (!name || name === '/') ? '.' : name;
+    }
+    // Path-based multi-pod: first URL segment.
+    const urlPath = pathOrRequest.url?.split('?')[0] || '';
+    return getPodNameFromPath(urlPath);
   }
 
-  // String form (single-pod contexts, e.g. quota helpers).
-  return '.';
+  // String form: path-based pod extraction.
+  return getPodNameFromPath(pathOrRequest);
 }
 
 /**

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -150,8 +150,16 @@ export function getResourceName(urlPath) {
 
 /**
  * Extract pod name from URL path or request
+ *
+ * In subdomain mode the pod name comes from the hostname. Otherwise JSS is a
+ * single-pod server: `dataRoot` itself is the one and only pod and there is
+ * no per-pod subdirectory. We return '.' so callers that build pod-scoped
+ * paths (e.g. the quota sidecar) resolve to `<dataRoot>/.quota.json` via
+ * `path.join` rather than mistaking the first URL segment for a pod name
+ * (which produced `<dataRoot>/index.html/.quota.json` → ENOTDIR on `PUT /index.html`).
+ *
  * @param {string|object} pathOrRequest - URL path string or Fastify request object
- * @returns {string|null} - Pod name or null if not found
+ * @returns {string} - Pod name, or '.' for single-pod mode
  */
 export function getPodName(pathOrRequest) {
   // If it's a request object
@@ -160,13 +168,12 @@ export function getPodName(pathOrRequest) {
     if (pathOrRequest.subdomainsEnabled && pathOrRequest.podName) {
       return pathOrRequest.podName;
     }
-    // Path mode: extract from URL
-    const urlPath = pathOrRequest.url?.split('?')[0] || '';
-    return getPodNameFromPath(urlPath);
+    // Single-pod mode: the whole dataRoot is the pod.
+    return '.';
   }
 
-  // If it's a string path
-  return getPodNameFromPath(pathOrRequest);
+  // String form (single-pod contexts, e.g. quota helpers).
+  return '.';
 }
 
 /**

--- a/test/url.test.js
+++ b/test/url.test.js
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for src/utils/url.js
+ *
+ * Focus: getPodName() resolution across the four supported deployment modes.
+ * Regression guard for #278 (single-user root-pod PUT → ENOTDIR).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { getPodName } from '../src/utils/url.js';
+
+describe('getPodName', () => {
+  describe('subdomain mode', () => {
+    it('returns request.podName when the subdomain is recognized', () => {
+      const req = { subdomainsEnabled: true, podName: 'alice', url: '/profile/card' };
+      assert.strictEqual(getPodName(req), 'alice');
+    });
+
+    it('returns null on base-domain access (no recognized subdomain)', () => {
+      const req = { subdomainsEnabled: true, podName: null, url: '/anything' };
+      assert.strictEqual(getPodName(req), null);
+    });
+  });
+
+  describe('single-user mode', () => {
+    it("returns '.' for a root pod (singleUserName empty)", () => {
+      const req = { singleUser: true, singleUserName: '', url: '/index.html' };
+      assert.strictEqual(getPodName(req), '.');
+    });
+
+    it("returns '.' for a root pod (singleUserName '/')", () => {
+      const req = { singleUser: true, singleUserName: '/', url: '/index.html' };
+      assert.strictEqual(getPodName(req), '.');
+    });
+
+    it('returns singleUserName for a named pod, regardless of URL', () => {
+      const req = { singleUser: true, singleUserName: 'me', url: '/index.html' };
+      assert.strictEqual(getPodName(req), 'me');
+    });
+
+    it('does not mistake a URL segment for a pod in single-user mode', () => {
+      // Regression for #278: PUT /index.html previously produced pod
+      // "index.html", making the quota sidecar path <dataRoot>/index.html/.quota.json.
+      const req = { singleUser: true, singleUserName: '', url: '/index.html' };
+      assert.notStrictEqual(getPodName(req), 'index.html');
+    });
+  });
+
+  describe('path-based multi-pod (default)', () => {
+    it('returns the first URL segment as the pod name', () => {
+      const req = { url: '/alice/profile/card' };
+      assert.strictEqual(getPodName(req), 'alice');
+    });
+
+    it('returns null for requests at /', () => {
+      const req = { url: '/' };
+      assert.strictEqual(getPodName(req), null);
+    });
+
+    it('skips system paths beginning with a dot', () => {
+      const req = { url: '/.well-known/openid-configuration' };
+      assert.strictEqual(getPodName(req), null);
+    });
+  });
+
+  describe('string-form input', () => {
+    it('extracts pod name from a URL path string', () => {
+      assert.strictEqual(getPodName('/alice/foo'), 'alice');
+    });
+
+    it('returns null for the root path', () => {
+      assert.strictEqual(getPodName('/'), null);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #278 — `getPodName()` did not know about single-user mode, so for a single-user deployment with a root pod (`singleUserName` empty or `'/'`), requests like `PUT /index.html` produced `podName = "index.html"`. The quota sidecar then landed at `<dataRoot>/index.html/.quota.json` → **500 ENOTDIR** (index.html is a file).

## Scope

The fix had to distinguish **four** deployment shapes, not two:

| Mode | Identification | `getPodName` returns |
|---|---|---|
| Subdomain | hostname → `request.podName` | `podName` or `null` (unrecognized subdomain) |
| Single-user, root pod (`singleUserName` empty/`/`) | `--single-user` | `'.'` → quota at `<dataRoot>/.quota.json` |
| Single-user, named pod | `--single-user --single-user-name me` | `singleUserName` (regardless of URL path) |
| Path-based multi-pod (default) | neither | first URL segment (unchanged behavior) |

## Changes

1. **`src/server.js`** — decorate requests with `singleUser` / `singleUserName`, populated in the per-request hook (same pattern as `subdomainsEnabled`).
2. **`src/utils/url.js`** `getPodName` — four explicit branches matching the table above. Path-based extraction via `getPodNameFromPath` is preserved for the default multi-pod case. Subdomain mode with no recognized subdomain returns `null` so callers' `if (podName)` guards skip quota on base-domain access (addresses a security concern flagged in review).
3. **`test/url.test.js`** — unit tests for all four branches plus a regression guard for the `PUT /index.html` case from #278. 11 passing.

No caller changes needed — existing `if (podName)` guards remain correct (`'.'` is truthy; `null` short-circuits).

## Addresses review feedback

- **Path-based pods are no longer collapsed.** Previous commit returned `'.'` for all non-subdomain requests, which would have merged per-pod quota (`<dataRoot>/alice/.quota.json`, `<dataRoot>/bob/.quota.json`, …) into one file.
- **`getPodNameFromPath` is no longer dead code** — the path-based branch still uses it.
- **Tests added** — `test/url.test.js`.
- **Subdomain + unrecognized subdomain** returns `null` rather than `'.'`, avoiding writes to the base pod.

## Test plan

- [x] `node --test test/url.test.js` — 11/11 pass.
- [ ] Full existing test suite still passes.
- [ ] Manual: `PUT /index.html` on a single-user `--pay` server succeeds (previously 500 ENOTDIR).
- [ ] Manual: quota sidecar for single-user root pod lands at `<dataRoot>/.quota.json`.
- [ ] Manual: path-based multi-pod server still writes per-pod quota at `<dataRoot>/<pod>/.quota.json`.
- [ ] Manual: subdomain mode unchanged; base-domain access does not touch a quota file.