### PR TITLE
Friendly /idp landing + /idp/auth no-client_id guard (#286, PR-A)

### DIFF
--- a/src/idp/index.js
+++ b/src/idp/index.js
@@ -162,7 +162,12 @@ export async function idpPlugin(fastify, options) {
       // Only catch the truly-bare case (no `client_id` param at all). An
       // explicit empty string is a malformed OIDC request — let
       // oidc-provider surface the spec error instead of redirecting.
-      if (request.method === 'GET' && request.query?.client_id === undefined) {
+      // HEAD is included so the friendly redirect also covers tools (and
+      // Fastify's auto-HEAD-from-GET) that probe with HEAD.
+      if (
+        (request.method === 'GET' || request.method === 'HEAD') &&
+        request.query?.client_id === undefined
+      ) {
         return reply.redirect('/idp');
       }
       return forwardToProvider(request, reply);

--- a/src/idp/index.js
+++ b/src/idp/index.js
@@ -156,14 +156,16 @@ export async function idpPlugin(fastify, options) {
   // return a raw `invalid_request` error page; we 302 to the friendly
   // landing instead. Real OIDC requests (with client_id) pass through.
   fastify.route({
-    method: ['GET', 'POST', 'DELETE', 'OPTIONS'],
+    // HEAD is listed explicitly so the route's contract doesn't depend on
+    // Fastify's auto-HEAD-from-GET (which `exposeHeadRoutes` can disable);
+    // the handler below treats HEAD the same as GET for the bare-client_id
+    // redirect.
+    method: ['GET', 'HEAD', 'POST', 'DELETE', 'OPTIONS'],
     url: '/idp/auth',
     handler: async (request, reply) => {
       // Only catch the truly-bare case (no `client_id` param at all). An
       // explicit empty string is a malformed OIDC request — let
       // oidc-provider surface the spec error instead of redirecting.
-      // HEAD is included so the friendly redirect also covers tools (and
-      // Fastify's auto-HEAD-from-GET) that probe with HEAD.
       if (
         (request.method === 'GET' || request.method === 'HEAD') &&
         request.query?.client_id === undefined

--- a/src/idp/index.js
+++ b/src/idp/index.js
@@ -24,6 +24,7 @@ import {
 } from './credentials.js';
 import * as passkey from './passkey.js';
 import { addTrustedIssuer } from '../auth/solid-oidc.js';
+import { landingPage } from './views.js';
 
 /**
  * IdP Fastify Plugin
@@ -140,7 +141,7 @@ export async function idpPlugin(fastify, options) {
 
   // Catch-all route for oidc-provider paths
   // Must be registered BEFORE specific routes to be matched as fallback
-  const oidcPaths = ['/idp/auth', '/idp/token', '/idp/reg', '/idp/me', '/idp/session', '/idp/session/*'];
+  const oidcPaths = ['/idp/token', '/idp/reg', '/idp/me', '/idp/session', '/idp/session/*'];
 
   for (const path of oidcPaths) {
     fastify.route({
@@ -150,8 +151,30 @@ export async function idpPlugin(fastify, options) {
     });
   }
 
+  // /idp/auth: guard against the human-fat-fingered case where someone opens
+  // the URL directly with no `client_id`. oidc-provider would otherwise
+  // return a raw `invalid_request` error page; we 302 to the friendly
+  // landing instead. Real OIDC requests (with client_id) pass through.
+  fastify.route({
+    method: ['GET', 'POST', 'DELETE', 'OPTIONS'],
+    url: '/idp/auth',
+    handler: async (request, reply) => {
+      if (request.method === 'GET' && !request.query?.client_id) {
+        return reply.redirect('/idp');
+      }
+      return forwardToProvider(request, reply);
+    },
+  });
+
   // Also handle /idp/auth/:uid for continued authorization after login
   fastify.get('/idp/auth/:uid', forwardToProvider);
+
+  // Friendly landing — Create Account button + sign-in note.
+  // Pairs with the /idp/auth guard above so a human visitor lands here
+  // rather than on a raw OIDC error.
+  fastify.get('/idp', async (request, reply) => {
+    return reply.type('text/html').send(landingPage({ baseUri: issuer }));
+  });
 
   // Token sub-paths
   fastify.route({

--- a/src/idp/index.js
+++ b/src/idp/index.js
@@ -159,7 +159,10 @@ export async function idpPlugin(fastify, options) {
     method: ['GET', 'POST', 'DELETE', 'OPTIONS'],
     url: '/idp/auth',
     handler: async (request, reply) => {
-      if (request.method === 'GET' && !request.query?.client_id) {
+      // Only catch the truly-bare case (no `client_id` param at all). An
+      // explicit empty string is a malformed OIDC request — let
+      // oidc-provider surface the spec error instead of redirecting.
+      if (request.method === 'GET' && request.query?.client_id === undefined) {
         return reply.redirect('/idp');
       }
       return forwardToProvider(request, reply);

--- a/src/idp/views.js
+++ b/src/idp/views.js
@@ -551,9 +551,6 @@ export function errorPage(title, message) {
 }
 
 /**
- * Registration page HTML
- */
-/**
  * Friendly landing page for the IdP root.
  *
  * The OIDC authorization endpoint (/idp/auth) requires a client_id; opening
@@ -624,6 +621,9 @@ export function landingPage(ctx = {}) {
   `;
 }
 
+/**
+ * Registration page HTML
+ */
 export function registerPage(uid = null, error = null, success = null, inviteOnly = false, ctx = {}) {
   const inviteField = inviteOnly ? `
       <label for="invite">Invite Code</label>

--- a/src/idp/views.js
+++ b/src/idp/views.js
@@ -723,7 +723,9 @@ export function registerPage(uid = null, error = null, success = null, inviteOnl
     </form>
 
     <p style="text-align: center; margin-top: 24px; color: #666; font-size: 14px;">
-      Already have an account? <a href="${uid ? `/idp/interaction/${uid}` : '/idp'}" style="color: #0066cc;">${uid ? 'Sign In' : 'Back to home'}</a>
+      ${uid
+        ? `Already have an account? <a href="/idp/interaction/${uid}" style="color: #0066cc;">Sign In</a>`
+        : `<a href="/idp" style="color: #0066cc;">Back to home</a>`}
     </p>
   </div>
 

--- a/src/idp/views.js
+++ b/src/idp/views.js
@@ -553,6 +553,77 @@ export function errorPage(title, message) {
 /**
  * Registration page HTML
  */
+/**
+ * Friendly landing page for the IdP root.
+ *
+ * The OIDC authorization endpoint (/idp/auth) requires a client_id; opening
+ * /idp manually used to drop the user into a raw OIDC error. This page is
+ * the human-navigable entry point — Create Account is wired up; Sign In is
+ * intentionally a description for now (PR-B / #286 will introduce a
+ * standalone /idp/login form).
+ */
+export function landingPage(ctx = {}) {
+  const issuer = ctx.baseUri || '';
+  return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Solid Pod Server</title>
+  <style>${styles}
+  /* landingPage local polish (#286) */
+  .container.landing { padding-top: 32px; }
+  .landing-header {
+    margin: -40px -40px 24px;
+    padding: 32px 40px 26px;
+    background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+    color: #fff;
+    border-radius: 12px 12px 0 0;
+    text-align: center;
+  }
+  .landing-header h1 { color: #fff; margin: 0 0 6px; font-size: 24px; }
+  .landing-header .subtitle { color: rgba(255,255,255,.85); margin: 0; font-size: 14px; }
+  .landing .signin-note {
+    margin-top: 18px;
+    padding: 14px 16px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    color: #475569;
+    font-size: 13px;
+    line-height: 1.55;
+  }
+  .landing .signin-note strong { color: #1e293b; }
+  .landing .issuer {
+    margin-top: 18px;
+    text-align: center;
+    color: #94a3b8;
+    font: 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+    word-break: break-all;
+  }
+  </style>
+</head>
+<body>
+  <div class="container landing">
+    <div class="landing-header">
+      <h1>Solid Pod Server</h1>
+      <p class="subtitle">Create an account, then sign in from any Solid app.</p>
+    </div>
+
+    <a href="/idp/register" class="btn btn-primary" style="text-decoration: none;">Create Account</a>
+
+    <div class="signin-note">
+      <strong>Already have an account?</strong> Sign in from inside the Solid app you want to use — the app will redirect here when authentication is needed.
+    </div>
+
+    ${issuer ? `<div class="issuer">Issuer: ${escapeHtml(issuer.replace(/\/$/, ''))}</div>` : ''}
+  </div>
+</body>
+</html>
+  `;
+}
+
 export function registerPage(uid = null, error = null, success = null, inviteOnly = false, ctx = {}) {
   const inviteField = inviteOnly ? `
       <label for="invite">Invite Code</label>
@@ -652,7 +723,7 @@ export function registerPage(uid = null, error = null, success = null, inviteOnl
     </form>
 
     <p style="text-align: center; margin-top: 24px; color: #666; font-size: 14px;">
-      Already have an account? <a href="${uid ? `/idp/interaction/${uid}` : '/idp/auth'}" style="color: #0066cc;">Sign In</a>
+      Already have an account? <a href="${uid ? `/idp/interaction/${uid}` : '/idp'}" style="color: #0066cc;">${uid ? 'Sign In' : 'Back to home'}</a>
     </p>
   </div>
 

--- a/src/server.js
+++ b/src/server.js
@@ -436,7 +436,9 @@ export function createServer(options = {}) {
     if (request.url === '/.pods' ||
         request.url === '/.notifications' ||
         request.method === 'OPTIONS' ||
+        request.url === '/idp' ||
         request.url.startsWith('/idp/') ||
+        request.url.startsWith('/idp?') ||
         request.url.startsWith('/.well-known/') ||
         (nostrEnabled && request.url.startsWith(nostrPath)) ||
         (gitEnabled && isGitRequest(request.url)) ||

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -203,11 +203,22 @@ describe('Identity Provider', () => {
     it('GET /idp/auth WITH client_id still reaches oidc-provider', async () => {
       // Sanity: the guard must not block real OIDC requests. We don't care
       // what oidc-provider does with this fake client_id (it'll likely
-      // surface its own error) — only that we did not 302 to /idp.
+      // surface its own error) — only that the guard did not redirect us.
       const res = await fetch(
         `${baseUrl}/idp/auth?client_id=test&redirect_uri=http://localhost&response_type=code&scope=openid`,
         { redirect: 'manual' }
       );
+      // Must NOT be a redirect (the guard's only effect would be a 302).
+      assert.ok(res.status < 300 || res.status >= 400,
+        `expected non-redirect response, got ${res.status}`);
+      // And must not have a Location header pointing anywhere.
+      assert.strictEqual(res.headers.get('location'), null);
+    });
+
+    it('GET /idp/auth with empty client_id is a malformed OIDC request, not bare', async () => {
+      // Tightened guard (=== undefined) lets ?client_id= pass through to
+      // oidc-provider rather than redirecting to /idp.
+      const res = await fetch(`${baseUrl}/idp/auth?client_id=`, { redirect: 'manual' });
       assert.notStrictEqual(res.headers.get('location'), '/idp');
     });
   });

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -200,19 +200,30 @@ describe('Identity Provider', () => {
       assert.strictEqual(res.headers.get('location'), '/idp');
     });
 
+    it('HEAD /idp/auth without client_id also redirects to /idp', async () => {
+      // Fastify auto-creates HEAD handlers for GET routes; the guard must
+      // catch HEAD too so probing tools land on the friendly page rather
+      // than the raw OIDC error.
+      const res = await fetch(`${baseUrl}/idp/auth`, { method: 'HEAD', redirect: 'manual' });
+      assert.strictEqual(res.status, 302);
+      assert.strictEqual(res.headers.get('location'), '/idp');
+    });
+
     it('GET /idp/auth WITH client_id still reaches oidc-provider', async () => {
-      // Sanity: the guard must not block real OIDC requests. We don't care
-      // what oidc-provider does with this fake client_id (it'll likely
-      // surface its own error) — only that the guard did not redirect us.
+      // Sanity: the guard must not block real OIDC requests. The provider
+      // may legitimately redirect (e.g. to /idp/interaction/:uid) for
+      // valid client/parameter combinations, so we test the precise
+      // contract — the guard's specific 302→/idp response — rather than
+      // "no redirect at all".
       const res = await fetch(
         `${baseUrl}/idp/auth?client_id=test&redirect_uri=http://localhost&response_type=code&scope=openid`,
         { redirect: 'manual' }
       );
-      // Must NOT be a redirect (the guard's only effect would be a 302).
-      assert.ok(res.status < 300 || res.status >= 400,
-        `expected non-redirect response, got ${res.status}`);
-      // And must not have a Location header pointing anywhere.
-      assert.strictEqual(res.headers.get('location'), null);
+      const location = res.headers.get('location');
+      assert.ok(
+        !(res.status === 302 && location === '/idp'),
+        `request should bypass the /idp guard, got ${res.status} → ${location}`
+      );
     });
 
     it('GET /idp/auth with empty client_id is a malformed OIDC request, not bare', async () => {

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -182,6 +182,36 @@ describe('Identity Provider', () => {
     });
   });
 
+  // Regression coverage for #286 — friendly /idp landing + /idp/auth guard.
+  describe('Landing page', () => {
+    it('GET /idp returns the landing HTML', async () => {
+      const res = await fetch(`${baseUrl}/idp`);
+      assert.strictEqual(res.status, 200);
+      assert.match(res.headers.get('content-type') || '', /text\/html/);
+      const body = await res.text();
+      assert.match(body, /Solid Pod Server/);
+      assert.match(body, /Create Account/);
+      assert.match(body, /href="\/idp\/register"/);
+    });
+
+    it('GET /idp/auth without client_id redirects to /idp', async () => {
+      const res = await fetch(`${baseUrl}/idp/auth`, { redirect: 'manual' });
+      assert.strictEqual(res.status, 302);
+      assert.strictEqual(res.headers.get('location'), '/idp');
+    });
+
+    it('GET /idp/auth WITH client_id still reaches oidc-provider', async () => {
+      // Sanity: the guard must not block real OIDC requests. We don't care
+      // what oidc-provider does with this fake client_id (it'll likely
+      // surface its own error) — only that we did not 302 to /idp.
+      const res = await fetch(
+        `${baseUrl}/idp/auth?client_id=test&redirect_uri=http://localhost&response_type=code&scope=openid`,
+        { redirect: 'manual' }
+      );
+      assert.notStrictEqual(res.headers.get('location'), '/idp');
+    });
+  });
+
   // Regression coverage for #284 — relaxed username regex + `..` rejection.
   // Each register call below also exercises the .jsonld pod-creation flow
   // from #283, since handleRegisterPost calls createPodStructure on success.


### PR DESCRIPTION
First half of #286 — the cheap, no-OIDC-risk parts. Standalone \`/idp/login\` and auto-login on register are deferred to PR-B (they share the \`oidc-provider\` session-minting unknown).

## What's new

- **\`GET /idp\`**: friendly landing card with gradient header (matches the register page from #284), single \"Create Account\" CTA, and a sign-in note explaining that login goes through the Solid app you want to use. Issuer URL displayed in the footer.
- **\`/idp/auth\` no-\`client_id\` guard**: a human opening \`/idp/auth\` directly used to get a raw \`invalid_request\` OIDC error. GET requests with no \`client_id\` now \`302 → /idp\`. Real OIDC requests (with \`client_id\`) pass through to \`oidc-provider\` unchanged.
- **Register page \"Sign In\" link**: previously pointed at \`/idp/auth\` (the broken-without-client_id endpoint), now points at \`/idp\`. The link text reads \"Back to home\" outside an interaction; \"Sign In\" inside one (where the link actually leads somewhere useful).
- **Auth bypass**: \`server.js\` already let \`/idp/*\` through unauthenticated — extended to cover the trailing-slash-less \`/idp\` and \`/idp?…\` so the landing is reachable without auth.

## Files

- \`src/idp/views.js\` — new \`landingPage()\` view, register Sign-In link repointed.
- \`src/idp/index.js\` — \`GET /idp\` route, \`/idp/auth\` pulled out of catch-all into a guarded handler.
- \`src/server.js\` — auth-bypass list extended for \`/idp\`.
- \`test/idp.test.js\` — three new cases covering the landing render, the redirect, and the pass-through.

## Test plan

- [x] Full suite: 394/394 pass (was 391).
- [x] Smoke against a live \`--idp\` server:
  - \`GET /idp\` → 200 \`text/html\` containing \"Solid Pod Server\" + \"Create Account\" + \`href=\"/idp/register\"\`.
  - \`GET /idp/auth\` (no client_id) → \`302 Location: /idp\`.
  - \`GET /idp/auth?client_id=test&…\` → 400 from oidc-provider, **not** redirected.

## What's still open under #286

PR-B will add:
- \`GET /idp/login\` (standalone form, no client_id required)
- \`POST /idp/login\` (authenticate + set OIDC session cookie)
- Auto-login on register (folds in once session-minting is solved)
- Re-link this landing page's sign-in note to a real \"Sign In\" button