### PR TITLE
Unify Vary and add Cache-Control on RDF variants (#315)

### DIFF
--- a/src/handlers/container.js
+++ b/src/handlers/container.js
@@ -141,7 +141,7 @@ export async function handlePost(request, reply) {
     connegEnabled
   });
   headers['Location'] = resourceUrl;
-  headers['Vary'] = getVaryHeader(connegEnabled);
+  headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
 
   Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
 

--- a/src/handlers/container.js
+++ b/src/handlers/container.js
@@ -5,7 +5,7 @@ import { isContainer, getEffectiveUrlPath, getPodName } from '../utils/url.js';
 import { generateProfile, generatePreferences, generateTypeIndex, serialize } from '../webid/profile.js';
 import { generateOwnerAcl, generatePrivateAcl, generateInboxAcl, generatePublicFolderAcl, serializeAcl } from '../wac/parser.js';
 import { createToken } from '../auth/token.js';
-import { canAcceptInput, toJsonLd, getVaryHeader, RDF_TYPES } from '../rdf/conneg.js';
+import { canAcceptInput, toJsonLd, RDF_TYPES } from '../rdf/conneg.js';
 import { emitChange } from '../notifications/events.js';
 
 /**
@@ -138,10 +138,10 @@ export async function handlePost(request, reply) {
   const headers = getAllHeaders({
     isContainer: isCreatingContainer,
     origin,
-    connegEnabled
+    connegEnabled,
+    mashlibEnabled: request.mashlibEnabled
   });
   headers['Location'] = resourceUrl;
-  headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
 
   Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
 

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -22,6 +22,12 @@ import { generateDatabrowserHtml, generateModuleDatabrowserHtml, shouldServeMash
  */
 const LIVE_RELOAD_SCRIPT = `<script>(function(){var ws=new WebSocket((location.protocol==='https:'?'wss:':'ws:')+'//' +location.host+'/.notifications');ws.onopen=function(){ws.send('sub '+location.href)};ws.onmessage=function(e){if(e.data.startsWith('pub '))location.reload()};ws.onclose=function(){setTimeout(function(){location.reload()},1000)}})();</script>`;
 
+// Cache-Control for RDF data responses: let clients keep the body but force
+// revalidation via ETag on every use. This prevents stale bodies from leaking
+// across auth-state changes (WAC) and closes the mashlib render-race window
+// where a cached data variant was served on top-level navigation (#315).
+const RDF_CACHE_CONTROL = 'private, no-cache, must-revalidate';
+
 /**
  * Inject live reload script into HTML content
  */
@@ -241,7 +247,7 @@ export async function handleGet(request, reply) {
         resourceUrl,
         connegEnabled
       });
-      headers['Vary'] = 'Accept';
+      headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
       headers['X-Frame-Options'] = 'DENY';
       headers['Content-Security-Policy'] = "frame-ancestors 'none'";
       headers['Cache-Control'] = 'no-store';
@@ -276,7 +282,8 @@ export async function handleGet(request, reply) {
           resourceUrl,
           connegEnabled
         });
-        headers['Vary'] = 'Accept';
+        headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
+        headers['Cache-Control'] = RDF_CACHE_CONTROL;
 
         Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
         return reply.send(turtleContent);
@@ -294,6 +301,7 @@ export async function handleGet(request, reply) {
       resourceUrl,
       connegEnabled
     });
+    headers['Cache-Control'] = RDF_CACHE_CONTROL;
 
     Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
     return reply.send(serializeJsonLd(jsonLd));
@@ -317,7 +325,7 @@ export async function handleGet(request, reply) {
       resourceUrl,
       connegEnabled
     });
-    headers['Vary'] = 'Accept';
+    headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
     headers['X-Frame-Options'] = 'DENY';
     headers['Content-Security-Policy'] = "frame-ancestors 'none'";
     // Don't cache the HTML wrapper - always negotiate fresh
@@ -400,6 +408,7 @@ export async function handleGet(request, reply) {
             connegEnabled
           });
           headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
+          headers['Cache-Control'] = RDF_CACHE_CONTROL;
 
           Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
           return reply.send(turtleContent);
@@ -430,6 +439,7 @@ export async function handleGet(request, reply) {
           connegEnabled
         });
         headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
+        headers['Cache-Control'] = RDF_CACHE_CONTROL;
 
         Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
         return reply.send(outputContent);
