### PR TITLE
Conneg: recognise .acl and .meta as RDF (#294) — unblocks umai

### DIFF
--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -239,6 +239,16 @@ export function getContentType(filePath) {
     '.m3u8': 'application/vnd.apple.mpegurl',
     '.pls': 'audio/x-scpls'
   };
+
+  // Solid convention dotfiles (.acl, .meta) are RDF resources. path.extname
+  // returns '' for leading-dot names, so the map lookup above misses them;
+  // fall back to a basename check and tag them as JSON-LD — the format JSS
+  // writes them in via serializeAcl() / createPodStructure(). Content
+  // negotiation then handles Turtle-native clients (umai, Soukai-based apps,
+  // older Solid tooling) via handleGet's conneg branch.
+  const base = path.basename(filePath);
+  if (base === '.acl' || base === '.meta') return 'application/ld+json';
+
   return types[ext] || 'application/octet-stream';
 }
 

--- a/test/conneg.test.js
+++ b/test/conneg.test.js
@@ -194,6 +194,73 @@ describe('Content Negotiation (conneg enabled)', () => {
         'Accept-Post should include text/turtle');
     });
   });
+
+  // Regression coverage for #294 — Solid convention dotfiles (.acl, .meta)
+  // were excluded from conneg because getContentType() returned
+  // application/octet-stream for them. Turtle-native clients (umai etc.)
+  // fetching <container>/.meta got JSON-LD back and errored on parse.
+  describe('Solid convention dotfiles (#294)', () => {
+    const metaData = {
+      '@context': { 'ldp': 'http://www.w3.org/ns/ldp#' },
+      '@id': '',
+      '@type': 'ldp:BasicContainer'
+    };
+
+    before(async () => {
+      // Write a JSON-LD .meta file (the format JSS writes internally).
+      await request('/connegtest/public/.meta', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/ld+json' },
+        body: JSON.stringify(metaData),
+        auth: 'connegtest'
+      });
+    });
+
+    it('serves .meta as JSON-LD by default', async () => {
+      const res = await request('/connegtest/public/.meta', { auth: 'connegtest' });
+      assertStatus(res, 200);
+      assertHeaderContains(res, 'Content-Type', 'application/ld+json');
+    });
+
+    it('serves .meta as Turtle when Accept: text/turtle (the umai case)', async () => {
+      const res = await request('/connegtest/public/.meta', {
+        headers: { 'Accept': 'text/turtle' },
+        auth: 'connegtest'
+      });
+      assertStatus(res, 200);
+      assertHeaderContains(res, 'Content-Type', 'text/turtle');
+      const turtle = await res.text();
+      // First byte after the `@prefix` block must parse as Turtle,
+      // not '{' (the bug signature umai hit).
+      assert.ok(!turtle.trimStart().startsWith('{'),
+        `response looks like JSON, not Turtle: ${turtle.slice(0, 60)}`);
+    });
+
+    it('accepts Turtle PUT to .meta and round-trips to JSON-LD', async () => {
+      const turtle = `
+        @prefix ldp: <http://www.w3.org/ns/ldp#>.
+        <> a ldp:BasicContainer.
+      `;
+      const putRes = await request('/connegtest/public/.meta', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'text/turtle' },
+        body: turtle,
+        auth: 'connegtest'
+      });
+      assert.ok(putRes.status < 300, `PUT turtle should succeed, got ${putRes.status}`);
+
+      // Default GET now serves the converted-and-stored JSON-LD.
+      const getRes = await request('/connegtest/public/.meta', {
+        headers: { 'Accept': 'application/ld+json' },
+        auth: 'connegtest'
+      });
+      assertStatus(getRes, 200);
+      assertHeaderContains(getRes, 'Content-Type', 'application/ld+json');
+      const body = await getRes.json();
+      assert.ok(body['@context'] || body['@graph'] || body['@type'] || body['@id'],
+        'round-tripped JSON-LD should have at least one @-keyword');
+    });
+  });
 });
 
 describe('Content Negotiation (conneg disabled - default)', () => {

--- a/test/url.test.js
+++ b/test/url.test.js
@@ -7,7 +7,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { getPodName } from '../src/utils/url.js';
+import { getPodName, getContentType } from '../src/utils/url.js';
 
 describe('getPodName', () => {
   describe('subdomain mode', () => {
@@ -70,6 +70,40 @@ describe('getPodName', () => {
 
     it('returns null for the root path', () => {
       assert.strictEqual(getPodName('/'), null);
+    });
+  });
+});
+
+// Regression coverage for #294 — .acl and .meta must be recognised as RDF
+// resources so content negotiation kicks in for Turtle-native clients.
+describe('getContentType', () => {
+  describe('extension-based mapping (existing)', () => {
+    it('maps .jsonld → application/ld+json', () => {
+      assert.strictEqual(getContentType('/x/card.jsonld'), 'application/ld+json');
+    });
+    it('maps .ttl → text/turtle', () => {
+      assert.strictEqual(getContentType('/x/card.ttl'), 'text/turtle');
+    });
+    it('falls back to application/octet-stream for unknown extensions', () => {
+      assert.strictEqual(getContentType('/x/file.xyz'), 'application/octet-stream');
+    });
+  });
+
+  describe('Solid convention dotfiles (#294)', () => {
+    it('treats .acl as application/ld+json (the format JSS writes it in)', () => {
+      assert.strictEqual(getContentType('/alice/public/.acl'), 'application/ld+json');
+      assert.strictEqual(getContentType('.acl'), 'application/ld+json');
+    });
+
+    it('treats .meta as application/ld+json', () => {
+      assert.strictEqual(getContentType('/alice/public/.meta'), 'application/ld+json');
+      assert.strictEqual(getContentType('.meta'), 'application/ld+json');
+    });
+
+    it('does not mistake non-dotfile paths containing .acl for ACL files', () => {
+      // A regular file that happens to have "acl" in its name/path stays
+      // classified by extension, not by coincidence.
+      assert.strictEqual(getContentType('/alice/notes/my-acl-plan.md'), 'text/markdown');
     });
   });
 });


### PR DESCRIPTION
Fixes #294.

## Summary

\`getContentType()\` in \`src/utils/url.js\` is extension-based, but \`path.extname()\` returns \`''\` for leading-dot names like \`.acl\` / \`.meta\` (node treats them as dotfiles). Both were falling through to \`application/octet-stream\`, which \`isRdfContentType()\` rejects, so \`handleGet\`'s conneg branch never ran for them.

**Visible break**: Turtle-native clients (umai, Soukai-based apps, older Solid tooling) fetching \`<container>/.meta\` got JSON-LD back and errored with \`MalformedSolidDocumentError: Malformed Turtle document — Expected entity but got { on line 2\`. Hit today against ewingson's \`test.solidweb.app\` pod (JSS 0.0.144, \`conneg: true\`).

**Latent twin**: same bug applies to \`.acl\`. Hasn't shown up yet because (a) JSS's internal \`parseAcl()\` is forgiving (tries JSON then Turtle), and (b) most clients read \`wac-allow\` instead of fetching \`.acl\` directly. But any strict-Turtle ACL editor pointed at any existing JSS pod would hit the same parser error.

## Change

One basename check in \`getContentType\`:

\`\`\`js
const base = path.basename(filePath);
if (base === '.acl' || base === '.meta') return 'application/ld+json';
\`\`\`

Mapped to \`application/ld+json\` (not \`text/turtle\`) because that's the format JSS already writes them in (\`serializeAcl()\`, \`createPodStructure()\`). Conneg handles translation for Turtle clients through \`handleGet\`'s existing JSON-LD-to-Turtle path, and \`handlePut\` already converts incoming Turtle to JSON-LD before storing when \`--conneg\` is on.

**Zero migration**: existing pods keep their JSON-LD-stored \`.acl\` / \`.meta\` files on disk. They become Turtle-servable immediately, no rewrite.

## Round-trip table

| Client | Request | Before | After |
|---|---|---|---|
| umai | \`GET .meta Accept: text/turtle\` | JSON-LD (parser error) | Turtle ✓ |
| umai | \`PUT .meta Content-Type: text/turtle\` | Stored as Turtle bytes | Converted to JSON-LD, stored ✓ |
| pilot | \`GET .meta Accept: application/ld+json\` | JSON-LD raw | JSON-LD raw (unchanged) ✓ |

## Files

- \`src/utils/url.js\` — 1 basename check in \`getContentType\`, 1 comment block.
- \`test/url.test.js\` — new \`getContentType\` describe block (6 cases; covers extension mapping, dotfile mapping, and a guard that non-dotfile paths containing \"acl\" aren't mistaken for ACL files).
- \`test/conneg.test.js\` — new \`Solid convention dotfiles (#294)\` block with 3 integration cases against a running \`--conneg\` server: GET .meta default → ld+json; GET .meta Accept turtle → turtle (the umai case, with an explicit regression-guard assertion that the body doesn't look like JSON); PUT turtle .meta → round-trips to JSON-LD.

## Test plan

- [x] \`node --test test/url.test.js\` — 17/17 pass.
- [x] \`node --test test/conneg.test.js\` — 18/18 pass.
- [x] \`npm test\` — 407/407 pass (was 398 + 9 new).
- [ ] Manual: point umai at \`test.solidweb.app\` after deploy. Should no longer \`{\` on line 2.

## Relation to #295

#295 proposes a sibling tightening: when \`--conneg\` is off, reject non-JSON-LD PUTs with 415 instead of silently storing corrupted bytes. That's a design-ier purity fix; deliberately kept separate from this PR so the real interop blocker (umai) ships first without getting stalled on 415-response bikeshed.