### PR TITLE
fix: type indexes marked with solid:ListedDocument / solid:UnlistedDocument

### DIFF
--- a/src/handlers/container.js
+++ b/src/handlers/container.js
@@ -182,10 +182,10 @@ export async function createPodStructure(name, webId, podUri, issuer, defaultQuo
   await storage.write(`${podPath}settings/prefs.jsonld`, serialize(prefs));
 
   // Generate and write type indexes
-  const publicTypeIndex = generateTypeIndex(`${podUri}settings/publicTypeIndex.jsonld`);
+  const publicTypeIndex = generateTypeIndex(`${podUri}settings/publicTypeIndex.jsonld`, { listed: true });
   await storage.write(`${podPath}settings/publicTypeIndex.jsonld`, serialize(publicTypeIndex));
 
-  const privateTypeIndex = generateTypeIndex(`${podUri}settings/privateTypeIndex.jsonld`);
+  const privateTypeIndex = generateTypeIndex(`${podUri}settings/privateTypeIndex.jsonld`, { listed: false });
   await storage.write(`${podPath}settings/privateTypeIndex.jsonld`, serialize(privateTypeIndex));
 
   // Create default ACL files

--- a/src/server.js
+++ b/src/server.js
@@ -606,10 +606,10 @@ export function createServer(options = {}) {
     const prefs = generatePreferences({ webId, podUri });
     await storage.write('/settings/prefs.jsonld', serialize(prefs));
 
-    const publicTypeIndex = generateTypeIndex(`${podUri}settings/publicTypeIndex.jsonld`);
+    const publicTypeIndex = generateTypeIndex(`${podUri}settings/publicTypeIndex.jsonld`, { listed: true });
     await storage.write('/settings/publicTypeIndex.jsonld', serialize(publicTypeIndex));
 
-    const privateTypeIndex = generateTypeIndex(`${podUri}settings/privateTypeIndex.jsonld`);
+    const privateTypeIndex = generateTypeIndex(`${podUri}settings/privateTypeIndex.jsonld`, { listed: false });
     await storage.write('/settings/privateTypeIndex.jsonld', serialize(privateTypeIndex));
 
     // ACL files

--- a/src/webid/profile.js
+++ b/src/webid/profile.js
@@ -98,17 +98,25 @@ export function generatePreferences({ webId, podUri }) {
 }
 
 /**
- * Generate an empty type index
+ * Generate an empty type index.
+ * Per the Solid Type Indexes spec, a public index is additionally typed
+ * `solid:ListedDocument` and a private one `solid:UnlistedDocument`.
  * @param {string} uri - URI of the type index
+ * @param {object} [opts]
+ * @param {boolean} [opts.listed] - true for publicTypeIndex, false for privateTypeIndex.
+ *   If omitted, only `solid:TypeIndex` is set (back-compat).
  * @returns {object} JSON-LD type index document
  */
-export function generateTypeIndex(uri) {
+export function generateTypeIndex(uri, opts = {}) {
+  const types = ['solid:TypeIndex'];
+  if (opts.listed === true) types.push('solid:ListedDocument');
+  else if (opts.listed === false) types.push('solid:UnlistedDocument');
   return {
     '@context': {
       'solid': SOLID
     },
     '@id': uri,
-    '@type': 'solid:TypeIndex'
+    '@type': types.length === 1 ? types[0] : types
   };
 }
 

--- a/test/pod.test.js
+++ b/test/pod.test.js
@@ -131,5 +131,33 @@ describe('Pod Lifecycle', () => {
       const prefs = await request('/elsa/settings/prefs.jsonld');
       assertStatus(prefs, 401);
     });
+
+    it('should type indexes with ListedDocument / UnlistedDocument', async () => {
+      await createTestPod('frida');
+
+      const pub = await request('/frida/settings/publicTypeIndex.jsonld');
+      assertStatus(pub, 200);
+      const pubBody = await pub.json();
+      assert.ok(
+        Array.isArray(pubBody['@type']) && pubBody['@type'].includes('solid:ListedDocument'),
+        'publicTypeIndex should be solid:ListedDocument'
+      );
+      assert.ok(
+        Array.isArray(pubBody['@type']) && pubBody['@type'].includes('solid:TypeIndex'),
+        'publicTypeIndex should be solid:TypeIndex'
+      );
+
+      const priv = await request('/frida/settings/privateTypeIndex.jsonld', { auth: 'frida' });
+      assertStatus(priv, 200);
+      const privBody = await priv.json();
+      assert.ok(
+        Array.isArray(privBody['@type']) && privBody['@type'].includes('solid:UnlistedDocument'),
+        'privateTypeIndex should be solid:UnlistedDocument'
+      );
+      assert.ok(
+        Array.isArray(privBody['@type']) && privBody['@type'].includes('solid:TypeIndex'),
+        'privateTypeIndex should be solid:TypeIndex'
+      );
+    });
   });
 });

--- a/test/pod.test.js
+++ b/test/pod.test.js
@@ -132,7 +132,7 @@ describe('Pod Lifecycle', () => {
       assertStatus(prefs, 401);
     });
 
-    it('should type indexes with ListedDocument / UnlistedDocument', async () => {
+    it('should mark type indexes as ListedDocument / UnlistedDocument', async () => {
       await createTestPod('frida');
 
       const pub = await request('/frida/settings/publicTypeIndex.jsonld');


### PR DESCRIPTION
## Summary
- `generateTypeIndex()` now accepts `{ listed: true | false }` and emits the corresponding visibility marker
- publicTypeIndex → `[solid:TypeIndex, solid:ListedDocument]`
- privateTypeIndex → `[solid:TypeIndex, solid:UnlistedDocument]`
- Back-compat: calling without the option still produces `solid:TypeIndex` alone

## Why
Apps like pilot and SolidOS rely on these visibility types to distinguish public from private indexes. Matches the Solid Type Indexes spec and pivot's reference template.

Closes #301

## Test plan
- [x] All 415 tests pass (1 new)