@@ -458,6 +468,9 @@ export async function handleGet(request, reply) {
     connegEnabled
   });
   headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
+  if (isRdfContentType(actualContentType)) {
+    headers['Cache-Control'] = RDF_CACHE_CONTROL;
+  }
 
   Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
 

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -187,6 +187,7 @@ export async function handleGet(request, reply) {
                 resourceUrl,
                 connegEnabled
               });
+              headers['Cache-Control'] = RDF_CACHE_CONTROL;
 
               Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
               return reply.send(turtleContent);
@@ -200,6 +201,7 @@ export async function handleGet(request, reply) {
                 resourceUrl,
                 connegEnabled
               });
+              headers['Cache-Control'] = RDF_CACHE_CONTROL;
 
               Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
               return reply.send(JSON.stringify(jsonLd, null, 2));

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -10,7 +10,6 @@ import {
   canAcceptInput,
   toJsonLd,
   fromJsonLd,
-  getVaryHeader,
   RDF_TYPES
 } from '../rdf/conneg.js';
 import { emitChange } from '../notifications/events.js';
@@ -247,9 +246,9 @@ export async function handleGet(request, reply) {
         contentType: 'text/html',
         origin,
         resourceUrl,
-        connegEnabled
+        connegEnabled,
+        mashlibEnabled: request.mashlibEnabled
       });
-      headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
       headers['X-Frame-Options'] = 'DENY';
       headers['Content-Security-Policy'] = "frame-ancestors 'none'";
       headers['Cache-Control'] = 'no-store';
@@ -282,9 +281,9 @@ export async function handleGet(request, reply) {
           contentType: 'text/turtle',
           origin,
           resourceUrl,
-          connegEnabled
+          connegEnabled,
+          mashlibEnabled: request.mashlibEnabled
         });
-        headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
         headers['Cache-Control'] = RDF_CACHE_CONTROL;
 
         Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
@@ -301,7 +300,8 @@ export async function handleGet(request, reply) {
       contentType: 'application/ld+json',
       origin,
       resourceUrl,
-      connegEnabled
+      connegEnabled,
+      mashlibEnabled: request.mashlibEnabled
     });
     headers['Cache-Control'] = RDF_CACHE_CONTROL;
 
@@ -325,9 +325,9 @@ export async function handleGet(request, reply) {
       contentType: 'text/html',
       origin,
       resourceUrl,
-      connegEnabled
+      connegEnabled,
+      mashlibEnabled: request.mashlibEnabled
     });
-    headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
     headers['X-Frame-Options'] = 'DENY';
     headers['Content-Security-Policy'] = "frame-ancestors 'none'";
     // Don't cache the HTML wrapper - always negotiate fresh
@@ -407,9 +407,9 @@ export async function handleGet(request, reply) {
             contentType: 'text/turtle',
             origin,
             resourceUrl,
-            connegEnabled
+            connegEnabled,
+            mashlibEnabled: request.mashlibEnabled
           });
-          headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
           headers['Cache-Control'] = RDF_CACHE_CONTROL;
 
           Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
@@ -438,9 +438,9 @@ export async function handleGet(request, reply) {
           contentType: outputType,
           origin,
           resourceUrl,
-          connegEnabled
+          connegEnabled,
+          mashlibEnabled: request.mashlibEnabled
         });
-        headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
         headers['Cache-Control'] = RDF_CACHE_CONTROL;
 
         Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
@@ -467,9 +467,9 @@ export async function handleGet(request, reply) {
     contentType: actualContentType,
     origin,
     resourceUrl,
-    connegEnabled
+    connegEnabled,
+    mashlibEnabled: request.mashlibEnabled
   });
-  headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
   if (isRdfContentType(actualContentType)) {
     headers['Cache-Control'] = RDF_CACHE_CONTROL;
   }
@@ -686,9 +686,8 @@ export async function handlePut(request, reply) {
   }
 
   const origin = request.headers.origin;
-  const headers = getAllHeaders({ isContainer: false, origin, resourceUrl, connegEnabled });
+  const headers = getAllHeaders({ isContainer: false, origin, resourceUrl, connegEnabled, mashlibEnabled: request.mashlibEnabled });
   headers['Location'] = resourceUrl;
