### PR TITLE
Auto-generate and persist TOKEN_SECRET on first run (#280)

### DIFF
--- a/src/auth/token-secret.js
+++ b/src/auth/token-secret.js
@@ -1,0 +1,68 @@
+/**
+ * TOKEN_SECRET resolution.
+ *
+ * Extracted from token.js so it can be unit-tested without pulling in the
+ * full auth graph (solid-oidc, nostr, webid-tls), which does module-level
+ * work that keeps the node:test event loop busy.
+ */
+
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+export const DEFAULT_SECRET_PATH = path.join(os.homedir(), '.jss', 'token.secret');
+
+/**
+ * Read a persisted secret from `filePath`, or generate one and write it
+ * (with dir mode 0700 and file mode 0600) if the file is missing.
+ * Anything other than ENOENT (permission denied, read-only FS, …) throws.
+ */
+export function readOrWritePersistedSecret(filePath = DEFAULT_SECRET_PATH) {
+  try {
+    const existing = fs.readFileSync(filePath, 'utf8').trim();
+    if (existing) return existing;
+  } catch (e) {
+    if (e.code !== 'ENOENT') throw e;
+  }
+  const generated = crypto.randomBytes(32).toString('hex');
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  // mode is honoured on POSIX; silently ignored on Windows (uses ACLs).
+  fs.writeFileSync(filePath, generated, { mode: 0o600 });
+  return generated;
+}
+
+/**
+ * Resolve the token secret.
+ *
+ *   1. TOKEN_SECRET env → use it.
+ *   2. Else read/create ~/.jss/token.secret.
+ *   3. On file-write failure: hard-exit in production, ephemeral secret otherwise.
+ *
+ * Console I/O is injected so tests can assert log behaviour without spamming
+ * the real console; defaults to the real console.
+ */
+export function resolveTokenSecret({
+  env = process.env,
+  secretPath = DEFAULT_SECRET_PATH,
+  log = console,
+  exit = (code) => process.exit(code),
+} = {}) {
+  if (env.TOKEN_SECRET) return env.TOKEN_SECRET;
+
+  try {
+    const s = readOrWritePersistedSecret(secretPath);
+    log.warn(`Using persisted TOKEN_SECRET at ${secretPath} (set TOKEN_SECRET env var to override).`);
+    return s;
+  } catch (e) {
+    if (env.NODE_ENV === 'production') {
+      log.error(`SECURITY ERROR: TOKEN_SECRET not set and ${secretPath} is not writable (${e.message}).`);
+      log.error('Set TOKEN_SECRET explicitly, or grant write access to ~/.jss/.');
+      exit(1);
+      return undefined; // for tests that stub `exit`
+    }
+    const ephemeral = crypto.randomBytes(32).toString('hex');
+    log.warn(`WARNING: Could not persist TOKEN_SECRET (${e.message}). Using ephemeral secret; tokens will not survive restarts.`);
+    return ephemeral;
+  }
+}

--- a/src/auth/token-secret.js
+++ b/src/auth/token-secret.js
@@ -13,22 +13,66 @@ import path from 'path';
 
 export const DEFAULT_SECRET_PATH = path.join(os.homedir(), '.jss', 'token.secret');
 
+// Tighten permissions on POSIX. No-op on Windows, which uses ACLs and
+// surfaces EPERM on chmod — swallow that specifically.
+function chmodBestEffort(target, mode) {
+  try {
+    fs.chmodSync(target, mode);
+  } catch (e) {
+    if (e.code !== 'EPERM' && e.code !== 'ENOTSUP') throw e;
+  }
+}
+
 /**
  * Read a persisted secret from `filePath`, or generate one and write it
- * (with dir mode 0700 and file mode 0600) if the file is missing.
- * Anything other than ENOENT (permission denied, read-only FS, …) throws.
+ * (with dir mode 0700 and file mode 0600) if the file is missing. Safe
+ * against multiple JSS processes starting in parallel: the write uses an
+ * exclusive flag and we re-read on EEXIST, so every process converges on
+ * the same secret rather than racing.
+ *
+ * Anything other than ENOENT on read (permission denied, read-only FS, …)
+ * throws.
  */
 export function readOrWritePersistedSecret(filePath = DEFAULT_SECRET_PATH) {
+  // Always ensure the dir exists and is 0700 — enforce perms on every call,
+  // not only when we're the one creating it. mkdirSync({mode}) is only
+  // applied on creation, so an existing dir with looser mode needs chmod.
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  chmodBestEffort(dir, 0o700);
+
+  // Fast path: file already exists and is non-empty.
   try {
     const existing = fs.readFileSync(filePath, 'utf8').trim();
-    if (existing) return existing;
+    if (existing) {
+      chmodBestEffort(filePath, 0o600);
+      return existing;
+    }
   } catch (e) {
     if (e.code !== 'ENOENT') throw e;
   }
+
   const generated = crypto.randomBytes(32).toString('hex');
-  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
-  // mode is honoured on POSIX; silently ignored on Windows (uses ACLs).
+  try {
+    // Exclusive create — concurrent processes can't overwrite each other's
+    // freshly generated secrets. mode is honoured on POSIX; Windows ignores
+    // it (uses ACLs).
+    fs.writeFileSync(filePath, generated, { mode: 0o600, flag: 'wx' });
+    chmodBestEffort(filePath, 0o600);
+    return generated;
+  } catch (e) {
+    if (e.code !== 'EEXIST') throw e;
+  }
+
+  // Another process won the race — read what they wrote.
+  const existing = fs.readFileSync(filePath, 'utf8').trim();
+  if (existing) {
+    chmodBestEffort(filePath, 0o600);
+    return existing;
+  }
+  // Same fallback as before for a pre-existing empty file.
   fs.writeFileSync(filePath, generated, { mode: 0o600 });
+  chmodBestEffort(filePath, 0o600);
   return generated;
 }
 
@@ -57,7 +101,7 @@ export function resolveTokenSecret({
   } catch (e) {
     if (env.NODE_ENV === 'production') {
       log.error(`SECURITY ERROR: TOKEN_SECRET not set and ${secretPath} is not writable (${e.message}).`);
-      log.error('Set TOKEN_SECRET explicitly, or grant write access to ~/.jss/.');
+      log.error(`Set TOKEN_SECRET explicitly, or grant write access to ${path.dirname(secretPath)}.`);
       exit(1);
       return undefined; // for tests that stub `exit`
     }

--- a/src/auth/token-secret.js
+++ b/src/auth/token-secret.js
@@ -43,8 +43,10 @@ function chmodBestEffort(target, mode) {
 export function readOrWritePersistedSecret(filePath = DEFAULT_SECRET_PATH) {
   const dir = path.dirname(filePath);
 
-  // Fast path: pre-existing non-empty file. No mkdir/chmod attempt on the
-  // parent dir here — a read-only FS must not fail this path.
+  // Fast path: pre-existing non-empty file. We do not mkdir the parent
+  // dir here, and perm-tightening is best-effort (chmodBestEffort swallows
+  // all errors), so a pre-provisioned secret on a read-only filesystem
+  // still boots cleanly.
   try {
     const existing = fs.readFileSync(filePath, 'utf8').trim();
     if (existing) {
@@ -105,8 +107,9 @@ export function resolveTokenSecret({
     return s;
   } catch (e) {
     if (env.NODE_ENV === 'production') {
-      log.error(`SECURITY ERROR: TOKEN_SECRET not set and ${secretPath} is not writable (${e.message}).`);
-      log.error(`Set TOKEN_SECRET explicitly, or grant write access to ${path.dirname(secretPath)}.`);
+      const code = e?.code ? ` [${e.code}]` : '';
+      log.error(`SECURITY ERROR: TOKEN_SECRET not set and ${secretPath} could not be read or created${code} (${e.message}).`);
+      log.error(`Set TOKEN_SECRET explicitly, or grant the necessary access to ${path.dirname(secretPath)}.`);
       exit(1);
       // `exit` is injectable; if a caller stubs it out we must not silently
       // return undefined and let downstream code use an invalid secret.

--- a/src/auth/token-secret.js
+++ b/src/auth/token-secret.js
@@ -13,38 +13,42 @@ import path from 'path';
 
 export const DEFAULT_SECRET_PATH = path.join(os.homedir(), '.jss', 'token.secret');
 
-// Tighten permissions on POSIX. No-op on Windows, which uses ACLs and
-// surfaces EPERM on chmod — swallow that specifically.
+// Tighten permissions on POSIX, best-effort. No-op on Windows (ACLs) and
+// on read-only filesystems — we never want perm-tightening to block using
+// an otherwise-valid secret.
 function chmodBestEffort(target, mode) {
   try {
     fs.chmodSync(target, mode);
-  } catch (e) {
-    if (e.code !== 'EPERM' && e.code !== 'ENOTSUP') throw e;
+  } catch {
+    // Intentionally swallow — perms are defensive hardening, not required.
   }
 }
 
 /**
  * Read a persisted secret from `filePath`, or generate one and write it
- * (with dir mode 0700 and file mode 0600) if the file is missing. Safe
- * against multiple JSS processes starting in parallel: the write uses an
- * exclusive flag and we re-read on EEXIST, so every process converges on
- * the same secret rather than racing.
+ * (with dir mode 0700 and file mode 0600) if the file is missing.
  *
- * Anything other than ENOENT on read (permission denied, read-only FS, …)
- * throws.
+ * Read-first: if the file already exists and is non-empty we return it
+ * without trying to mkdir or tighten the containing directory. Deployments
+ * with a pre-provisioned secret on a read-only filesystem boot cleanly.
+ *
+ * Concurrent-startup safe: new secrets are written to a per-process temp
+ * file in the same directory and `renameSync`'d into place, so another
+ * process reading the target never sees a half-written file. If a peer
+ * process won the rename we fall back to reading their value.
+ *
+ * Anything other than ENOENT on the initial read (permission denied,
+ * corrupt FS, …) propagates.
  */
 export function readOrWritePersistedSecret(filePath = DEFAULT_SECRET_PATH) {
-  // Always ensure the dir exists and is 0700 — enforce perms on every call,
-  // not only when we're the one creating it. mkdirSync({mode}) is only
-  // applied on creation, so an existing dir with looser mode needs chmod.
   const dir = path.dirname(filePath);
-  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-  chmodBestEffort(dir, 0o700);
 
-  // Fast path: file already exists and is non-empty.
+  // Fast path: pre-existing non-empty file. No mkdir/chmod attempt on the
+  // parent dir here — a read-only FS must not fail this path.
   try {
     const existing = fs.readFileSync(filePath, 'utf8').trim();
     if (existing) {
+      chmodBestEffort(dir, 0o700);
       chmodBestEffort(filePath, 0o600);
       return existing;
     }
@@ -52,28 +56,29 @@ export function readOrWritePersistedSecret(filePath = DEFAULT_SECRET_PATH) {
     if (e.code !== 'ENOENT') throw e;
   }
 
-  const generated = crypto.randomBytes(32).toString('hex');
-  try {
-    // Exclusive create — concurrent processes can't overwrite each other's
-    // freshly generated secrets. mode is honoured on POSIX; Windows ignores
-    // it (uses ACLs).
-    fs.writeFileSync(filePath, generated, { mode: 0o600, flag: 'wx' });
-    chmodBestEffort(filePath, 0o600);
-    return generated;
-  } catch (e) {
-    if (e.code !== 'EEXIST') throw e;
-  }
+  // Slow path: create it. Only touch the FS with writes from here on.
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  chmodBestEffort(dir, 0o700);
 
-  // Another process won the race — read what they wrote.
-  const existing = fs.readFileSync(filePath, 'utf8').trim();
-  if (existing) {
-    chmodBestEffort(filePath, 0o600);
-    return existing;
+  const generated = crypto.randomBytes(32).toString('hex');
+  // Atomic write: fully write a temp file, then rename into place. On
+  // POSIX the rename is atomic, so concurrent readers see either the old
+  // content or the new complete content — never a half-written file.
+  const tmpPath = `${filePath}.${crypto.randomBytes(8).toString('hex')}.tmp`;
+  try {
+    fs.writeFileSync(tmpPath, generated, { mode: 0o600 });
+    fs.renameSync(tmpPath, filePath);
+  } catch (e) {
+    try { fs.unlinkSync(tmpPath); } catch { /* ignore */ }
+    throw e;
   }
-  // Same fallback as before for a pre-existing empty file.
-  fs.writeFileSync(filePath, generated, { mode: 0o600 });
   chmodBestEffort(filePath, 0o600);
-  return generated;
+
+  // Multiple processes racing each produce a different secret; only the
+  // last renamer's value sticks on disk. Re-read so every process ends up
+  // using the winning secret and token verification stays consistent.
+  const persisted = fs.readFileSync(filePath, 'utf8').trim();
+  return persisted || generated;
 }
 
 /**
@@ -103,7 +108,9 @@ export function resolveTokenSecret({
       log.error(`SECURITY ERROR: TOKEN_SECRET not set and ${secretPath} is not writable (${e.message}).`);
       log.error(`Set TOKEN_SECRET explicitly, or grant write access to ${path.dirname(secretPath)}.`);
       exit(1);
-      return undefined; // for tests that stub `exit`
+      // `exit` is injectable; if a caller stubs it out we must not silently
+      // return undefined and let downstream code use an invalid secret.
+      throw new Error(`Failed to resolve TOKEN_SECRET in production: ${e.message}`);
     }
     const ephemeral = crypto.randomBytes(32).toString('hex');
     log.warn(`WARNING: Could not persist TOKEN_SECRET (${e.message}). Using ephemeral secret; tokens will not survive restarts.`);

--- a/src/auth/token.js
+++ b/src/auth/token.js
@@ -11,30 +11,11 @@ import crypto from 'crypto';
 import { verifySolidOidc, hasSolidOidcAuth } from './solid-oidc.js';
 import { verifyNostrAuth, hasNostrAuth } from './nostr.js';
 import { webIdTlsAuth, hasClientCertificate } from './webid-tls.js';
+import { resolveTokenSecret } from './token-secret.js';
 
-// Secret for signing tokens
-// SECURITY: In production, TOKEN_SECRET must be set via environment variable
-const getSecret = () => {
-  if (process.env.TOKEN_SECRET) {
-    return process.env.TOKEN_SECRET;
-  }
-
-  // In production (NODE_ENV=production), require explicit secret
-  if (process.env.NODE_ENV === 'production') {
-    console.error('SECURITY ERROR: TOKEN_SECRET environment variable must be set in production');
-    console.error('Generate one with: node -e "console.log(require(\'crypto\').randomBytes(32).toString(\'hex\'))"');
-    process.exit(1);
-  }
-
-  // In development, generate a random secret per process (tokens won't survive restarts)
-  const devSecret = crypto.randomBytes(32).toString('hex');
-  console.warn('WARNING: No TOKEN_SECRET set. Using random secret (tokens will not survive restarts).');
-  console.warn('Set TOKEN_SECRET environment variable for persistent tokens.');
-  return devSecret;
-};
-
-// Initialize secret once at module load
-const SECRET = getSecret();
+// Initialize secret once at module load. See token-secret.js for the
+// resolution order (env → ~/.jss/token.secret → exit-or-ephemeral).
+const SECRET = resolveTokenSecret();
 
 /**
  * Create a simple token for a WebID

--- a/test/token-secret.test.js
+++ b/test/token-secret.test.js
@@ -56,6 +56,27 @@ describe('readOrWritePersistedSecret', () => {
     const unwritable = path.join(blockerFile, '.jss', 'token.secret');
     assert.throws(() => readOrWritePersistedSecret(unwritable));
   });
+
+  it('recovers when the secret file already exists but is empty', () => {
+    // Simulates the lose-a-race case: another process created the file
+    // between our read and our write. Exclusive-create fails EEXIST and
+    // we fall back to reading / (if empty) writing without wx.
+    const p = path.join(tmpDir, 'empty', '.jss', 'token.secret');
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, '');
+    const s = readOrWritePersistedSecret(p);
+    assert.strictEqual(s.length, 64);
+    assert.strictEqual(fs.readFileSync(p, 'utf8').trim(), s);
+  });
+
+  it('tightens permissions when the file already exists with loose mode', { skip: process.platform === 'win32' }, () => {
+    const p = path.join(tmpDir, 'loose', '.jss', 'token.secret');
+    fs.mkdirSync(path.dirname(p), { recursive: true, mode: 0o755 });
+    fs.writeFileSync(p, 'a'.repeat(64), { mode: 0o644 });
+    readOrWritePersistedSecret(p);
+    assert.strictEqual(fs.statSync(p).mode & 0o777, 0o600);
+    assert.strictEqual(fs.statSync(path.dirname(p)).mode & 0o777, 0o700);
+  });
 });
 
 describe('resolveTokenSecret', () => {
@@ -112,6 +133,22 @@ describe('resolveTokenSecret', () => {
       exit: (code) => { exitCode = code; },
     });
     assert.strictEqual(exitCode, 1);
+  });
+
+  it('production error message references the actual secret directory', () => {
+    const secretPath = buildUnwritable('custom-path');
+    const errors = [];
+    resolveTokenSecret({
+      env: { NODE_ENV: 'production' },
+      secretPath,
+      log: { warn: () => {}, error: (msg) => errors.push(msg) },
+      exit: () => {},
+    });
+    // Guidance line should point at the dirname we actually tried to write.
+    assert.ok(
+      errors.some(m => m.includes(path.dirname(secretPath))),
+      `expected an error to mention ${path.dirname(secretPath)}, got: ${errors.join(' | ')}`
+    );
   });
 
   it('falls back to an ephemeral secret outside production when persistence fails', () => {

--- a/test/token-secret.test.js
+++ b/test/token-secret.test.js
@@ -77,6 +77,22 @@ describe('readOrWritePersistedSecret', () => {
     assert.strictEqual(fs.statSync(p).mode & 0o777, 0o600);
     assert.strictEqual(fs.statSync(path.dirname(p)).mode & 0o777, 0o700);
   });
+
+  it('reads a pre-existing secret even when the parent dir is not writable', { skip: process.platform === 'win32' || process.getuid?.() === 0 }, () => {
+    // Simulates a read-only deployment: secret provisioned ahead of time,
+    // parent dir not writable for the current user. Must not block startup.
+    const p = path.join(tmpDir, 'readonly-parent', '.jss', 'token.secret');
+    fs.mkdirSync(path.dirname(p), { recursive: true, mode: 0o700 });
+    const expected = 'b'.repeat(64);
+    fs.writeFileSync(p, expected);
+    fs.chmodSync(path.dirname(p), 0o500); // r-x, no write
+    try {
+      const s = readOrWritePersistedSecret(p);
+      assert.strictEqual(s, expected);
+    } finally {
+      fs.chmodSync(path.dirname(p), 0o700);  // let after()'s rmSync clean up
+    }
+  });
 });
 
 describe('resolveTokenSecret', () => {
@@ -126,25 +142,45 @@ describe('resolveTokenSecret', () => {
 
   it('hard-exits in production when persistence fails', () => {
     let exitCode;
-    resolveTokenSecret({
-      env: { NODE_ENV: 'production' },
-      secretPath: buildUnwritable('prod'),
-      log: silentLog,
-      exit: (code) => { exitCode = code; },
+    assert.throws(() => {
+      resolveTokenSecret({
+        env: { NODE_ENV: 'production' },
+        secretPath: buildUnwritable('prod'),
+        log: silentLog,
+        exit: (code) => { exitCode = code; },  // stubbed — doesn't actually terminate
+      });
     });
+    // exit(1) must still have been invoked even though we throw afterwards,
+    // so a non-stubbed production process actually terminates.
     assert.strictEqual(exitCode, 1);
+  });
+
+  it('throws after exit so a stubbed exit() cannot leak undefined downstream', () => {
+    // Regression: earlier versions returned undefined "for tests" after
+    // calling exit(), which could let callers continue with an invalid
+    // secret when exit is stubbed.
+    assert.throws(
+      () => resolveTokenSecret({
+        env: { NODE_ENV: 'production' },
+        secretPath: buildUnwritable('no-leak'),
+        log: silentLog,
+        exit: () => {},
+      }),
+      /TOKEN_SECRET/
+    );
   });
 
   it('production error message references the actual secret directory', () => {
     const secretPath = buildUnwritable('custom-path');
     const errors = [];
-    resolveTokenSecret({
-      env: { NODE_ENV: 'production' },
-      secretPath,
-      log: { warn: () => {}, error: (msg) => errors.push(msg) },
-      exit: () => {},
+    assert.throws(() => {
+      resolveTokenSecret({
+        env: { NODE_ENV: 'production' },
+        secretPath,
+        log: { warn: () => {}, error: (msg) => errors.push(msg) },
+        exit: () => {},
+      });
     });
-    // Guidance line should point at the dirname we actually tried to write.
     assert.ok(
       errors.some(m => m.includes(path.dirname(secretPath))),
       `expected an error to mention ${path.dirname(secretPath)}, got: ${errors.join(' | ')}`

--- a/test/token-secret.test.js
+++ b/test/token-secret.test.js
@@ -58,9 +58,10 @@ describe('readOrWritePersistedSecret', () => {
   });
 
   it('recovers when the secret file already exists but is empty', () => {
-    // Simulates the lose-a-race case: another process created the file
-    // between our read and our write. Exclusive-create fails EEXIST and
-    // we fall back to reading / (if empty) writing without wx.
+    // Simulates a concurrent or interrupted persistence case: the file
+    // is present (so the fast path falls through the trim-empty check)
+    // but carries no usable secret yet. tmp-file + renameSync repairs
+    // it by overwriting atomically.
     const p = path.join(tmpDir, 'empty', '.jss', 'token.secret');
     fs.mkdirSync(path.dirname(p), { recursive: true });
     fs.writeFileSync(p, '');

--- a/test/token-secret.test.js
+++ b/test/token-secret.test.js
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for TOKEN_SECRET resolution (src/auth/token-secret.js).
+ *
+ * Covers #280: TOKEN_SECRET auto-persists on first run rather than hard-exiting.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  readOrWritePersistedSecret,
+  resolveTokenSecret,
+  DEFAULT_SECRET_PATH,
+} from '../src/auth/token-secret.js';
+
+describe('readOrWritePersistedSecret', () => {
+  let tmpDir;
+  let secretPath;
+
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jss-token-secret-'));
+    secretPath = path.join(tmpDir, '.jss', 'token.secret');
+  });
+
+  after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('generates + persists a secret when the file is missing', () => {
+    const s = readOrWritePersistedSecret(secretPath);
+    assert.strictEqual(typeof s, 'string');
+    assert.strictEqual(s.length, 64); // 32 bytes, hex-encoded
+    assert.strictEqual(fs.readFileSync(secretPath, 'utf8').trim(), s);
+  });
+
+  it('returns the same secret on subsequent calls', () => {
+    const first  = readOrWritePersistedSecret(secretPath);
+    const second = readOrWritePersistedSecret(secretPath);
+    assert.strictEqual(first, second);
+  });
+
+  it('enforces tight permissions on POSIX (skipped on Windows)', { skip: process.platform === 'win32' }, () => {
+    const stat = fs.statSync(secretPath);
+    assert.strictEqual(stat.mode & 0o777, 0o600, 'secret file should be mode 0600');
+    const dirStat = fs.statSync(path.dirname(secretPath));
+    assert.strictEqual(dirStat.mode & 0o777, 0o700, 'secret dir should be mode 0700');
+  });
+
+  it('propagates errors other than ENOENT', () => {
+    // Use a regular file as the would-be parent directory — mkdirSync then
+    // fails with ENOTDIR synchronously. Portable across OSes.
+    const blockerFile = path.join(tmpDir, 'blocker-file');
+    fs.writeFileSync(blockerFile, 'not a dir');
+    const unwritable = path.join(blockerFile, '.jss', 'token.secret');
+    assert.throws(() => readOrWritePersistedSecret(unwritable));
+  });
+});
+
+describe('resolveTokenSecret', () => {
+  let tmpDir;
+
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jss-resolve-secret-'));
+  });
+
+  after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const silentLog = { warn: () => {}, error: () => {} };
+
+  it('prefers TOKEN_SECRET env var', () => {
+    const s = resolveTokenSecret({
+      env: { TOKEN_SECRET: 'from-env' },
+      secretPath: path.join(tmpDir, 'unused', 'token.secret'),
+      log: silentLog,
+    });
+    assert.strictEqual(s, 'from-env');
+  });
+
+  it('persists a generated secret when env is unset', () => {
+    const p = path.join(tmpDir, 'persist', 'token.secret');
+    const s = resolveTokenSecret({ env: {}, secretPath: p, log: silentLog });
+    assert.strictEqual(s.length, 64);
+    assert.strictEqual(fs.readFileSync(p, 'utf8').trim(), s);
+  });
+
+  it('returns the same persisted secret on the next call', () => {
+    const p = path.join(tmpDir, 'persist-twice', 'token.secret');
+    const first  = resolveTokenSecret({ env: {}, secretPath: p, log: silentLog });
+    const second = resolveTokenSecret({ env: {}, secretPath: p, log: silentLog });
+    assert.strictEqual(first, second);
+  });
+
+  // Build an unwritable path by planting a regular file where the helper
+  // would try to mkdir a directory. mkdirSync then fails synchronously.
+  function buildUnwritable(name) {
+    const blocker = path.join(tmpDir, name, 'blocker-file');
+    fs.mkdirSync(path.dirname(blocker), { recursive: true });
+    fs.writeFileSync(blocker, 'not a dir');
+    return path.join(blocker, '.jss', 'token.secret');
+  }
+
+  it('hard-exits in production when persistence fails', () => {
+    let exitCode;
+    resolveTokenSecret({
+      env: { NODE_ENV: 'production' },
+      secretPath: buildUnwritable('prod'),
+      log: silentLog,
+      exit: (code) => { exitCode = code; },
+    });
+    assert.strictEqual(exitCode, 1);
+  });
+
+  it('falls back to an ephemeral secret outside production when persistence fails', () => {
+    const s = resolveTokenSecret({
+      env: {},
+      secretPath: buildUnwritable('dev'),
+      log: silentLog,
+      exit: () => { throw new Error('exit should not be called in dev') },
+    });
+    assert.strictEqual(typeof s, 'string');
+    assert.strictEqual(s.length, 64);
+  });
+});
+
+describe('DEFAULT_SECRET_PATH', () => {
+  it('is absolute and platform-native', () => {
+    assert.ok(path.isAbsolute(DEFAULT_SECRET_PATH));
+    assert.ok(DEFAULT_SECRET_PATH.includes('.jss'));
+    assert.ok(DEFAULT_SECRET_PATH.includes('token.secret'));
+  });
+});


### PR DESCRIPTION
Fixes #280.

## Summary

Previously a production boot without a \`TOKEN_SECRET\` env var hard-exited. A beginner starting JSS under pm2 with \`NODE_ENV=production\` (a natural default) was greeted by a SECURITY ERROR that pointed at a \`node -e …\` command they might not even have in their shell path — see [serverproject-dev/solidweb.app#1](https://github.com/serverproject-dev/solidweb.app/issues/1) for exactly that scenario.

## Change

Resolution order is now:

1. \`TOKEN_SECRET\` env var — unchanged.
2. \`~/.jss/token.secret\` — auto-generated on first run, dir \`chmod 700\`, file \`chmod 600\`.
3. Hard-exit only when (1) is unset, (2) can't be written, **and** \`NODE_ENV=production\`. Dev falls back to an ephemeral random secret with a warning (matches prior dev behaviour).

Operators who set \`TOKEN_SECRET\` explicitly see no behaviour change.

## Why \`~/.jss\` and not \`<dataRoot>/.jss\`

\`urlToPath()\` does not filter dotfiles; the traversal guard only blocks \`..\`. A \`GET /.jss/token.secret\` against a server rooted at \`<dataRoot>\` would happily resolve to the secret file. Staying outside \`dataRoot\` sidesteps that entirely.

\`os.homedir()\` + \`path.join\` works cross-platform — same family as \`~/.npm\`, \`~/.gh\`, \`~/.docker\`, \`~/.aws\`. File mode 0o600 is honoured on POSIX and silently ignored on Windows (which uses ACLs) — passing it is harmless on Windows and correct on Linux/macOS.

## Structure

Pulled the resolution logic into \`src/auth/token-secret.js\` so it can be unit-tested. Importing \`token.js\` triggers \`solid-oidc.js\` / \`nostr.js\` / \`webid-tls.js\`, which do module-level work that keeps the \`node:test\` event loop alive — so tests that imported the full module hung. The new file has only stdlib imports.

## Test plan

- [x] New \`test/token-secret.test.js\` — 10 cases: env-wins, read-write cycle, same-secret-on-reread, POSIX permissions, non-ENOENT propagation, production-exit-on-failure, dev-ephemeral-on-failure. Uses a planted regular file to provoke \`ENOTDIR\` (portable across OSes — \`/proc/\` tricks hang on Linux).
- [x] Existing suite: \`npm test\` → 374/374 pass (was 364 before adding 10 new cases).
- [ ] Manual: \`NODE_ENV=production\` boot with no \`TOKEN_SECRET\` → server comes up, \`~/.jss/token.secret\` written with 0600.
- [ ] Manual: second boot → same secret read back, same tokens still valid.