### PR TITLE
fix(cli): invite create -u/--uses stored maxUses as null

### DIFF
--- a/bin/jss.js
+++ b/bin/jss.js
@@ -327,7 +327,7 @@ const inviteCmd = program
 inviteCmd
   .command('create')
   .description('Create a new invite code')
-  .option('-u, --uses <number>', 'Maximum uses (default: 1)', parseInt, 1)
+  .option('-u, --uses <number>', 'Maximum uses (default: 1)', (v) => parseInt(v, 10), 1)
   .option('-n, --note <text>', 'Optional note/description')
   .option('-r, --root <path>', 'Data directory')
   .action(async (options) => {


### PR DESCRIPTION
Closes #304.

## Summary
- `jss invite create -u <n>` and `--uses <n>` were producing unusable invites (stored `maxUses: null`, rejected as "fully used" on first redemption).
- Root cause: commander invokes the option parser as `(value, previousValue)`. With bare `parseInt` as the parser and a default of `1`, the first call was `parseInt("1", 1)` — radix 1 is invalid, so `parseInt` returned `NaN`, which JSON-serialized to `null`.
- Fix: wrap in an arrow so the radix is explicit: `(v) => parseInt(v, 10)`.

Only line 330 has the default-value + bare-parseInt combination that triggers this; the other `parseInt` option parsers in `bin/jss.js` omit the default, so `parseInt(value, undefined)` correctly falls back to radix 10. Left those alone per minimal-change scope.

## Test plan
Manual repro against a temp data root:

```
$ node bin/jss.js invite create -u 1 -r "$TMP"
Created invite code: ZQSXFXHC

$ node bin/jss.js invite create --uses 3 -r "$TMP"
Created invite code: ZG1XYA10
Uses: 0/3

$ node bin/jss.js invite create -r "$TMP"
Created invite code: 1WN15P6

$ node bin/jss.js invite list -r "$TMP"
  CODE        USES     CREATED      NOTE
  -------------------------------------------------------
  ZQSXFXHC    0/1      2026-04-23
  ZG1XYA10    0/3      2026-04-23
  1WN15P6     0/1      2026-04-23
```

Before the fix, the first two rows showed `0/null`.

- [ ] Existing test suite passes
- [ ] No regression in the no-flag default path