### PR TITLE
/idp landing: name pilot as the example sign-in client (#288)

### DIFF
--- a/src/idp/views.js
+++ b/src/idp/views.js
@@ -592,6 +592,8 @@ export function landingPage(ctx = {}) {
     line-height: 1.55;
   }
   .landing .signin-note strong { color: #1e293b; }
+  .landing .signin-note a { color: #4f46e5; text-decoration: none; font-weight: 500; }
+  .landing .signin-note a:hover { text-decoration: underline; }
   .landing .issuer {
     margin-top: 18px;
     text-align: center;
@@ -611,7 +613,7 @@ export function landingPage(ctx = {}) {
     <a href="/idp/register" class="btn btn-primary" style="text-decoration: none;">Create Account</a>
 
     <div class="signin-note">
-      <strong>Already have an account?</strong> Sign in from inside the Solid app you want to use — the app will redirect here when authentication is needed.
+      <strong>Already have an account?</strong> Sign in from a Solid app — for example, <a href="https://solid-apps.github.io/pilot/" target="_blank" rel="noopener">pilot</a> is a minimal console you can open right now. Point it at this server and click Sign In.
     </div>
 
     ${issuer ? `<div class="issuer">Issuer: ${escapeHtml(issuer.replace(/\/$/, ''))}</div>` : ''}

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -192,6 +192,8 @@ describe('Identity Provider', () => {
       assert.match(body, /Solid Pod Server/);
       assert.match(body, /Create Account/);
       assert.match(body, /href="\/idp\/register"/);
+      // Sign-in note names pilot as the example client (#288).
+      assert.match(body, /solid-apps\.github\.io\/pilot/);
     });
 
     it('GET /idp/auth without client_id redirects to /idp', async () => {


### PR DESCRIPTION
Fixes #288.

## Change

Sign-in note on the \`/idp\` landing used to read \"Sign in from inside the Solid app you want to use\" — honest about today's standalone-login gap, but vague. Names [pilot](https://solid-apps.github.io/pilot/) as a concrete onramp instead:

> **Already have an account?** Sign in from a Solid app — for example, [pilot](https://solid-apps.github.io/pilot/) is a minimal console you can open right now. Point it at this server and click Sign In.

5-line change in \`landingPage()\` plus a small CSS rule so the link looks like a link.

## Why pilot, not mashlib

Different roles:
- mashlib is auto-injected on raw pod resources via \`--mashlib-module\` — always-there plumbing, doesn't need calling out on the landing.
- pilot is a focused console (Profile / Tasks / Settings) at a stable gh-pages URL — the inviting first impression a brand-new account is missing.

Both still have a place. The landing just names the inviting one.

## Files

- \`src/idp/views.js\` — sign-in note copy + 3-line CSS rule for link styling.
- \`test/idp.test.js\` — assert the landing body contains the pilot URL.

## Test plan

- [x] Full \`test/idp.test.js\`: 35/35 pass.
- [ ] Manual: open the landing, hover the \"pilot\" link, confirm it opens \`https://solid-apps.github.io/pilot/\` in a new tab.