### PR TITLE
CLI: add 'jss account delete' + refactor 'passwd' (#292)

### DIFF
--- a/bin/jss.js
+++ b/bin/jss.js
@@ -13,6 +13,7 @@ import { Command } from 'commander';
 import { createServer } from '../src/server.js';
 import { loadConfig, saveConfig, printConfig, defaults } from '../src/config.js';
 import { createInvite, listInvites, revokeInvite } from '../src/idp/invites.js';
+import { findByUsername, updatePassword, deleteAccount } from '../src/idp/accounts.js';
 import { setQuotaLimit, getQuotaInfo, reconcileQuota, formatBytes } from '../src/storage/quota.js';
 import { parseSize } from '../src/config.js';
 import crypto from 'crypto';
@@ -637,31 +638,11 @@ program
         process.env.DATA_ROOT = path.resolve(options.root);
       }
 
-      // Load account by username
-      const dataRoot = process.env.DATA_ROOT || './data';
-      const accountsDir = path.join(dataRoot, '.idp', 'accounts');
-      const indexPath = path.join(accountsDir, '_username_index.json');
-
-      let usernameIndex;
-      try {
-        usernameIndex = await fs.readJson(indexPath);
-      } catch (err) {
-        if (err.code === 'ENOENT') {
-          console.error(`Error: No accounts found (missing ${indexPath})`);
-          process.exit(1);
-        }
-        throw err;
-      }
-
-      const normalizedUsername = username.toLowerCase().trim();
-      const accountId = usernameIndex[normalizedUsername];
-      if (!accountId) {
+      const account = await findByUsername(username);
+      if (!account) {
         console.error(`Error: User not found: ${username}`);
         process.exit(1);
       }
-
-      const accountPath = path.join(accountsDir, `${accountId}.json`);
-      const account = await fs.readJson(accountPath);
 
       // Determine new password
       let newPassword;
@@ -673,8 +654,8 @@ program
       } else {
         // Interactive prompt
         newPassword = await promptPassword('New password: ');
-        const confirm = await promptPassword('Confirm password: ');
-        if (newPassword !== confirm) {
+        const confirmation = await promptPassword('Confirm password: ');
+        if (newPassword !== confirmation) {
           console.error('Error: Passwords do not match');
           process.exit(1);
         }
@@ -685,17 +666,63 @@ program
         process.exit(1);
       }
 
-      // Hash and save
-      const bcrypt = await import('bcryptjs').then(m => m.default);
-      account.passwordHash = await bcrypt.hash(newPassword, 10);
-      account.passwordChangedAt = new Date().toISOString();
-      await fs.writeJson(accountPath, account, { spaces: 2 });
+      await updatePassword(account.id, newPassword);
 
       if (options.generate) {
-        console.log(`\nPassword updated for ${normalizedUsername}`);
+        console.log(`\nPassword updated for ${account.username}`);
         console.log(`Generated password: ${newPassword}\n`);
       } else {
-        console.log(`\nPassword updated for ${normalizedUsername}\n`);
+        console.log(`\nPassword updated for ${account.username}\n`);
+      }
+    } catch (err) {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+  });
+
+/**
+ * Account commands - manage user accounts
+ */
+const accountCmd = program
+  .command('account')
+  .description('Manage user accounts');
+
+accountCmd
+  .command('delete <username>')
+  .description('Delete a user account from the IdP')
+  .option('-r, --root <path>',  'Data directory')
+  .option('-y, --yes',          'Skip the confirmation prompt')
+  .option('--purge',            'Also delete pod data at <dataRoot>/<username>/')
+  .action(async (username, options) => {
+    try {
+      if (options.root) {
+        process.env.DATA_ROOT = path.resolve(options.root);
+      }
+
+      const account = await findByUsername(username);
+      if (!account) {
+        console.error(`Error: User not found: ${username}`);
+        process.exit(1);
+      }
+
+      if (!options.yes) {
+        const summary = `Delete account '${account.username}' (${account.webId})${options.purge ? ' AND purge pod data' : ''}?`;
+        const ok = await confirm(summary, false);
+        if (!ok) {
+          console.log('Cancelled.');
+          process.exit(0);
+        }
+      }
+
+      await deleteAccount(account.id);
+
+      if (options.purge) {
+        const dataRoot = process.env.DATA_ROOT || './data';
+        const podPath = path.join(dataRoot, account.username);
+        await fs.remove(podPath);
+        console.log(`\nDeleted account ${account.username}. Pod data removed from ${podPath}.\n`);
+      } else {
+        console.log(`\nDeleted account ${account.username}. Pod data preserved at <dataRoot>/${account.username}/ (use --purge to remove).\n`);
       }
     } catch (err) {
       console.error(`Error: ${err.message}`);


### PR DESCRIPTION
Fixes #292.

## Two related changes

### 1. \`jss account delete <username>\` (new)

Wraps the existing \`accounts.deleteAccount(id)\` (which already prunes the username/email/webId indexes and removes the account JSON) behind a CLI surface. Operators no longer need to hand-edit JSON to drop an account.

\`\`\`
jss account delete melvin                       # confirm prompt, account record only
jss account delete melvin --yes                 # skip prompt
jss account delete melvin --yes --purge         # also remove <dataRoot>/melvin/
\`\`\`

\`--purge\` is **opt-in** because the two destructive levels are genuinely different:

- Account record removal revokes identity (recoverable — the user could re-register).
- Pod data removal is irreversible.

Default behaviour preserves pod data so you can re-bind a different account later or back it up before deletion. \`--purge\` is for the clean-slate case (which my smoke test confirmed lets you re-register the same username afterward).

### 2. \`jss passwd\` refactored to use the wrapper

Same external behaviour, but the body now calls \`findByUsername\` + \`updatePassword\` from \`src/idp/accounts.js\` instead of duplicating the index lookup and bcrypt hashing inline. ~40 fewer lines, single source of truth for the hashing parameters (\`SALT_ROUNDS\` lives in \`accounts.js\`; \`passwd\` no longer hard-codes \`10\`).

This brings \`passwd\` into the same shape as \`invite\` / \`quota\` / the new \`account delete\` — every CLI command consumes its corresponding \`src/\` module instead of re-implementing internals.

## Files

Single file: \`bin/jss.js\` (+58, -31).

## Test plan

- [x] Existing suite: 398/398 pass.
- [x] Manual smoke test against \`--idp\` server:
  - register charlie → \`jss account delete charlie --yes\` → account JSON gone, indexes pruned, pod dir preserved.
  - register charlie again with same name → still blocked (pod dir exists, JSS refuses duplicate).
  - register charlie → \`jss account delete charlie --yes --purge\` → account + pod dir both gone.
  - register charlie one more time → succeeds (clean slate).
  - register bob → \`jss passwd bob --password ...\` → password updated via wrapper.
- No unit tests added — the CLI isn't covered by any existing test suite. Worth a separate \`test/cli.test.js\` later but explicitly out of scope here.

## Non-goals

- Account list / info / disable subcommands — tracked separately.
- HTTP \`DELETE /idp/account\` self-service endpoint — needs an auth-story design (admin vs self), separate issue.
- Token / session revocation for the deleted account — tokens expire naturally; thorough revocation is its own concern.