### PR TITLE
feat: default landing page + ACL at server root (#276)

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -551,9 +551,18 @@ export function createServer(options = {}) {
   // Skipped in read-only mode — startup must not mutate DATA_ROOT.
   if (!options.readOnly) {
     fastify.addHook('onReady', async () => {
+      // Read the version from package.json — a missing or unreadable file
+      // (some production bundles omit it) shouldn't block seeding; fall
+      // back to "unknown" and continue.
+      let version = 'unknown';
       try {
         const pkg = await readFile(join(__dirname, '..', 'package.json'), 'utf8');
-        const { version } = JSON.parse(pkg);
+        ({ version } = JSON.parse(pkg));
+      } catch (err) {
+        fastify.log.warn({ err }, 'Failed to read package.json version; seeding server root with version=unknown');
+      }
+
+      try {
         await seedServerRoot({
           version,
           singleUser,

--- a/src/server.js
+++ b/src/server.js
@@ -569,7 +569,8 @@ export function createServer(options = {}) {
             notifications: notificationsEnabled,
             mashlib: mashlibEnabled,
             mongo: mongoEnabled,
-            tunnel: tunnelEnabled
+            tunnel: tunnelEnabled,
+            terminal: terminalEnabled
           }
         });
       } catch (err) {

--- a/src/server.js
+++ b/src/server.js
@@ -548,32 +548,35 @@ export function createServer(options = {}) {
 
   // Server-root landing page: seed /index.html and /.acl on first start
   // (skip-if-exists, operator customisations preserved). See #276.
-  fastify.addHook('onReady', async () => {
-    try {
-      const pkg = await readFile(join(__dirname, '..', 'package.json'), 'utf8');
-      const { version } = JSON.parse(pkg);
-      await seedServerRoot({
-        version,
-        singleUser,
-        idp: idpEnabled,
-        singleUserName,
-        enabled: {
+  // Skipped in read-only mode — startup must not mutate DATA_ROOT.
+  if (!options.readOnly) {
+    fastify.addHook('onReady', async () => {
+      try {
+        const pkg = await readFile(join(__dirname, '..', 'package.json'), 'utf8');
+        const { version } = JSON.parse(pkg);
+        await seedServerRoot({
+          version,
+          singleUser,
           idp: idpEnabled,
-          nostr: nostrEnabled,
-          webrtc: webrtcEnabled,
-          activitypub: activitypubEnabled,
-          git: gitEnabled,
-          pay: payEnabled,
-          notifications: notificationsEnabled,
-          mashlib: mashlibEnabled,
-          mongo: mongoEnabled,
-          tunnel: tunnelEnabled
-        }
-      });
-    } catch (err) {
-      fastify.log.warn({ err }, 'Failed to seed server root');
-    }
-  });
+          singleUserName,
+          enabled: {
+            idp: idpEnabled,
+            nostr: nostrEnabled,
+            webrtc: webrtcEnabled,
+            activitypub: activitypubEnabled,
+            git: gitEnabled,
+            pay: payEnabled,
+            notifications: notificationsEnabled,
+            mashlib: mashlibEnabled,
+            mongo: mongoEnabled,
+            tunnel: tunnelEnabled
+          }
+        });
+      } catch (err) {
+        fastify.log.warn({ err }, 'Failed to seed server root');
+      }
+    });
+  }
 
   // Single-user mode: create pod on startup if it doesn't exist
   if (singleUser) {

--- a/src/server.js
+++ b/src/server.js
@@ -571,7 +571,7 @@ export function createServer(options = {}) {
         }
       });
     } catch (err) {
-      fastify.log.warn(`Failed to seed server root: ${err.message}`);
+      fastify.log.warn({ err }, 'Failed to seed server root');
     }
   });
 

--- a/src/server.js
+++ b/src/server.js
@@ -21,6 +21,7 @@ import { dbPlugin } from './db/index.js';
 import { webrtcPlugin } from './webrtc/index.js';
 import { tunnelPlugin } from './tunnel/index.js';
 import { terminalPlugin } from './terminal/index.js';
+import { seedServerRoot } from './ui/server-root.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -544,6 +545,35 @@ export function createServer(options = {}) {
   fastify.head('/', handleHead);
   fastify.options('/', handleOptions);
   fastify.post('/', writeRateLimit, handlePost);
+
+  // Server-root landing page: seed /index.html and /.acl on first start
+  // (skip-if-exists, operator customisations preserved). See #276.
+  fastify.addHook('onReady', async () => {
+    try {
+      const pkg = await readFile(join(__dirname, '..', 'package.json'), 'utf8');
+      const { version } = JSON.parse(pkg);
+      await seedServerRoot({
+        version,
+        singleUser,
+        idp: idpEnabled,
+        singleUserName,
+        enabled: {
+          idp: idpEnabled,
+          nostr: nostrEnabled,
+          webrtc: webrtcEnabled,
+          activitypub: activitypubEnabled,
+          git: gitEnabled,
+          pay: payEnabled,
+          notifications: notificationsEnabled,
+          mashlib: mashlibEnabled,
+          mongo: mongoEnabled,
+          tunnel: tunnelEnabled
+        }
+      });
+    } catch (err) {
+      fastify.log.warn(`Failed to seed server root: ${err.message}`);
+    }
+  });
 
   // Single-user mode: create pod on startup if it doesn't exist
   if (singleUser) {

--- a/src/ui/server-root.html
+++ b/src/ui/server-root.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{title}}</title>
+  <meta name="description" content="A personal data server powered by JSS">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: Georgia, 'Times New Roman', serif;
+      background: #fafaf8;
+      color: #2c2c2c;
+      line-height: 1.7;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+    }
+    .container { max-width: 560px; width: 100%; }
+    h1 { font-size: 2.2rem; font-weight: 400; margin-bottom: 0.25rem; }
+    .subtitle { color: #666; font-size: 1.05rem; margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid #ddd; }
+    p { margin-bottom: 1.25rem; }
+    .actions { display: flex; gap: 0.75rem; margin: 1.5rem 0 2rem; flex-wrap: wrap; }
+    .btn {
+      display: inline-block;
+      padding: 0.6rem 1.2rem;
+      border-radius: 4px;
+      text-decoration: none;
+      font-family: Georgia, serif;
+      font-size: 0.95rem;
+      border: 1px solid transparent;
+      cursor: pointer;
+      transition: all 0.1s;
+    }
+    .btn-primary { background: #7c3aed; color: #fff; }
+    .btn-primary:hover { background: #6025c0; }
+    .btn-secondary { background: #fff; color: #2c2c2c; border-color: #ccc; }
+    .btn-secondary:hover { background: #f0efeb; }
+    .info { background: #f5f4f0; border-radius: 4px; padding: 1rem; font-size: 0.85rem; color: #666; margin-top: 1.5rem; }
+    .info .row { display: flex; justify-content: space-between; padding: 0.2rem 0; }
+    .info .label { color: #999; }
+    .info code { font-family: 'SFMono-Regular', Consolas, monospace; font-size: 0.9em; color: #555; }
+    footer { margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #ddd; color: #999; font-size: 0.8rem; text-align: center; }
+    footer a { color: #888; }
+    .features { font-size: 0.85rem; color: #666; margin-top: 0.5rem; }
+    .features span { display: inline-block; background: #eee; padding: 0.15rem 0.5rem; border-radius: 3px; margin-right: 0.3rem; margin-bottom: 0.3rem; font-family: 'SFMono-Regular', Consolas, monospace; font-size: 0.8rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>{{heading}}</h1>
+    <div class="subtitle">{{subtitle}}</div>
+    <p>{{description}}</p>
+
+    {{actions}}
+
+    <div class="info">
+      <div class="row"><span class="label">Version</span><code>{{version}}</code></div>
+      <div class="row"><span class="label">Mode</span><code>{{mode}}</code></div>
+      <div class="features">{{features}}</div>
+    </div>
+
+    <footer>
+      Powered by <a href="https://jss.live">JSS</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/src/ui/server-root.js
+++ b/src/ui/server-root.js
@@ -1,0 +1,161 @@
+/**
+ * Server-root landing page.
+ *
+ * Renders src/ui/server-root.html with runtime values, and seeds
+ * DATA_ROOT/index.html + DATA_ROOT/.acl on first start (skip-if-exists,
+ * so operator customisation is preserved).
+ *
+ * See issue #276.
+ */
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import * as storage from '../storage/filesystem.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEMPLATE_PATH = join(__dirname, 'server-root.html');
+
+/**
+ * Collect the list of enabled features for display on the landing page.
+ */
+function listFeatures(options = {}) {
+  const f = [];
+  if (options.idp) f.push('idp');
+  if (options.nostr) f.push('nostr');
+  if (options.webrtc) f.push('webrtc');
+  if (options.activitypub) f.push('activitypub');
+  if (options.git) f.push('git');
+  if (options.pay) f.push('payments');
+  if (options.notifications) f.push('notifications');
+  if (options.mashlib) f.push('mashlib');
+  if (options.mongo) f.push('mongo');
+  if (options.tunnel) f.push('tunnel');
+  return f;
+}
+
+/**
+ * Build an HTML snippet of action buttons based on server mode.
+ */
+function renderActions({ singleUser, idp }) {
+  const buttons = [];
+  if (!singleUser && idp) {
+    buttons.push('<a href="/.account/new" class="btn btn-primary">Create a pod</a>');
+    buttons.push('<a href="/idp/auth" class="btn btn-secondary">Sign in</a>');
+  } else if (singleUser && idp) {
+    buttons.push('<a href="/idp/auth" class="btn btn-primary">Sign in</a>');
+  }
+  buttons.push('<a href="https://javascriptsolidserver.github.io/docs/" class="btn btn-secondary">Docs</a>');
+  return `<div class="actions">${buttons.join('\n      ')}</div>`;
+}
+
+/**
+ * Render the landing page as an HTML string.
+ *
+ * @param {object} ctx
+ * @param {string} ctx.version - JSS version
+ * @param {boolean} [ctx.singleUser]
+ * @param {boolean} [ctx.idp]
+ * @param {string} [ctx.singleUserName]
+ * @param {object} [ctx.enabled] - Map of feature flags
+ * @returns {string} HTML
+ */
+export function renderServerRoot(ctx = {}) {
+  const { version = 'unknown', singleUser = false, idp = false, singleUserName, enabled = {} } = ctx;
+
+  const tpl = readFileSync(TEMPLATE_PATH, 'utf8');
+  const mode = singleUser ? 'single-user' : 'multi-user';
+  const features = listFeatures(enabled)
+    .map(f => `<span>${f}</span>`)
+    .join(' ');
+
+  const heading = 'JSS';
+  const subtitle = singleUser
+    ? `Personal pod${singleUserName && singleUserName !== '/' ? ` for ${escape(singleUserName)}` : ''}`
+    : 'A personal data server';
+  const description = singleUser
+    ? 'This server hosts a personal data pod. Apps come to the data rather than the other way around.'
+    : 'This server hosts personal data pods on the web. Each pod is a space you own, with your own identity and access control.';
+
+  return tpl
+    .replace(/{{title}}/g, heading)
+    .replace(/{{heading}}/g, heading)
+    .replace(/{{subtitle}}/g, subtitle)
+    .replace(/{{description}}/g, description)
+    .replace(/{{actions}}/g, renderActions({ singleUser, idp }))
+    .replace(/{{version}}/g, escape(version))
+    .replace(/{{mode}}/g, mode)
+    .replace(/{{features}}/g, features);
+}
+
+function escape(s = '') {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Seed DATA_ROOT/index.html and DATA_ROOT/.acl if they don't already
+ * exist. Operator's own files are never overwritten.
+ *
+ * Default ACL at root: public read. Write access is not granted — the
+ * operator edits the file on disk, not via the web.
+ *
+ * @param {object} ctx - Same context passed to renderServerRoot
+ * @returns {Promise<{seeded: boolean}>}
+ */
+export async function seedServerRoot(ctx = {}) {
+  let seededHtml = false;
+  let seededAcl = false;
+
+  // Seed /index.html if operator hasn't written one.
+  if (!(await storage.exists('/index.html'))) {
+    const html = renderServerRoot(ctx);
+    await storage.write('/index.html', html);
+    seededHtml = true;
+  }
+
+  // Seed /.acl if one doesn't already exist. Public read on the container
+  // itself — so GET / serves the landing page. Independent of index.html.
+  // (createRootPodStructure in single-user mode writes its own ACL and
+  // runs in a later hook, which will overwrite this if needed.)
+  if (!(await storage.exists('/.acl'))) {
+    const acl = JSON.stringify({
+      '@context': { acl: 'http://www.w3.org/ns/auth/acl#', foaf: 'http://xmlns.com/foaf/0.1/' },
+      '@graph': [
+        {
+          '@id': '#public',
+          '@type': 'acl:Authorization',
+          'acl:agentClass': { '@id': 'foaf:Agent' },
+          'acl:accessTo': { '@id': '/' },
+          'acl:mode': [{ '@id': 'acl:Read' }]
+        }
+      ]
+    }, null, 2);
+    await storage.write('/.acl', acl);
+    seededAcl = true;
+  }
+
+  // Dedicated ACL for the landing page itself — public read. The container
+  // ACL above has no acl:default (we don't want to implicitly publish all
+  // children), so /index.html needs its own rule when fetched directly.
+  if (!(await storage.exists('/index.html.acl'))) {
+    const pageAcl = JSON.stringify({
+      '@context': { acl: 'http://www.w3.org/ns/auth/acl#', foaf: 'http://xmlns.com/foaf/0.1/' },
+      '@graph': [
+        {
+          '@id': '#public',
+          '@type': 'acl:Authorization',
+          'acl:agentClass': { '@id': 'foaf:Agent' },
+          'acl:accessTo': { '@id': '/index.html' },
+          'acl:mode': [{ '@id': 'acl:Read' }]
+        }
+      ]
+    }, null, 2);
+    await storage.write('/index.html.acl', pageAcl);
+  }
+
+  return { seededHtml, seededAcl };
+}

--- a/src/ui/server-root.js
+++ b/src/ui/server-root.js
@@ -12,6 +12,7 @@ import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import * as storage from '../storage/filesystem.js';
+import { generatePublicReadAcl, serializeAcl } from '../wac/parser.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATE_PATH = join(__dirname, 'server-root.html');
@@ -96,25 +97,6 @@ function escape(s = '') {
     .replace(/"/g, '&quot;');
 }
 
-/**
- * Build a public-read-only ACL (no owner) for the server root.
- * The existing WAC generators all require an owner WebID; the server
- * root has none, so this is a tiny local helper.
- */
-function publicReadAcl(target) {
-  return JSON.stringify({
-    '@context': { acl: 'http://www.w3.org/ns/auth/acl#', foaf: 'http://xmlns.com/foaf/0.1/' },
-    '@graph': [
-      {
-        '@id': '#public',
-        '@type': 'acl:Authorization',
-        'acl:agentClass': { '@id': 'foaf:Agent' },
-        'acl:accessTo': { '@id': target },
-        'acl:mode': [{ '@id': 'acl:Read' }]
-      }
-    ]
-  }, null, 2);
-}
 
 /**
  * Seed DATA_ROOT/index.html, DATA_ROOT/.acl and DATA_ROOT/index.html.acl
@@ -152,7 +134,7 @@ export async function seedServerRoot(ctx = {}) {
   // (createRootPodStructure in single-user mode writes its own ACL and
   // runs in a later hook, which will overwrite this if needed.)
   if (!(await storage.exists('/.acl'))) {
-    const ok = await storage.write('/.acl', publicReadAcl('/'));
+    const ok = await storage.write('/.acl', serializeAcl(generatePublicReadAcl('/')));
     if (ok) seededAcl = true;
   }
 
@@ -160,7 +142,7 @@ export async function seedServerRoot(ctx = {}) {
   // ACL above has no acl:default (we don't want to implicitly publish all
   // children), so /index.html needs its own rule when fetched directly.
   if (!(await storage.exists('/index.html.acl'))) {
-    const ok = await storage.write('/index.html.acl', publicReadAcl('/index.html'));
+    const ok = await storage.write('/index.html.acl', serializeAcl(generatePublicReadAcl('/index.html')));
     if (ok) seededPageAcl = true;
   }
 

--- a/src/ui/server-root.js
+++ b/src/ui/server-root.js
@@ -40,10 +40,10 @@ function listFeatures(options = {}) {
 function renderActions({ singleUser, idp }) {
   const buttons = [];
   if (!singleUser && idp) {
-    buttons.push('<a href="/.account/new" class="btn btn-primary">Create a pod</a>');
-    buttons.push('<a href="/idp/auth" class="btn btn-secondary">Sign in</a>');
+    buttons.push('<a href="/idp/register" class="btn btn-primary">Create a pod</a>');
+    buttons.push('<a href="/idp" class="btn btn-secondary">Sign in</a>');
   } else if (singleUser && idp) {
-    buttons.push('<a href="/idp/auth" class="btn btn-primary">Sign in</a>');
+    buttons.push('<a href="/idp" class="btn btn-primary">Sign in</a>');
   }
   buttons.push('<a href="https://javascriptsolidserver.github.io/docs/" class="btn btn-secondary">Docs</a>');
   return `<div class="actions">${buttons.join('\n      ')}</div>`;
@@ -97,23 +97,53 @@ function escape(s = '') {
 }
 
 /**
- * Seed DATA_ROOT/index.html and DATA_ROOT/.acl if they don't already
- * exist. Operator's own files are never overwritten.
+ * Build a public-read-only ACL (no owner) for the server root.
+ * The existing WAC generators all require an owner WebID; the server
+ * root has none, so this is a tiny local helper.
+ */
+function publicReadAcl(target) {
+  return JSON.stringify({
+    '@context': { acl: 'http://www.w3.org/ns/auth/acl#', foaf: 'http://xmlns.com/foaf/0.1/' },
+    '@graph': [
+      {
+        '@id': '#public',
+        '@type': 'acl:Authorization',
+        'acl:agentClass': { '@id': 'foaf:Agent' },
+        'acl:accessTo': { '@id': target },
+        'acl:mode': [{ '@id': 'acl:Read' }]
+      }
+    ]
+  }, null, 2);
+}
+
+/**
+ * Seed DATA_ROOT/index.html, DATA_ROOT/.acl and DATA_ROOT/index.html.acl
+ * if they don't already exist. Operator's own files are never overwritten.
  *
- * Default ACL at root: public read. Write access is not granted — the
- * operator edits the file on disk, not via the web.
+ * Default ACL: public read. No write access — the operator edits
+ * /index.html on disk, not via the web.
+ *
+ * If the HTML write fails (permissions, full disk, read-only DATA_ROOT),
+ * ACL seeding is aborted to avoid leaving the server with a public-read
+ * root ACL and no index page.
  *
  * @param {object} ctx - Same context passed to renderServerRoot
- * @returns {Promise<{seeded: boolean}>}
+ * @returns {Promise<{seededHtml: boolean, seededAcl: boolean, seededPageAcl: boolean}>}
  */
 export async function seedServerRoot(ctx = {}) {
   let seededHtml = false;
   let seededAcl = false;
+  let seededPageAcl = false;
 
   // Seed /index.html if operator hasn't written one.
   if (!(await storage.exists('/index.html'))) {
     const html = renderServerRoot(ctx);
-    await storage.write('/index.html', html);
+    const ok = await storage.write('/index.html', html);
+    if (!ok) {
+      // Don't proceed with ACLs if the page itself failed to write —
+      // leaves us in a consistent unchanged state.
+      return { seededHtml: false, seededAcl: false, seededPageAcl: false };
+    }
     seededHtml = true;
   }
 
@@ -122,40 +152,17 @@ export async function seedServerRoot(ctx = {}) {
   // (createRootPodStructure in single-user mode writes its own ACL and
   // runs in a later hook, which will overwrite this if needed.)
   if (!(await storage.exists('/.acl'))) {
-    const acl = JSON.stringify({
-      '@context': { acl: 'http://www.w3.org/ns/auth/acl#', foaf: 'http://xmlns.com/foaf/0.1/' },
-      '@graph': [
-        {
-          '@id': '#public',
-          '@type': 'acl:Authorization',
-          'acl:agentClass': { '@id': 'foaf:Agent' },
-          'acl:accessTo': { '@id': '/' },
-          'acl:mode': [{ '@id': 'acl:Read' }]
-        }
-      ]
-    }, null, 2);
-    await storage.write('/.acl', acl);
-    seededAcl = true;
+    const ok = await storage.write('/.acl', publicReadAcl('/'));
+    if (ok) seededAcl = true;
   }
 
   // Dedicated ACL for the landing page itself — public read. The container
   // ACL above has no acl:default (we don't want to implicitly publish all
   // children), so /index.html needs its own rule when fetched directly.
   if (!(await storage.exists('/index.html.acl'))) {
-    const pageAcl = JSON.stringify({
-      '@context': { acl: 'http://www.w3.org/ns/auth/acl#', foaf: 'http://xmlns.com/foaf/0.1/' },
-      '@graph': [
-        {
-          '@id': '#public',
-          '@type': 'acl:Authorization',
-          'acl:agentClass': { '@id': 'foaf:Agent' },
-          'acl:accessTo': { '@id': '/index.html' },
-          'acl:mode': [{ '@id': 'acl:Read' }]
-        }
-      ]
-    }, null, 2);
-    await storage.write('/index.html.acl', pageAcl);
+    const ok = await storage.write('/index.html.acl', publicReadAcl('/index.html'));
+    if (ok) seededPageAcl = true;
   }
 
-  return { seededHtml, seededAcl };
+  return { seededHtml, seededAcl, seededPageAcl };
 }

--- a/src/ui/server-root.js
+++ b/src/ui/server-root.js
@@ -32,6 +32,7 @@ function listFeatures(options = {}) {
   if (options.mashlib) f.push('mashlib');
   if (options.mongo) f.push('mongo');
   if (options.tunnel) f.push('tunnel');
+  if (options.terminal) f.push('terminal');
   return f;
 }
 

--- a/test/server-root.test.js
+++ b/test/server-root.test.js
@@ -1,0 +1,71 @@
+/**
+ * Server-root landing page seed (#276).
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs-extra';
+import { createServer } from '../src/server.js';
+import { startTestServer, stopTestServer, request, assertStatus } from './helpers.js';
+
+describe('Server-root landing page', () => {
+  before(async () => {
+    await startTestServer();
+  });
+
+  after(async () => {
+    await stopTestServer();
+  });
+
+  it('seeds /index.html so GET / serves HTML', async () => {
+    const res = await request('/', { headers: { Accept: 'text/html' } });
+    assertStatus(res, 200);
+    const body = await res.text();
+    assert.match(body, /<title>JSS<\/title>/);
+    assert.match(body, /A personal data server/);
+  });
+
+  it('landing page is publicly readable (no auth required)', async () => {
+    const res = await request('/index.html');
+    assertStatus(res, 200);
+  });
+});
+
+// Operator's existing /index.html is preserved — dedicated server + data dir.
+describe('Server-root landing — operator override', () => {
+  let server;
+  let baseUrl;
+  const DATA_DIR = './test-data-server-root-override';
+  const CUSTOM_HTML = '<!doctype html><html><body>my custom page</body></html>';
+
+  before(async () => {
+    await fs.remove(DATA_DIR);
+    await fs.ensureDir(DATA_DIR);
+    await fs.writeFile(`${DATA_DIR}/index.html`, CUSTOM_HTML);
+
+    server = createServer({
+      logger: false,
+      root: DATA_DIR,
+      forceCloseConnections: true,
+    });
+    await server.listen({ port: 0, host: '127.0.0.1' });
+    baseUrl = `http://127.0.0.1:${server.server.address().port}`;
+  });
+
+  after(async () => {
+    await server.close();
+    await fs.remove(DATA_DIR);
+  });
+
+  it('does not overwrite operator-provided /index.html', async () => {
+    const current = await fs.readFile(`${DATA_DIR}/index.html`, 'utf8');
+    assert.strictEqual(current, CUSTOM_HTML);
+  });
+
+  it('GET / serves operator custom page', async () => {
+    const res = await fetch(`${baseUrl}/`, { headers: { Accept: 'text/html' } });
+    assert.strictEqual(res.status, 200);
+    const body = await res.text();
+    assert.match(body, /my custom page/);
+  });
+});

--- a/test/server-root.test.js
+++ b/test/server-root.test.js
@@ -35,10 +35,16 @@ describe('Server-root landing page', () => {
 describe('Server-root landing — operator override', () => {
   let server;
   let baseUrl;
+  let savedDataRoot;
   const DATA_DIR = './test-data-server-root-override';
   const CUSTOM_HTML = '<!doctype html><html><body>my custom page</body></html>';
 
   before(async () => {
+    // Capture process.env.DATA_ROOT — createServer mutates it when options.root
+    // is provided. Restore in after() to avoid cross-test interference with
+    // suites that rely on the default ./data dir.
+    savedDataRoot = process.env.DATA_ROOT;
+
     await fs.remove(DATA_DIR);
     await fs.ensureDir(DATA_DIR);
     await fs.writeFile(`${DATA_DIR}/index.html`, CUSTOM_HTML);
@@ -55,6 +61,8 @@ describe('Server-root landing — operator override', () => {
   after(async () => {
     await server.close();
     await fs.remove(DATA_DIR);
+    if (savedDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = savedDataRoot;
   });
 
   it('does not overwrite operator-provided /index.html', async () => {

--- a/test/server-root.test.js
+++ b/test/server-root.test.js
@@ -6,6 +6,7 @@ import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
 import fs from 'fs-extra';
 import { createServer } from '../src/server.js';
+import { renderServerRoot } from '../src/ui/server-root.js';
 import { startTestServer, stopTestServer, request, assertStatus } from './helpers.js';
 
 describe('Server-root landing page', () => {
@@ -75,5 +76,57 @@ describe('Server-root landing — operator override', () => {
     assert.strictEqual(res.status, 200);
     const body = await res.text();
     assert.match(body, /my custom page/);
+  });
+});
+
+describe('renderServerRoot — mode-specific output', () => {
+  it('multi-user + IDP shows Create a pod + Sign in', () => {
+    const html = renderServerRoot({ version: '1.0.0', singleUser: false, idp: true });
+    assert.match(html, /Create a pod/);
+    assert.match(html, /href="\/idp\/register"/);
+    assert.match(html, /href="\/idp"/);
+    assert.match(html, /Sign in/);
+  });
+
+  it('single-user + IDP shows Sign in only (no Create a pod)', () => {
+    const html = renderServerRoot({ version: '1.0.0', singleUser: true, idp: true, singleUserName: 'alice' });
+    assert.doesNotMatch(html, /Create a pod/);
+    assert.match(html, /Sign in/);
+  });
+
+  it('multi-user without IDP shows only the Docs link', () => {
+    const html = renderServerRoot({ version: '1.0.0', singleUser: false, idp: false });
+    assert.doesNotMatch(html, /Create a pod/);
+    assert.doesNotMatch(html, /Sign in/);
+    assert.match(html, /Docs/);
+  });
+
+  it('single-user subtitle includes the pod name when provided', () => {
+    const html = renderServerRoot({ version: '1.0.0', singleUser: true, idp: false, singleUserName: 'alice' });
+    assert.match(html, /Personal pod for alice/);
+  });
+
+  it('lists enabled features', () => {
+    const html = renderServerRoot({
+      version: '1.0.0',
+      singleUser: false,
+      idp: true,
+      enabled: { idp: true, nostr: true, webrtc: true, terminal: true }
+    });
+    assert.match(html, /<span>idp<\/span>/);
+    assert.match(html, /<span>nostr<\/span>/);
+    assert.match(html, /<span>webrtc<\/span>/);
+    assert.match(html, /<span>terminal<\/span>/);
+  });
+
+  it('interpolates version', () => {
+    const html = renderServerRoot({ version: '9.9.9' });
+    assert.match(html, /<code>9\.9\.9<\/code>/);
+  });
+
+  it('escapes version to prevent injection', () => {
+    const html = renderServerRoot({ version: '<script>alert(1)</script>' });
+    assert.doesNotMatch(html, /<script>alert\(1\)<\/script>/);
+    assert.match(html, /&lt;script&gt;/);
   });
 });


### PR DESCRIPTION
## Summary
On server startup, seed `DATA_ROOT/index.html` with a minimal landing page and `DATA_ROOT/.acl` + `DATA_ROOT/index.html.acl` with public-read ACLs. Skip-if-exists — operator-provided files are preserved.

Landing page adapts to server mode:
- **Multi-user + IDP** → Create a pod / Sign in
- **Single-user** → Pod info
- Always shows version, mode, enabled features

## Why
Multi-user JSS deployments currently show a raw container listing at `/`. New pod providers (e.g. solidweb.app) had to build a landing page from scratch.

## Design choices
- **Public read only** at the root — no public write. Operators edit `/index.html` on disk, not via the web. Avoids the "who owns the multi-user root?" question.
- **Skip-if-exists** for both the HTML and ACLs. Operator customisation never stomped.
- **A later iteration** could add `--admin-webid` for web-edit access.

See the design comment on #276 for full rationale.

Closes #276

## Test plan
- [x] All 419 tests pass (4 new in `test/server-root.test.js`)
- [x] Default landing page served on `GET /` with no operator file
- [x] Operator-provided `/index.html` preserved and served as-is