### PR TITLE
fix: add foaf:isPrimaryTopicOf to WebID profile

### DIFF
--- a/src/webid/profile.js
+++ b/src/webid/profile.js
@@ -24,7 +24,6 @@ const PIM = 'http://www.w3.org/ns/pim/space#';
  */
 export function generateProfileJsonLd({ webId, name, podUri, issuer }) {
   const pod = podUri.endsWith('/') ? podUri : podUri + '/';
-  const profileDoc = webId.split('#')[0];
 
   return {
     '@context': {
@@ -39,12 +38,14 @@ export function generateProfileJsonLd({ webId, name, podUri, issuer }) {
       'preferencesFile': { '@id': 'pim:preferencesFile', '@type': '@id' },
       'publicTypeIndex': { '@id': 'solid:publicTypeIndex', '@type': '@id' },
       'privateTypeIndex': { '@id': 'solid:privateTypeIndex', '@type': '@id' },
+      'isPrimaryTopicOf': { '@id': 'foaf:isPrimaryTopicOf', '@type': '@id' },
       'mainEntityOfPage': { '@id': 'schema:mainEntityOfPage', '@type': '@id' }
     },
     '@id': webId,
     '@type': ['foaf:Person', 'schema:Person'],
     'foaf:name': name,
-    'mainEntityOfPage': profileDoc,
+    'isPrimaryTopicOf': '',
+    'mainEntityOfPage': '',
     'inbox': `${pod}inbox/`,
     'storage': pod,
     'oidcIssuer': issuer,

--- a/test/webid.test.js
+++ b/test/webid.test.js
@@ -83,20 +83,20 @@ describe('WebID Profile', () => {
       assert.ok(jsonLd['inbox'].endsWith('/webidtest/inbox/'), 'Should have inbox');
     });
 
-    it('should have mainEntityOfPage', async () => {
+    it('should have mainEntityOfPage pointing to the document', async () => {
       const res = await request(profilePath);
       const jsonLd = await res.json();
 
-      // Empty string is a relative URI reference to the document itself
-      assert.ok('mainEntityOfPage' in jsonLd, 'Should have mainEntityOfPage');
+      // Empty string is a relative URI reference to the document itself (JSON-LD)
+      assert.strictEqual(jsonLd['mainEntityOfPage'], '', 'mainEntityOfPage should be "" (self)');
     });
 
     it('should have isPrimaryTopicOf pointing to the document', async () => {
       const res = await request(profilePath);
       const jsonLd = await res.json();
 
-      // Empty string is a relative URI reference to the document itself
-      assert.ok('isPrimaryTopicOf' in jsonLd, 'Should have foaf:isPrimaryTopicOf');
+      // Empty string is a relative URI reference to the document itself (JSON-LD)
+      assert.strictEqual(jsonLd['isPrimaryTopicOf'], '', 'isPrimaryTopicOf should be "" (self)');
     });
   });
 

--- a/test/webid.test.js
+++ b/test/webid.test.js
@@ -87,7 +87,16 @@ describe('WebID Profile', () => {
       const res = await request(profilePath);
       const jsonLd = await res.json();
 
-      assert.ok(jsonLd['mainEntityOfPage'], 'Should have mainEntityOfPage');
+      // Empty string is a relative URI reference to the document itself
+      assert.ok('mainEntityOfPage' in jsonLd, 'Should have mainEntityOfPage');
+    });
+
+    it('should have isPrimaryTopicOf pointing to the document', async () => {
+      const res = await request(profilePath);
+      const jsonLd = await res.json();
+
+      // Empty string is a relative URI reference to the document itself
+      assert.ok('isPrimaryTopicOf' in jsonLd, 'Should have foaf:isPrimaryTopicOf');
     });
   });
 


### PR DESCRIPTION
## Summary
- WebID profiles now include `foaf:isPrimaryTopicOf` pointing from `#me` to the document, per the [Solid WebID Profile spec](https://solid.github.io/webid-profile/)
- Uses empty string `""` as a relative URI reference to the document itself (standard JSON-LD pattern)
- Keeps existing `schema:mainEntityOfPage` for schema.org-aware consumers

## Why
Apps dereferencing the document URL need a way to find the subject WebID inside it. `foaf:isPrimaryTopicOf` (forward direction from agent to doc) is what the Solid WebID Profile spec recommends.

Closes #299

## Test plan
- [x] All 414 tests pass (1 new test)
- [x] Generated profile matches spec