### PR TITLE
fix: publicTypeIndex.jsonld should be publicly readable

### DIFF
--- a/src/handlers/container.js
+++ b/src/handlers/container.js
@@ -197,9 +197,13 @@ export async function createPodStructure(name, webId, podUri, issuer, defaultQuo
   const privateAcl = generatePrivateAcl(`${podUri}private/`, webId);
   await storage.write(`${podPath}private/.acl`, serializeAcl(privateAcl));
 
-  // settings folder: owner only
+  // settings folder: owner only (contains private preferences)
   const settingsAcl = generatePrivateAcl(`${podUri}settings/`, webId);
   await storage.write(`${podPath}settings/.acl`, serializeAcl(settingsAcl));
+
+  // publicTypeIndex: public read, overrides the private default inherited from /settings/
+  const publicTypeIndexAcl = generateOwnerAcl(`${podUri}settings/publicTypeIndex.jsonld`, webId, false);
+  await storage.write(`${podPath}settings/publicTypeIndex.jsonld.acl`, serializeAcl(publicTypeIndexAcl));
 
   // Inbox: owner full, public append
   const inboxAcl = generateInboxAcl(`${podUri}inbox/`, webId);

--- a/src/server.js
+++ b/src/server.js
@@ -622,6 +622,10 @@ export function createServer(options = {}) {
     const settingsAcl = generatePrivateAcl(`${podUri}settings/`, webId);
     await storage.write('/settings/.acl', serializeAcl(settingsAcl));
 
+    // publicTypeIndex: public read, overrides the private default inherited from /settings/
+    const publicTypeIndexAcl = generateOwnerAcl(`${podUri}settings/publicTypeIndex.jsonld`, webId, false);
+    await storage.write('/settings/publicTypeIndex.jsonld.acl', serializeAcl(publicTypeIndexAcl));
+
     const inboxAcl = generateInboxAcl(`${podUri}inbox/`, webId);
     await storage.write('/inbox/.acl', serializeAcl(inboxAcl));
 

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -237,7 +237,10 @@ export function getContentType(filePath) {
     '.md': 'text/markdown',
     '.m3u': 'audio/mpegurl',
     '.m3u8': 'application/vnd.apple.mpegurl',
-    '.pls': 'audio/x-scpls'
+    '.pls': 'audio/x-scpls',
+    // Solid ACL/meta as extensions (e.g. publicTypeIndex.jsonld.acl)
+    '.acl': 'application/ld+json',
+    '.meta': 'application/ld+json'
   };
 
   // Solid convention dotfiles (.acl, .meta) are RDF resources. path.extname

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -409,6 +409,55 @@ describe('Identity Provider - Single-user mode landing', () => {
   });
 });
 
+// Root-level pod (singleUserName: '/') — verifies createRootPodStructure wires
+// publicTypeIndex as public-read and privateTypeIndex as owner-only.
+// Regression coverage for #297.
+describe('Identity Provider - Root pod type index ACLs', () => {
+  let server;
+  let baseUrl;
+  const ROOT_POD_DATA_DIR = './test-data-idp-root-pod';
+
+  before(async () => {
+    await fs.remove(ROOT_POD_DATA_DIR);
+    await fs.ensureDir(ROOT_POD_DATA_DIR);
+
+    const port = await getAvailablePort();
+    baseUrl = `http://${TEST_HOST}:${port}`;
+
+    server = createServer({
+      logger: false,
+      root: ROOT_POD_DATA_DIR,
+      idp: true,
+      idpIssuer: baseUrl,
+      singleUser: true,
+      singleUserName: '/',
+      forceCloseConnections: true,
+    });
+
+    await server.listen({ port, host: TEST_HOST });
+  });
+
+  after(async () => {
+    await server.close();
+    await fs.remove(ROOT_POD_DATA_DIR);
+  });
+
+  it('publicTypeIndex is readable without auth', async () => {
+    const res = await fetch(`${baseUrl}/settings/publicTypeIndex.jsonld`);
+    assert.strictEqual(res.status, 200);
+  });
+
+  it('privateTypeIndex requires auth', async () => {
+    const res = await fetch(`${baseUrl}/settings/privateTypeIndex.jsonld`);
+    assert.strictEqual(res.status, 401);
+  });
+
+  it('prefs requires auth', async () => {
+    const res = await fetch(`${baseUrl}/settings/prefs.jsonld`);
+    assert.strictEqual(res.status, 401);
+  });
+});
+
 describe('Identity Provider - Accounts', () => {
   let server;
   let accountsUrl;

--- a/test/pod.test.js
+++ b/test/pod.test.js
@@ -115,5 +115,21 @@ describe('Pod Lifecycle', () => {
       const privIndex = await request('/dan/settings/privateTypeIndex.jsonld', { auth: 'dan' });
       assertStatus(privIndex, 200);
     });
+
+    it('should make publicTypeIndex publicly readable but keep privateTypeIndex private', async () => {
+      await createTestPod('elsa');
+
+      // publicTypeIndex: no auth required (per Solid Type Indexes spec)
+      const pubIndex = await request('/elsa/settings/publicTypeIndex.jsonld');
+      assertStatus(pubIndex, 200);
+
+      // privateTypeIndex: auth required
+      const privIndex = await request('/elsa/settings/privateTypeIndex.jsonld');
+      assertStatus(privIndex, 401);
+
+      // prefs: auth required (private by inheritance from /settings/)
+      const prefs = await request('/elsa/settings/prefs.jsonld');
+      assertStatus(prefs, 401);
+    });
   });
 });

--- a/test/url.test.js
+++ b/test/url.test.js
@@ -106,4 +106,15 @@ describe('getContentType', () => {
       assert.strictEqual(getContentType('/alice/notes/my-acl-plan.md'), 'text/markdown');
     });
   });
+
+  describe('.acl / .meta as extensions (#297)', () => {
+    it('treats *.acl (extension) as application/ld+json', () => {
+      assert.strictEqual(getContentType('/settings/publicTypeIndex.jsonld.acl'), 'application/ld+json');
+      assert.strictEqual(getContentType('/alice/private/secret.json.acl'), 'application/ld+json');
+    });
+
+    it('treats *.meta (extension) as application/ld+json', () => {
+      assert.strictEqual(getContentType('/alice/resource.meta'), 'application/ld+json');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Write `settings/publicTypeIndex.jsonld.acl` during pod creation with public read + owner full control
- Overrides the private default inherited from `/settings/.acl`
- Applies to both container-based pods and single-user root-level pods

## Background
Solid apps rely on `publicTypeIndex` to discover what types of resources a user has (data browsers, contact apps, friend lists, etc.). Currently it inherits the owner-only ACL from `/settings/` and is unreachable.

Closes #297

## Test plan
- [x] All 407 tests pass