-  headers['Vary'] = getVaryHeader(connegEnabled, request.mashlibEnabled);
 
   Object.entries(headers).forEach(([k, v]) => reply.header(k, v));
 

--- a/src/ldp/headers.js
+++ b/src/ldp/headers.js
@@ -2,7 +2,7 @@
  * LDP (Linked Data Platform) header utilities
  */
 
-import { getAcceptHeaders } from '../rdf/conneg.js';
+import { getAcceptHeaders, getVaryHeader } from '../rdf/conneg.js';
 
 const LDP = 'http://www.w3.org/ns/ldp#';
 
@@ -49,7 +49,7 @@ export function getAclUrl(resourceUrl, isContainer) {
  * @param {object} options
  * @returns {object}
  */
-export function getResponseHeaders({ isContainer = false, etag = null, contentType = null, resourceUrl = null, wacAllow = null, connegEnabled = false, updatesVia = null }) {
+export function getResponseHeaders({ isContainer = false, etag = null, contentType = null, resourceUrl = null, wacAllow = null, connegEnabled = false, mashlibEnabled = false, updatesVia = null }) {
   // Calculate ACL URL if resource URL provided
   const aclUrl = resourceUrl ? getAclUrl(resourceUrl, isContainer) : null;
 
@@ -58,7 +58,7 @@ export function getResponseHeaders({ isContainer = false, etag = null, contentTy
     'Accept-Patch': 'text/n3, application/sparql-update',
     'Accept-Ranges': isContainer ? 'none' : 'bytes',
     'Allow': 'GET, HEAD, PUT, DELETE, PATCH, OPTIONS' + (isContainer ? ', POST' : ''),
-    'Vary': connegEnabled ? 'Accept, Authorization, Origin' : 'Authorization, Origin'
+    'Vary': getVaryHeader(connegEnabled, mashlibEnabled)
   };
 
   // Only set WAC-Allow if explicitly provided (otherwise the auth hook sets it)
@@ -107,9 +107,9 @@ export function getCorsHeaders(origin) {
  * @param {object} options
  * @returns {object}
  */
-export function getAllHeaders({ isContainer = false, etag = null, contentType = null, origin = null, resourceUrl = null, wacAllow = null, connegEnabled = false, updatesVia = null }) {
+export function getAllHeaders({ isContainer = false, etag = null, contentType = null, origin = null, resourceUrl = null, wacAllow = null, connegEnabled = false, mashlibEnabled = false, updatesVia = null }) {
   return {
-    ...getResponseHeaders({ isContainer, etag, contentType, resourceUrl, wacAllow, connegEnabled, updatesVia }),
+    ...getResponseHeaders({ isContainer, etag, contentType, resourceUrl, wacAllow, connegEnabled, mashlibEnabled, updatesVia }),
     ...getCorsHeaders(origin)
   };
 }
@@ -120,7 +120,7 @@ export function getAllHeaders({ isContainer = false, etag = null, contentType = 
  * @param {object} options
  * @returns {object}
  */
-export function getNotFoundHeaders({ resourceUrl = null, origin = null, connegEnabled = false }) {
+export function getNotFoundHeaders({ resourceUrl = null, origin = null, connegEnabled = false, mashlibEnabled = false }) {
   // Determine if this would be a container based on URL ending with /
   const isContainer = resourceUrl?.endsWith('/') || false;
   const aclUrl = resourceUrl ? getAclUrl(resourceUrl, isContainer) : null;
@@ -134,7 +134,7 @@ export function getNotFoundHeaders({ resourceUrl = null, origin = null, connegEn
     'Accept-Patch': 'text/n3, application/sparql-update',
     'Accept-Put': acceptHeaders['Accept-Put'] || 'application/ld+json, */*',
     'Allow': 'GET, HEAD, PUT, PATCH, OPTIONS' + (isContainer ? ', POST' : ''),
-    'Vary': connegEnabled ? 'Accept, Authorization, Origin' : 'Authorization, Origin'
+    'Vary': getVaryHeader(connegEnabled, mashlibEnabled)
   };
 
   if (isContainer && acceptHeaders['Accept-Post']) {

--- a/src/rdf/conneg.js
+++ b/src/rdf/conneg.js
@@ -189,10 +189,19 @@ export async function fromJsonLd(jsonLd, targetType, baseUri, connegEnabled = fa
 
 /**
  * Get Vary header value for content negotiation
- * Include Accept when conneg or mashlib is enabled (response varies by Accept header)
+ *
+ * Must be identical across all variants of a given URL — inconsistent Vary
+ * across variants confuses browser caches and can cause the wrong variant
+ * to be served on reload (see #315).
+ *
+ * - `Accept` — response body depends on Accept (conneg or mashlib HTML shell)
+ * - `Authorization` — response body depends on the authenticated user (WAC)
+ * - `Origin` — CORS headers echo the request's Origin
  */
 export function getVaryHeader(connegEnabled, mashlibEnabled = false) {
-  return (connegEnabled || mashlibEnabled) ? 'Accept, Origin' : 'Origin';
+  return (connegEnabled || mashlibEnabled)
+    ? 'Accept, Authorization, Origin'
+    : 'Authorization, Origin';
 }
 
 /**

--- a/test/vary-cache-headers.test.js
+++ b/test/vary-cache-headers.test.js
@@ -55,6 +55,7 @@ describe('Vary / Cache-Control consistency (#315)', () => {
     assert.strictEqual(unique.size, 1,
       `expected identical Vary across variants, got: ${JSON.stringify(varys)}`);
     const vary = [...unique][0];
+    assert.ok(vary, `expected Vary header across variants, got: ${JSON.stringify(varys)}`);
     assert.match(vary, /Accept/, 'Vary must include Accept (conneg active)');
     assert.match(vary, /Authorization/, 'Vary must include Authorization (WAC)');
     assert.match(vary, /Origin/, 'Vary must include Origin (CORS)');
@@ -76,6 +77,36 @@ describe('Vary / Cache-Control consistency (#315)', () => {
       assert.match(cc, /no-cache|no-store/, `Cache-Control "${cc}" must prevent stale reuse (Accept: ${accept})`);
       // ETag is preserved so revalidation is cheap (304).
       assert.ok(res.headers.get('etag'), `expected ETag on ${accept} variant`);
+    }
+  });
+
+  it('container index.html data-island variants also carry revalidating Cache-Control', async () => {
+    // Publish an index.html with a JSON-LD data island; conneg should extract
+    // and serve it as Turtle/JSON-LD. Those variants were missing
+    // Cache-Control pre-#315.
+    const html = [
+      '<!doctype html><html><head>',
+      '<script type="application/ld+json">',
+      JSON.stringify({
+        '@context': { foaf: 'http://xmlns.com/foaf/0.1/' },
+        '@id': '#this',
+        'foaf:name': 'Island'
+      }),
+      '</script></head><body>hi</body></html>'
+    ].join('');
+    await request('/varytest/public/index.html', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'text/html' },
+      body: html,
+      auth: 'varytest'
+    });
+
+    for (const accept of ['text/turtle', 'application/ld+json']) {
+      const res = await request('/varytest/public/', { headers: { Accept: accept } });
+      const cc = res.headers.get('cache-control');
+      assert.ok(cc, `expected Cache-Control on ${accept} island variant, got headers: ${[...res.headers].map(([k, v]) => `${k}=${v}`).join(', ')}`);
+      assert.match(cc, /no-cache|no-store/,
+        `Cache-Control "${cc}" must prevent stale reuse (Accept: ${accept})`);
     }
   });
 });

--- a/test/vary-cache-headers.test.js
+++ b/test/vary-cache-headers.test.js
@@ -44,18 +44,18 @@ describe('Vary / Cache-Control consistency (#315)', () => {
       'text/turtle',                        // Turtle conversion
       'application/ld+json'                 // native JSON-LD
     ];
-    const varys = [];
+    const varyValues = [];
     for (const accept of accepts) {
       const res = await request('/varytest/public/card.jsonld', { headers: { Accept: accept } });
-      varys.push({ accept, vary: res.headers.get('vary') });
+      varyValues.push({ accept, vary: res.headers.get('vary') });
     }
     // All three variants must carry the same Vary — inconsistent Vary is
     // what confused browser caches into serving the wrong variant.
-    const unique = new Set(varys.map((v) => v.vary));
-    assert.strictEqual(unique.size, 1,
-      `expected identical Vary across variants, got: ${JSON.stringify(varys)}`);
-    const vary = [...unique][0];
-    assert.ok(vary, `expected Vary header across variants, got: ${JSON.stringify(varys)}`);
+    const uniqueVaryValues = new Set(varyValues.map((v) => v.vary));
+    assert.strictEqual(uniqueVaryValues.size, 1,
+      `expected identical Vary across variants, got: ${JSON.stringify(varyValues)}`);
+    const vary = [...uniqueVaryValues][0];
+    assert.ok(vary, `expected Vary header across variants, got: ${JSON.stringify(varyValues)}`);
     assert.match(vary, /Accept/, 'Vary must include Accept (conneg active)');
     assert.match(vary, /Authorization/, 'Vary must include Authorization (WAC)');
     assert.match(vary, /Origin/, 'Vary must include Origin (CORS)');
@@ -70,11 +70,14 @@ describe('Vary / Cache-Control consistency (#315)', () => {
   });
 
   it('RDF data variants force revalidation (no stale bodies across auth changes)', async () => {
+    // Full expected policy — pinning every directive so a regression that
+    // drops `private` or `must-revalidate` (both needed to prevent auth-state
+    // leakage and force freshness) fails the test.
+    const expected = 'private, no-cache, must-revalidate';
     for (const accept of ['text/turtle', 'application/ld+json']) {
       const res = await request('/varytest/public/card.jsonld', { headers: { Accept: accept } });
-      const cc = res.headers.get('cache-control');
-      assert.ok(cc, `expected Cache-Control on ${accept} variant`);
-      assert.match(cc, /no-cache|no-store/, `Cache-Control "${cc}" must prevent stale reuse (Accept: ${accept})`);
+      assert.strictEqual(res.headers.get('cache-control'), expected,
+        `Cache-Control mismatch on Accept: ${accept}`);
       // ETag is preserved so revalidation is cheap (304).
       assert.ok(res.headers.get('etag'), `expected ETag on ${accept} variant`);
     }
@@ -101,12 +104,11 @@ describe('Vary / Cache-Control consistency (#315)', () => {
       auth: 'varytest'
     });
 
+    const expected = 'private, no-cache, must-revalidate';
     for (const accept of ['text/turtle', 'application/ld+json']) {
       const res = await request('/varytest/public/', { headers: { Accept: accept } });
-      const cc = res.headers.get('cache-control');
-      assert.ok(cc, `expected Cache-Control on ${accept} island variant, got headers: ${[...res.headers].map(([k, v]) => `${k}=${v}`).join(', ')}`);
-      assert.match(cc, /no-cache|no-store/,
-        `Cache-Control "${cc}" must prevent stale reuse (Accept: ${accept})`);
+      assert.strictEqual(res.headers.get('cache-control'), expected,
+        `Cache-Control mismatch on island variant (Accept: ${accept})`);
     }
   });
 });

--- a/test/vary-cache-headers.test.js
+++ b/test/vary-cache-headers.test.js
@@ -1,0 +1,81 @@
+/**
+ * Regression tests for #315 — inconsistent Vary / Cache-Control across
+ * conneg variants caused stale-render races on browser reload.
+ *
+ * What we guarantee now:
+ *  - Every variant of the same URL returns an *identical* Vary header.
+ *  - RDF data variants carry Cache-Control that forces revalidation via
+ *    ETag, so a cached body cannot silently serve across auth changes or
+ *    be picked up on a top-level navigation by mistake.
+ *  - The mashlib HTML wrapper keeps `no-store` (it's a bootstrap template).
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import {
+  startTestServer,
+  stopTestServer,
+  request,
+  createTestPod
+} from './helpers.js';
+
+describe('Vary / Cache-Control consistency (#315)', () => {
+  before(async () => {
+    await startTestServer({ conneg: true, mashlibCdn: true });
+    await createTestPod('varytest');
+    // Create a JSON-LD resource to exercise all variants.
+    await request('/varytest/public/card.jsonld', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/ld+json' },
+      body: JSON.stringify({
+        '@context': { foaf: 'http://xmlns.com/foaf/0.1/' },
+        '@id': '#me',
+        'foaf:name': 'Vary Test'
+      }),
+      auth: 'varytest'
+    });
+  });
+
+  after(async () => { await stopTestServer(); });
+
+  it('Vary header is identical across all conneg variants of the same URL', async () => {
+    const accepts = [
+      'text/html,*/*;q=0.8',              // mashlib HTML wrapper
+      'text/turtle',                        // Turtle conversion
+      'application/ld+json'                 // native JSON-LD
+    ];
+    const varys = [];
+    for (const accept of accepts) {
+      const res = await request('/varytest/public/card.jsonld', { headers: { Accept: accept } });
+      varys.push({ accept, vary: res.headers.get('vary') });
+    }
+    // All three variants must carry the same Vary — inconsistent Vary is
+    // what confused browser caches into serving the wrong variant.
+    const unique = new Set(varys.map((v) => v.vary));
+    assert.strictEqual(unique.size, 1,
+      `expected identical Vary across variants, got: ${JSON.stringify(varys)}`);
+    const vary = [...unique][0];
+    assert.match(vary, /Accept/, 'Vary must include Accept (conneg active)');
+    assert.match(vary, /Authorization/, 'Vary must include Authorization (WAC)');
+    assert.match(vary, /Origin/, 'Vary must include Origin (CORS)');
+  });
+
+  it('mashlib HTML wrapper uses Cache-Control: no-store', async () => {
+    const res = await request('/varytest/public/card.jsonld', {
+      headers: { Accept: 'text/html,*/*;q=0.8' }
+    });
+    assert.match(res.headers.get('content-type') || '', /text\/html/);
+    assert.strictEqual(res.headers.get('cache-control'), 'no-store');
+  });
+
+  it('RDF data variants force revalidation (no stale bodies across auth changes)', async () => {
+    for (const accept of ['text/turtle', 'application/ld+json']) {
+      const res = await request('/varytest/public/card.jsonld', { headers: { Accept: accept } });
+      const cc = res.headers.get('cache-control');
+      assert.ok(cc, `expected Cache-Control on ${accept} variant`);
+      assert.match(cc, /no-cache|no-store/, `Cache-Control "${cc}" must prevent stale reuse (Accept: ${accept})`);
+      // ETag is preserved so revalidation is cheap (304).
+      assert.ok(res.headers.get('etag'), `expected ETag on ${accept} variant`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Browser reloads of mashlib-rendered RDF sometimes showed raw Turtle/JSON-LD body instead of the mashlib view. Hard refresh always worked; soft refresh could fail.

## Root cause
Three code paths emitted different \`Vary\` headers for variants of the same URL:

| Variant | \`Vary\` | \`Cache-Control\` |
|---|---|---|
| mashlib HTML wrapper | \`Accept\` | \`no-store\` |
| Turtle (via conneg) | \`Accept, Origin\` | *(missing)* |
| JSON-LD (via conneg) | \`Accept, Origin\` | *(missing)* |

Chromium caches get confused when variants disagree on \`Vary\` and can serve the cached Turtle body on top-level navigation → browser renders it as text. Aggressive caching on data variants (no \`Cache-Control\`) made it stick.

## Fix
- \`getVaryHeader(connegEnabled, mashlibEnabled)\` is the single source of truth; always emits \`Accept, Authorization, Origin\` when either flag is on, else \`Authorization, Origin\`. \`Authorization\` is included because WAC lets content vary per authenticated user.
- \`getResponseHeaders\` / \`getAllHeaders\` / \`getNotFoundHeaders\` accept \`mashlibEnabled\` and route through the helper.
- All \`headers['Vary'] = 'Accept'\` overrides in \`src/handlers/resource.js\` / \`container.js\` switched to the centralized helper.
- RDF data variants now carry \`Cache-Control: private, no-cache, must-revalidate\`. ETag is preserved, so revalidation is cheap (304). Mashlib HTML wrapper keeps \`no-store\`.

## Security benefit (bonus, not just UX)
Without revalidation, a cached response from one auth state could be served to another. \`must-revalidate\` + \`no-cache\` forces the browser to check \`If-None-Match\` on every use, so auth changes can't leak stale bodies.

## Test plan
- [x] New \`test/vary-cache-headers.test.js\`:
  - identical \`Vary\` across all three variants of the same URL (confirmed to fail on unpatched code)
  - mashlib wrapper keeps \`Cache-Control: no-store\`
  - RDF data variants carry revalidating \`Cache-Control\` and \`ETag\` (confirmed to fail on unpatched code)
- [x] Full suite green (436/436).

Fixes #315