### PR TITLE
fix: subdomain mode — don't rewrite file-like paths as pod subdomains

### DIFF
--- a/src/auth/middleware.js
+++ b/src/auth/middleware.js
@@ -23,13 +23,18 @@ import { generateDatabrowserHtml, generateModuleDatabrowserHtml } from '../mashl
  * @param {string} urlPath - URL path (e.g. /alice/public/file.ttl)
  * @returns {string} Normalized resource URL
  */
-function buildResourceUrl(request, urlPath) {
+export function buildResourceUrl(request, urlPath) {
   // Use request.headers.host (includes port) instead of request.hostname (strips port)
   const host = request.headers.host || request.hostname;
   if (request.subdomainsEnabled && request.baseDomain &&
       request.hostname === request.baseDomain && !request.podName) {
     const pathMatch = urlPath.match(/^\/([^/]+)(\/.*)?$/);
-    if (pathMatch && !pathMatch[1].startsWith('.')) {
+    // Treat a path segment as a pod name only if it looks like one:
+    //   - not a dotfile (.well-known, .acl, .meta, ...)
+    //   - no dot (pod names are DNS labels; file names have extensions)
+    // This avoids rewriting /mashlib.js to https://mashlib.js.basedomain/
+    // which would fail WAC against the base domain's ACL. (#307)
+    if (pathMatch && !pathMatch[1].startsWith('.') && !pathMatch[1].includes('.')) {
       const podName = pathMatch[1];
       const remainder = pathMatch[2] || '/';
       return `${request.protocol}://${podName}.${request.baseDomain}${remainder}`;

--- a/test/subdomain-base-files.test.js
+++ b/test/subdomain-base-files.test.js
@@ -11,7 +11,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { buildResourceUrl } from '../src/auth/middleware.js';
 
-function makeRequest({ urlPath, hostname, baseDomain, subdomainsEnabled = true, podName = null, protocol = 'https' }) {
+function makeRequest({ hostname, baseDomain, subdomainsEnabled = true, podName = null, protocol = 'https' }) {
   return {
     protocol,
     hostname,
@@ -26,27 +26,27 @@ describe('buildResourceUrl — base-domain files (#307)', () => {
   const baseDomain = 'example.com';
 
   it('base-domain root (/) — no rewrite', () => {
-    const req = makeRequest({ urlPath: '/', hostname: baseDomain, baseDomain });
+    const req = makeRequest({ hostname: baseDomain, baseDomain });
     assert.strictEqual(buildResourceUrl(req, '/'), 'https://example.com/');
   });
 
   it('base-domain /welcome.js — no rewrite (filename has extension)', () => {
-    const req = makeRequest({ urlPath: '/welcome.js', hostname: baseDomain, baseDomain });
+    const req = makeRequest({ hostname: baseDomain, baseDomain });
     assert.strictEqual(buildResourceUrl(req, '/welcome.js'), 'https://example.com/welcome.js');
   });
 
   it('base-domain /mashlib.js — no rewrite', () => {
-    const req = makeRequest({ urlPath: '/mashlib.js', hostname: baseDomain, baseDomain });
+    const req = makeRequest({ hostname: baseDomain, baseDomain });
     assert.strictEqual(buildResourceUrl(req, '/mashlib.js'), 'https://example.com/mashlib.js');
   });
 
   it('base-domain /terms.html — no rewrite', () => {
-    const req = makeRequest({ urlPath: '/terms.html', hostname: baseDomain, baseDomain });
+    const req = makeRequest({ hostname: baseDomain, baseDomain });
     assert.strictEqual(buildResourceUrl(req, '/terms.html'), 'https://example.com/terms.html');
   });
 
   it('base-domain /.well-known/foo — no rewrite (leading dot)', () => {
-    const req = makeRequest({ urlPath: '/.well-known/foo', hostname: baseDomain, baseDomain });
+    const req = makeRequest({ hostname: baseDomain, baseDomain });
     assert.strictEqual(
       buildResourceUrl(req, '/.well-known/foo'),
       'https://example.com/.well-known/foo'
@@ -58,17 +58,17 @@ describe('buildResourceUrl — pod routing still works', () => {
   const baseDomain = 'example.com';
 
   it('base-domain /alice/ — rewrites to alice.example.com (no dot → pod name)', () => {
-    const req = makeRequest({ urlPath: '/alice/', hostname: baseDomain, baseDomain });
+    const req = makeRequest({ hostname: baseDomain, baseDomain });
     assert.strictEqual(buildResourceUrl(req, '/alice/'), 'https://alice.example.com/');
   });
 
   it('base-domain /alice — rewrites (bare pod-root without trailing slash)', () => {
-    const req = makeRequest({ urlPath: '/alice', hostname: baseDomain, baseDomain });
+    const req = makeRequest({ hostname: baseDomain, baseDomain });
     assert.strictEqual(buildResourceUrl(req, '/alice'), 'https://alice.example.com/');
   });
 
   it('base-domain /alice/profile/card.jsonld — rewrites to alice.example.com/profile/card.jsonld', () => {
-    const req = makeRequest({ urlPath: '/alice/profile/card.jsonld', hostname: baseDomain, baseDomain });
+    const req = makeRequest({ hostname: baseDomain, baseDomain });
     assert.strictEqual(
       buildResourceUrl(req, '/alice/profile/card.jsonld'),
       'https://alice.example.com/profile/card.jsonld'
@@ -77,7 +77,6 @@ describe('buildResourceUrl — pod routing still works', () => {
 
   it('already-on-subdomain request — no rewrite (hostname !== baseDomain)', () => {
     const req = makeRequest({
-      urlPath: '/profile/card.jsonld',
       hostname: 'alice.example.com',
       baseDomain,
       podName: 'alice'
@@ -92,7 +91,6 @@ describe('buildResourceUrl — pod routing still works', () => {
 describe('buildResourceUrl — subdomain mode disabled', () => {
   it('no rewrite when subdomainsEnabled is false', () => {
     const req = makeRequest({
-      urlPath: '/alice/',
       hostname: 'example.com',
       baseDomain: 'example.com',
       subdomainsEnabled: false
@@ -102,7 +100,6 @@ describe('buildResourceUrl — subdomain mode disabled', () => {
 
   it('no rewrite when baseDomain is not set', () => {
     const req = makeRequest({
-      urlPath: '/alice/',
       hostname: 'example.com',
       baseDomain: null,
       subdomainsEnabled: true

--- a/test/subdomain-base-files.test.js
+++ b/test/subdomain-base-files.test.js
@@ -1,0 +1,112 @@
+/**
+ * Regression tests for #307 — buildResourceUrl rewriting the base-domain
+ * root file paths into non-existent pod subdomains.
+ *
+ * Unit tests against buildResourceUrl directly, since Node's fetch() overrides
+ * the Host header with the TCP target, which makes end-to-end tests of
+ * subdomain routing impossible without a real reverse proxy.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { buildResourceUrl } from '../src/auth/middleware.js';
+
+function makeRequest({ urlPath, hostname, baseDomain, subdomainsEnabled = true, podName = null, protocol = 'https' }) {
+  return {
+    protocol,
+    hostname,
+    headers: { host: hostname },
+    subdomainsEnabled,
+    baseDomain,
+    podName
+  };
+}
+
+describe('buildResourceUrl — base-domain files (#307)', () => {
+  const baseDomain = 'example.com';
+
+  it('base-domain root (/) — no rewrite', () => {
+    const req = makeRequest({ urlPath: '/', hostname: baseDomain, baseDomain });
+    assert.strictEqual(buildResourceUrl(req, '/'), 'https://example.com/');
+  });
+
+  it('base-domain /welcome.js — no rewrite (filename has extension)', () => {
+    const req = makeRequest({ urlPath: '/welcome.js', hostname: baseDomain, baseDomain });
+    assert.strictEqual(buildResourceUrl(req, '/welcome.js'), 'https://example.com/welcome.js');
+  });
+
+  it('base-domain /mashlib.js — no rewrite', () => {
+    const req = makeRequest({ urlPath: '/mashlib.js', hostname: baseDomain, baseDomain });
+    assert.strictEqual(buildResourceUrl(req, '/mashlib.js'), 'https://example.com/mashlib.js');
+  });
+
+  it('base-domain /terms.html — no rewrite', () => {
+    const req = makeRequest({ urlPath: '/terms.html', hostname: baseDomain, baseDomain });
+    assert.strictEqual(buildResourceUrl(req, '/terms.html'), 'https://example.com/terms.html');
+  });
+
+  it('base-domain /.well-known/foo — no rewrite (leading dot)', () => {
+    const req = makeRequest({ urlPath: '/.well-known/foo', hostname: baseDomain, baseDomain });
+    assert.strictEqual(
+      buildResourceUrl(req, '/.well-known/foo'),
+      'https://example.com/.well-known/foo'
+    );
+  });
+});
+
+describe('buildResourceUrl — pod routing still works', () => {
+  const baseDomain = 'example.com';
+
+  it('base-domain /alice/ — rewrites to alice.example.com (no dot → pod name)', () => {
+    const req = makeRequest({ urlPath: '/alice/', hostname: baseDomain, baseDomain });
+    assert.strictEqual(buildResourceUrl(req, '/alice/'), 'https://alice.example.com/');
+  });
+
+  it('base-domain /alice — rewrites (bare pod-root without trailing slash)', () => {
+    const req = makeRequest({ urlPath: '/alice', hostname: baseDomain, baseDomain });
+    assert.strictEqual(buildResourceUrl(req, '/alice'), 'https://alice.example.com/');
+  });
+
+  it('base-domain /alice/profile/card.jsonld — rewrites to alice.example.com/profile/card.jsonld', () => {
+    const req = makeRequest({ urlPath: '/alice/profile/card.jsonld', hostname: baseDomain, baseDomain });
+    assert.strictEqual(
+      buildResourceUrl(req, '/alice/profile/card.jsonld'),
+      'https://alice.example.com/profile/card.jsonld'
+    );
+  });
+
+  it('already-on-subdomain request — no rewrite (hostname !== baseDomain)', () => {
+    const req = makeRequest({
+      urlPath: '/profile/card.jsonld',
+      hostname: 'alice.example.com',
+      baseDomain,
+      podName: 'alice'
+    });
+    assert.strictEqual(
+      buildResourceUrl(req, '/profile/card.jsonld'),
+      'https://alice.example.com/profile/card.jsonld'
+    );
+  });
+});
+
+describe('buildResourceUrl — subdomain mode disabled', () => {
+  it('no rewrite when subdomainsEnabled is false', () => {
+    const req = makeRequest({
+      urlPath: '/alice/',
+      hostname: 'example.com',
+      baseDomain: 'example.com',
+      subdomainsEnabled: false
+    });
+    assert.strictEqual(buildResourceUrl(req, '/alice/'), 'https://example.com/alice/');
+  });
+
+  it('no rewrite when baseDomain is not set', () => {
+    const req = makeRequest({
+      urlPath: '/alice/',
+      hostname: 'example.com',
+      baseDomain: null,
+      subdomainsEnabled: true
+    });
+    assert.strictEqual(buildResourceUrl(req, '/alice/'), 'https://example.com/alice/');
+  });
+});


### PR DESCRIPTION
## Summary

In subdomain mode, files directly under the base domain root returned 401 because `buildResourceUrl` rewrote `/mashlib.js` to `https://mashlib.js.basedomain/` — a URL with no matching ACL.

## Why

Regression from ec4cf5b (March 2026) which loosened the pod-routing regex to match bare pod-roots (`/alice` without trailing slash). That change also started matching filenames.

## Fix

One-line: also exempt path segments containing a dot. Pod names are DNS labels (no dots); filenames have extensions.

```diff
- if (pathMatch && !pathMatch[1].startsWith('.')) {
+ if (pathMatch && !pathMatch[1].startsWith('.') && !pathMatch[1].includes('.')) {
```

## Behaviour matrix

| Path | Before | After |
|------|--------|-------|
| `/` | no rewrite ✓ | no rewrite ✓ |
| `/alice` | `→ alice.domain/` ✓ | `→ alice.domain/` ✓ |
| `/alice/foo/bar` | `→ alice.domain/foo/bar` ✓ | `→ alice.domain/foo/bar` ✓ |
| `/.well-known/x` | no rewrite ✓ | no rewrite ✓ |
| `/mashlib.js` | `→ mashlib.js.domain/` ✗ (401) | no rewrite ✓ |
| `/index.html` | `→ index.html.domain/` ✗ (401) | no rewrite ✓ |
| `/terms.html` | `→ terms.html.domain/` ✗ (401) | no rewrite ✓ |

Closes #307

## Test plan
- [x] 11 new unit tests in `test/subdomain-base-files.test.js`
- [x] All 426 tests pass