### PR TITLE
Seed IDP account on single-user --idp startup (#323)

### DIFF
--- a/bin/jss.js
+++ b/bin/jss.js
@@ -84,6 +84,7 @@ program
   .option('--no-invite-only', 'Allow open registration')
   .option('--single-user', 'Single-user mode (creates pod on startup, disables registration)')
   .option('--single-user-name <name>', 'Username for single-user mode (default: me)')
+  .option('--single-user-password <pw>', 'Initial IDP password to seed when creating the single-user pod (or set JSS_SINGLE_USER_PASSWORD)')
   .option('--webid-tls', 'Enable WebID-TLS client certificate authentication')
   .option('--no-webid-tls', 'Disable WebID-TLS authentication')
   .option('--public', 'Allow unauthenticated access (skip WAC, open read/write)')
@@ -164,6 +165,7 @@ program
         webidTls: config.webidTls,
         singleUser: config.singleUser,
         singleUserName: config.singleUserName,
+        singleUserPassword: config.singleUserPassword,
         public: config.public,
         readOnly: config.readOnly,
         liveReload: config.liveReload,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,6 +201,9 @@ export JSS_ACTIVITYPUB=true
 export JSS_AP_USERNAME=alice
 export JSS_PUBLIC=true
 export JSS_READ_ONLY=true
+export JSS_SINGLE_USER=true
+export JSS_SINGLE_USER_NAME=me
+export JSS_SINGLE_USER_PASSWORD=choose-a-good-one  # seeds IDP account on first start
 export JSS_LIVE_RELOAD=true
 export JSS_SOLIDOS_UI=true
 export JSS_PAY=true
@@ -256,7 +259,12 @@ For personal pod servers where only one user needs access:
 
 ```bash
 # Basic single-user mode (creates pod at /me/)
+# On first run JSS will prompt for an initial password (TTY only).
 jss start --single-user --idp
+
+# Provide the initial IDP password non-interactively (systemd, containers, CI):
+jss start --single-user --idp --single-user-password 'choose-a-good-one'
+JSS_SINGLE_USER_PASSWORD='choose-a-good-one' jss start --single-user --idp
 
 # Custom username
 jss start --single-user --single-user-name alice --idp
@@ -270,9 +278,18 @@ JSS_SINGLE_USER=true jss start --idp
 
 **Features:**
 - Pod auto-created on first startup with full structure (inbox, public, private, profile)
+- IDP account auto-seeded so the operator can log in immediately
 - Registration endpoint disabled (returns 403)
-- Login still works for the single user
+- Login works for the single user via password (`POST /idp/credentials`) or any other configured method
 - Proper ACLs generated automatically
+
+**Initial password sources, in priority order:**
+1. `--single-user-password <pw>` CLI flag
+2. `JSS_SINGLE_USER_PASSWORD` env var
+3. Interactive no-echo prompt (TTY only)
+4. None — server starts and warns; the pod is created but isn't loggable until a password is set later via `jss passwd <user>`
+
+The password is only consulted on the first start — once an account exists, subsequent restarts skip the seed step and never overwrite it. The password is never written to the saved config file (`.jss/config`).
 
 
 ## Invite-Only Registration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -287,7 +287,7 @@ JSS_SINGLE_USER=true jss start --idp
 1. `--single-user-password <pw>` CLI flag
 2. `JSS_SINGLE_USER_PASSWORD` env var
 3. Interactive no-echo prompt (TTY only)
-4. None — server starts and warns; the pod is created but isn't loggable until a password is set later via `jss passwd <user>`
+4. None — the server starts and warns; the pod is created but isn't loggable until you restart with `--single-user-password <pw>`, set `JSS_SINGLE_USER_PASSWORD`, or run on a TTY to be prompted. (`jss passwd <user>` does not work here — it returns "User not found" until an account exists.)
 
 The password is only consulted on the first start — once an account exists, subsequent restarts skip the seed step and never overwrite it. The password is never written to the saved config file (`.jss/config`).
 

--- a/src/config.js
+++ b/src/config.js
@@ -376,10 +376,22 @@ export function printConfig(config) {
   console.log(`  SSL:           ${config.ssl ? 'enabled' : 'disabled'}`);
   console.log(`  Multi-user:    ${config.multiuser}`);
   if (config.singleUser) {
-    const pwSource = config.singleUserPassword
-      ? 'provided'
-      : (process.stdin.isTTY ? 'will prompt at startup' : 'missing — login disabled');
-    console.log(`  Single-user:   ${config.singleUserName} (password: ${pwSource})`);
+    let details = `${config.singleUserName}`;
+    // Password seeding only runs when --idp is on AND the pod isn't the
+    // root-level case ('/'). Reflect both gates in the printed line so
+    // operators don't see a misleading "missing — login disabled" when
+    // login isn't governed by an IDP password at all.
+    if (config.idp) {
+      if (config.singleUserName === '/' || !config.singleUserName) {
+        details += ' (root pod; password not seeded)';
+      } else {
+        const pwSource = config.singleUserPassword
+          ? 'provided'
+          : (process.stdin.isTTY ? 'will prompt at startup' : 'missing — login disabled');
+        details += ` (password: ${pwSource})`;
+      }
+    }
+    console.log(`  Single-user:   ${details}`);
   }
   console.log(`  Conneg:        ${config.conneg}`);
   console.log(`  Notifications: ${config.notifications}`);

--- a/src/config.js
+++ b/src/config.js
@@ -75,6 +75,10 @@ export const defaults = {
   // Single-user mode (personal pod server)
   singleUser: false,
   singleUserName: 'me',
+  // Initial IDP password seeded on first single-user pod creation. If not
+  // set and --idp is enabled, the server prompts on TTY or fails clearly
+  // on non-TTY so the pod isn't unloggable.
+  singleUserPassword: null,
 
   // WebID-TLS client certificate authentication
   webidTls: false,
@@ -154,6 +158,7 @@ const envMap = {
   JSS_INVITE_ONLY: 'inviteOnly',
   JSS_SINGLE_USER: 'singleUser',
   JSS_SINGLE_USER_NAME: 'singleUserName',
+  JSS_SINGLE_USER_PASSWORD: 'singleUserPassword',
   JSS_WEBID_TLS: 'webidTls',
   JSS_DEFAULT_QUOTA: 'defaultQuota',
   JSS_PUBLIC: 'public',

--- a/src/config.js
+++ b/src/config.js
@@ -210,6 +210,7 @@ const BOOLEAN_KEYS = new Set([
   'tunnel',
   'activitypub',
   'inviteOnly',
+  'multiuser',
   'singleUser',
   'webidTls',
   'public',

--- a/src/config.js
+++ b/src/config.js
@@ -75,9 +75,10 @@ export const defaults = {
   // Single-user mode (personal pod server)
   singleUser: false,
   singleUserName: 'me',
-  // Initial IDP password seeded on first single-user pod creation. If not
-  // set and --idp is enabled, the server prompts on TTY or fails clearly
-  // on non-TTY so the pod isn't unloggable.
+  // Initial IDP password seeded on first single-user pod creation. If
+  // unset and --idp is enabled, the server prompts on a TTY or logs a
+  // warning and continues startup on non-TTY (so the pod is created but
+  // is not yet loggable until a password is set).
   singleUserPassword: null,
 
   // WebID-TLS client certificate authentication
@@ -190,14 +191,51 @@ export function parseSize(str) {
 }
 
 /**
+ * Config keys whose values are genuinely boolean. Only these get the
+ * "true"/"false" string coercion below — otherwise a user-supplied
+ * password (or any other string-valued option) like "true"/"false"
+ * would silently turn into a boolean and break downstream code (e.g.
+ * bcrypt hashing).
+ */
+const BOOLEAN_KEYS = new Set([
+  'ssl',
+  'conneg',
+  'subdomains',
+  'mashlib',
+  'mashlibCdn',
+  'git',
+  'nostr',
+  'webrtc',
+  'terminal',
+  'tunnel',
+  'activitypub',
+  'inviteOnly',
+  'singleUser',
+  'webidTls',
+  'public',
+  'readOnly',
+  'liveReload',
+  'pay',
+  'mongo',
+  'idp',
+  'notifications',
+  'logger',
+  'quiet'
+]);
+
+/**
  * Parse a value from environment variable string
  */
 function parseEnvValue(value, key) {
   if (value === undefined) return undefined;
 
-  // Boolean values
-  if (value.toLowerCase() === 'true') return true;
-  if (value.toLowerCase() === 'false') return false;
+  // Boolean values — only for known boolean keys; everything else
+  // stays a string so passwords / tokens / arbitrary text aren't
+  // silently coerced to booleans.
+  if (BOOLEAN_KEYS.has(key)) {
+    if (value.toLowerCase() === 'true') return true;
+    if (value.toLowerCase() === 'false') return false;
+  }
 
   // Numeric values for known numeric keys
   if ((key === 'port' || key === 'nostrMaxEvents' || key === 'payCost' || key === 'payRate') && !isNaN(value)) {

--- a/src/config.js
+++ b/src/config.js
@@ -355,6 +355,10 @@ export async function saveConfig(config, configFile) {
   // Remove derived/runtime values
   delete toSave.ssl;
   delete toSave.logger;
+  // Never persist secrets to a static config file. The password is
+  // expected to come from --single-user-password or
+  // JSS_SINGLE_USER_PASSWORD at runtime, not be written into .jss/config.
+  delete toSave.singleUserPassword;
 
   await fs.ensureDir(path.dirname(configFile));
   await fs.writeFile(configFile, JSON.stringify(toSave, null, 2));
@@ -371,6 +375,12 @@ export function printConfig(config) {
   console.log(`  Root:          ${path.resolve(config.root)}`);
   console.log(`  SSL:           ${config.ssl ? 'enabled' : 'disabled'}`);
   console.log(`  Multi-user:    ${config.multiuser}`);
+  if (config.singleUser) {
+    const pwSource = config.singleUserPassword
+      ? 'provided'
+      : (process.stdin.isTTY ? 'will prompt at startup' : 'missing — login disabled');
+    console.log(`  Single-user:   ${config.singleUserName} (password: ${pwSource})`);
+  }
   console.log(`  Conneg:        ${config.conneg}`);
   console.log(`  Notifications: ${config.notifications}`);
   console.log(`  IdP:           ${config.idp ? (config.idpIssuer || 'enabled') : 'disabled'}`);

--- a/src/server.js
+++ b/src/server.js
@@ -613,10 +613,20 @@ export function createServer(options = {}) {
     const existing = await findByUsername(username);
     if (existing) return; // already seeded — idempotent
 
-    let password = providedPassword;
+    // Treat anything that isn't a non-empty string as "not provided" so
+    // a misconfigured env coercion or stray boolean can't reach bcrypt.
+    let password = (typeof providedPassword === 'string' && providedPassword.length > 0)
+      ? providedPassword
+      : null;
+
     if (!password) {
       if (process.stdin.isTTY && process.stdout.isTTY) {
-        password = await promptPasswordOnce(`[jss] Set initial IDP password for "${username}": `);
+        try {
+          password = await promptPasswordOnce(`[jss] Set initial IDP password for "${username}": `);
+        } catch (err) {
+          fastify.log.warn({ err }, `Password prompt failed for "${username}"`);
+          return;
+        }
       } else {
         fastify.log.warn(
           `--single-user --idp: no password provided. Set --single-user-password or ` +
@@ -627,7 +637,7 @@ export function createServer(options = {}) {
       }
     }
 
-    if (!password) {
+    if (typeof password !== 'string' || password.length === 0) {
       fastify.log.warn(`Empty password — skipping IDP account creation for "${username}".`);
       return;
     }
@@ -641,25 +651,51 @@ export function createServer(options = {}) {
   }
 
   /**
-   * Read a password from stdin without echoing it. Cross-platform without
-   * extra dependencies — overrides readline's _writeToOutput so typed
-   * characters aren't echoed back to the terminal.
+   * Read a password from stdin without echoing it. Uses the public
+   * `emitKeypressEvents` + raw-mode keypress API rather than overriding
+   * the underscored `_writeToOutput` on a `readline.Interface`, which is
+   * a private/unstable hook.
    */
   async function promptPasswordOnce(prompt) {
-    const { createInterface } = await import('node:readline');
-    return new Promise((resolve) => {
-      const rl = createInterface({ input: process.stdin, output: process.stdout });
-      rl._writeToOutput = (chunk) => {
-        if (chunk === '\n' || chunk === '\r' || chunk === '\r\n') {
-          process.stdout.write(chunk);
+    const { emitKeypressEvents } = await import('node:readline');
+    const stdin = process.stdin;
+    const stdout = process.stdout;
+    if (!stdin.isTTY || typeof stdin.setRawMode !== 'function') {
+      throw new Error('Interactive password prompt requires a TTY');
+    }
+    return new Promise((resolve, reject) => {
+      let password = '';
+      const wasRaw = stdin.isRaw === true;
+      const onKeypress = (str, key = {}) => {
+        if (key.ctrl && key.name === 'c') {
+          cleanup();
+          reject(new Error('Password prompt cancelled'));
+          return;
         }
-        // Suppress everything else so the password isn't echoed.
+        if (key.name === 'return' || key.name === 'enter') {
+          cleanup();
+          resolve(password);
+          return;
+        }
+        if (key.name === 'backspace' || key.name === 'delete') {
+          password = password.slice(0, -1);
+          return;
+        }
+        if (!key.ctrl && !key.meta && typeof str === 'string' && str.length > 0) {
+          password += str;
+        }
       };
-      process.stdout.write(prompt);
-      rl.question('', (answer) => {
-        rl.close();
-        resolve(answer);
-      });
+      const cleanup = () => {
+        stdin.removeListener('keypress', onKeypress);
+        if (!wasRaw) stdin.setRawMode(false);
+        stdout.write('\n');
+        stdin.pause();
+      };
+      emitKeypressEvents(stdin);
+      stdout.write(prompt);
+      if (!wasRaw) stdin.setRawMode(true);
+      stdin.resume();
+      stdin.on('keypress', onKeypress);
     });
   }
 

--- a/src/server.js
+++ b/src/server.js
@@ -562,15 +562,21 @@ export function createServer(options = {}) {
       const isRootPod = !singleUserName || singleUserName === '/';
       const podPath = isRootPod ? '/' : `/${singleUserName}/`;
       const podUri = isRootPod ? `${baseUrl}/` : `${baseUrl}/${singleUserName}/`;
-      const webId = `${podUri}profile/card.jsonld#me`;
       const displayName = isRootPod ? 'me' : singleUserName;
 
       // Check if pod already exists. Accept either the new `card.jsonld`
       // or legacy extensionless `card` layout so we don't re-seed a pod
-      // that was created by an older JSS version.
-      const profileExists =
-        await storage.exists(`${podPath}profile/card.jsonld`) ||
-        await storage.exists(`${podPath}profile/card`);
+      // that was created by an older JSS version. Compute the effective
+      // WebID against whichever profile file actually resolves — a
+      // legacy pod must keep its `/profile/card#me` WebID, otherwise the
+      // seeded IDP account would point at a non-existent document.
+      const hasJsonLd = await storage.exists(`${podPath}profile/card.jsonld`);
+      const hasLegacy = !hasJsonLd && await storage.exists(`${podPath}profile/card`);
+      const profileFile = hasJsonLd ? 'profile/card.jsonld'
+                          : hasLegacy ? 'profile/card'
+                          : 'profile/card.jsonld'; // fresh pod default
+      const webId = `${podUri}${profileFile}#me`;
+      const profileExists = hasJsonLd || hasLegacy;
 
       if (!profileExists) {
         fastify.log.info(`Creating single-user pod at ${podUri}...`);

--- a/src/server.js
+++ b/src/server.js
@@ -94,6 +94,7 @@ export function createServer(options = {}) {
   // Single-user mode - creates pod on startup, disables registration
   const singleUser = options.singleUser ?? false;
   const singleUserName = options.singleUserName ?? 'me';
+  const singleUserPassword = options.singleUserPassword ?? null;
   // Default storage quota per pod (50MB default, 0 = unlimited)
   const defaultQuota = options.defaultQuota ?? 50 * 1024 * 1024;
   // WebID-TLS client certificate authentication is OFF by default
@@ -583,6 +584,82 @@ export function createServer(options = {}) {
         }
         fastify.log.info(`Single-user pod created at ${podUri}`);
       }
+
+      // Seed an IDP account so the operator can actually log in. Without
+      // this, single-user + --idp produces a pod but no credential, and
+      // registration is intentionally disabled in single-user mode — so
+      // the pod is unloggable until a password is set externally (#323).
+      if (idpEnabled && !isRootPod) {
+        await seedSingleUserIdpAccount({
+          fastify,
+          username: singleUserName,
+          webId,
+          podName: singleUserName,
+          providedPassword: singleUserPassword
+        });
+      }
+    });
+  }
+
+  /**
+   * Seed an IDP account for the single-user pod owner if one doesn't
+   * already exist. Password sources, in priority order:
+   *   1. `--single-user-password` / `JSS_SINGLE_USER_PASSWORD`
+   *   2. interactive prompt (TTY only)
+   *   3. error — server stays up but logs that login won't work yet
+   */
+  async function seedSingleUserIdpAccount({ fastify, username, webId, podName, providedPassword }) {
+    const { findByUsername, createAccount } = await import('./idp/accounts.js');
+    const existing = await findByUsername(username);
+    if (existing) return; // already seeded — idempotent
+
+    let password = providedPassword;
+    if (!password) {
+      if (process.stdin.isTTY && process.stdout.isTTY) {
+        password = await promptPasswordOnce(`[jss] Set initial IDP password for "${username}": `);
+      } else {
+        fastify.log.warn(
+          `--single-user --idp: no password provided. Set --single-user-password or ` +
+          `JSS_SINGLE_USER_PASSWORD before starting (or run on a TTY to be prompted). ` +
+          `Login is currently not possible for "${username}".`
+        );
+        return;
+      }
+    }
+
+    if (!password) {
+      fastify.log.warn(`Empty password — skipping IDP account creation for "${username}".`);
+      return;
+    }
+
+    try {
+      await createAccount({ username, password, webId, podName });
+      fastify.log.info(`IDP account seeded for single-user "${username}".`);
+    } catch (err) {
+      fastify.log.error({ err }, `Failed to seed IDP account for "${username}"`);
+    }
+  }
+
+  /**
+   * Read a password from stdin without echoing it. Cross-platform without
+   * extra dependencies — overrides readline's _writeToOutput so typed
+   * characters aren't echoed back to the terminal.
+   */
+  async function promptPasswordOnce(prompt) {
+    const { createInterface } = await import('node:readline');
+    return new Promise((resolve) => {
+      const rl = createInterface({ input: process.stdin, output: process.stdout });
+      rl._writeToOutput = (chunk) => {
+        if (chunk === '\n' || chunk === '\r' || chunk === '\r\n') {
+          process.stdout.write(chunk);
+        }
+        // Suppress everything else so the password isn't echoed.
+      };
+      process.stdout.write(prompt);
+      rl.question('', (answer) => {
+        rl.close();
+        resolve(answer);
+      });
     });
   }
 

--- a/src/server.js
+++ b/src/server.js
@@ -681,7 +681,12 @@ export function createServer(options = {}) {
           password = password.slice(0, -1);
           return;
         }
-        if (!key.ctrl && !key.meta && typeof str === 'string' && str.length > 0) {
+        // Only accept printable input — \P{C} excludes control codes,
+        // so escape sequences from arrow keys, function keys, etc. don't
+        // sneak invisible bytes into the password buffer.
+        if (!key.ctrl && !key.meta &&
+            typeof str === 'string' && str.length > 0 &&
+            /^\P{C}+$/u.test(str)) {
           password += str;
         }
       };

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -13,7 +13,7 @@ import { loadConfig } from '../src/config.js';
 
 describe('config — env var boolean coercion', () => {
   // Save/restore the env vars we touch so this test is hermetic.
-  const KEYS = ['JSS_SINGLE_USER_PASSWORD', 'JSS_IDP', 'JSS_BASE_DOMAIN'];
+  const KEYS = ['JSS_SINGLE_USER_PASSWORD', 'JSS_IDP', 'JSS_BASE_DOMAIN', 'JSS_MULTIUSER'];
   const original = {};
   before(() => { for (const k of KEYS) original[k] = process.env[k]; });
   after(() => {
@@ -52,5 +52,15 @@ describe('config — env var boolean coercion', () => {
     process.env.JSS_IDP = 'false';
     const cfg = await loadConfig({}, null);
     assert.strictEqual(cfg.idp, false);
+  });
+
+  it('coerces JSS_MULTIUSER to a boolean (regression for missed entry)', async () => {
+    process.env.JSS_MULTIUSER = 'false';
+    const cfg = await loadConfig({}, null);
+    assert.strictEqual(cfg.multiuser, false,
+      'multiuser must coerce to boolean false, not the string "false" (truthy)');
+    process.env.JSS_MULTIUSER = 'true';
+    const cfg2 = await loadConfig({}, null);
+    assert.strictEqual(cfg2.multiuser, true);
   });
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,7 +1,7 @@
 /**
  * Config / env-var parsing tests.
  *
- * Regression coverage for the env-coercion fix in #324: only known
+ * Regression coverage for the env-coercion fix in #323: only known
  * boolean keys may have their string values coerced to booleans.
  * Otherwise an env var like JSS_SINGLE_USER_PASSWORD="true" would silently
  * become a real boolean and break downstream code (bcrypt, etc.).

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,56 @@
+/**
+ * Config / env-var parsing tests.
+ *
+ * Regression coverage for the env-coercion fix in #324: only known
+ * boolean keys may have their string values coerced to booleans.
+ * Otherwise an env var like JSS_SINGLE_USER_PASSWORD="true" would silently
+ * become a real boolean and break downstream code (bcrypt, etc.).
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { loadConfig } from '../src/config.js';
+
+describe('config — env var boolean coercion', () => {
+  // Save/restore the env vars we touch so this test is hermetic.
+  const KEYS = ['JSS_SINGLE_USER_PASSWORD', 'JSS_IDP', 'JSS_BASE_DOMAIN'];
+  const original = {};
+  before(() => { for (const k of KEYS) original[k] = process.env[k]; });
+  after(() => {
+    for (const k of KEYS) {
+      if (original[k] === undefined) delete process.env[k];
+      else process.env[k] = original[k];
+    }
+  });
+
+  it('preserves string-valued env vars when their value is "true"', async () => {
+    process.env.JSS_SINGLE_USER_PASSWORD = 'true';
+    const cfg = await loadConfig({}, null);
+    assert.strictEqual(cfg.singleUserPassword, 'true',
+      'password env var must remain a string, not be coerced to boolean true');
+  });
+
+  it('preserves string-valued env vars when their value is "false"', async () => {
+    process.env.JSS_SINGLE_USER_PASSWORD = 'false';
+    const cfg = await loadConfig({}, null);
+    assert.strictEqual(cfg.singleUserPassword, 'false');
+  });
+
+  it('preserves string-valued env vars when set to other strings', async () => {
+    process.env.JSS_BASE_DOMAIN = 'example.com';
+    const cfg = await loadConfig({}, null);
+    assert.strictEqual(cfg.baseDomain, 'example.com');
+  });
+
+  it('still coerces known boolean keys', async () => {
+    process.env.JSS_IDP = 'true';
+    const cfg = await loadConfig({}, null);
+    assert.strictEqual(cfg.idp, true, 'idp env var should be coerced to boolean');
+  });
+
+  it('still coerces known boolean keys when "false"', async () => {
+    process.env.JSS_IDP = 'false';
+    const cfg = await loadConfig({}, null);
+    assert.strictEqual(cfg.idp, false);
+  });
+});

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -849,6 +849,47 @@ describe('Identity Provider — single-user password seeding (#323)', () => {
     }
   });
 
+  it('seeds with the legacy WebID when /profile/card (no .jsonld) already exists', async () => {
+    // Older JSS versions used /profile/card without the extension. A
+    // legacy pod must keep that URL — seeding an account whose WebID
+    // points at /profile/card.jsonld#me would create a credential bound
+    // to a document the user doesn't actually have.
+    const dir = './test-data-su-pw-legacy';
+    await fs.remove(dir);
+    await fs.ensureDir(dir);
+    // Pre-seed a legacy-layout pod so the server treats it as already
+    // existing on startup (no fresh creation).
+    const legacyProfileDir = path.join(dir, 'me/profile');
+    await fs.ensureDir(legacyProfileDir);
+    await fs.writeFile(path.join(legacyProfileDir, 'card'), '<html></html>');
+
+    const port = await getAvailablePort();
+    const baseUrl = `http://${TEST_HOST}:${port}`;
+    const server = createServer({
+      logger: false,
+      root: dir,
+      idp: true,
+      idpIssuer: baseUrl,
+      singleUser: true,
+      singleUserName: 'me',
+      singleUserPassword: 'legacy-pw',
+      forceCloseConnections: true,
+    });
+    try {
+      await server.listen({ port, host: TEST_HOST });
+      const { findByUsername } = await import('../src/idp/accounts.js');
+      const account = await findByUsername('me');
+      assert.ok(account, 'account should be seeded against the legacy pod');
+      assert.ok(
+        account.webId.endsWith('/me/profile/card#me'),
+        `legacy pod must keep /profile/card#me WebID, got ${account.webId}`
+      );
+    } finally {
+      await server.close();
+      await fs.remove(dir);
+    }
+  });
+
   it('does not seed when --idp is off', async () => {
     const dir = './test-data-su-pw-no-idp';
     await fs.remove(dir);

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -721,11 +721,16 @@ describe('Identity Provider - Credentials Endpoint', () => {
 describe('Identity Provider — single-user password seeding (#323)', () => {
   // Save/restore DATA_ROOT and stdin.isTTY around each test so we don't
   // leak global state into other tests in the same `node --test` run.
+  // For isTTY we capture the *property descriptor* so we can correctly
+  // restore an inherited (prototype) accessor — Object.defineProperty
+  // would otherwise leave a shadowing own-property behind.
   let originalDataRoot;
-  let originalIsTTY;
+  let originalIsTTYDescriptor;
+  let originalIsTTYWasOwn;
   before(() => {
     originalDataRoot = process.env.DATA_ROOT;
-    originalIsTTY = process.stdin.isTTY;
+    originalIsTTYWasOwn = Object.prototype.hasOwnProperty.call(process.stdin, 'isTTY');
+    originalIsTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
     // Force non-TTY so the no-password test never blocks on an
     // unanswerable prompt when the suite is run from an interactive shell.
     Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
@@ -733,7 +738,13 @@ describe('Identity Provider — single-user password seeding (#323)', () => {
   after(() => {
     if (originalDataRoot === undefined) delete process.env.DATA_ROOT;
     else process.env.DATA_ROOT = originalDataRoot;
-    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+    if (originalIsTTYWasOwn && originalIsTTYDescriptor) {
+      Object.defineProperty(process.stdin, 'isTTY', originalIsTTYDescriptor);
+    } else {
+      // Property was inherited; remove our shadowing own-property so
+      // the prototype's accessor is visible again.
+      delete process.stdin.isTTY;
+    }
   });
 
   it('seeds an IDP account when singleUserPassword is provided', async () => {

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -713,3 +713,138 @@ describe('Identity Provider - Credentials Endpoint', () => {
     });
   });
 });
+
+// Single-user + --idp must seed an IDP account so the operator can log in.
+// Without this, the pod is created but is unloggable: registration is
+// disabled in single-user mode and there's no pre-existing account.
+// Regression for #323.
+describe('Identity Provider — single-user password seeding (#323)', () => {
+  it('seeds an IDP account when singleUserPassword is provided', async () => {
+    const dir = './test-data-su-pw-provided';
+    await fs.remove(dir);
+    await fs.ensureDir(dir);
+    const port = await getAvailablePort();
+    const baseUrl = `http://${TEST_HOST}:${port}`;
+    const server = createServer({
+      logger: false,
+      root: dir,
+      idp: true,
+      idpIssuer: baseUrl,
+      singleUser: true,
+      singleUserName: 'me',
+      singleUserPassword: 'hunter2-test',
+      forceCloseConnections: true,
+    });
+    try {
+      await server.listen({ port, host: TEST_HOST });
+      // Set DATA_ROOT for the dynamically-imported accounts module.
+      process.env.DATA_ROOT = path.resolve(dir);
+      const { findByUsername, authenticate } = await import('../src/idp/accounts.js');
+      const account = await findByUsername('me');
+      assert.ok(account, 'IDP account for single-user "me" should exist');
+      assert.strictEqual(account.username, 'me');
+      assert.ok(account.webId.includes('/me/profile/card.jsonld#me'));
+      const authed = await authenticate('me', 'hunter2-test');
+      assert.ok(authed, 'should authenticate with the seeded password');
+    } finally {
+      await server.close();
+      await fs.remove(dir);
+    }
+  });
+
+  it('skips seeding (no error) when no password and not on a TTY', async () => {
+    // In CI / `npm test`, stdin is not a TTY — the seed step should warn
+    // and skip rather than block on an unanswerable prompt.
+    const dir = './test-data-su-pw-missing';
+    await fs.remove(dir);
+    await fs.ensureDir(dir);
+    const port = await getAvailablePort();
+    const baseUrl = `http://${TEST_HOST}:${port}`;
+    const server = createServer({
+      logger: false,
+      root: dir,
+      idp: true,
+      idpIssuer: baseUrl,
+      singleUser: true,
+      singleUserName: 'me',
+      // singleUserPassword intentionally omitted
+      forceCloseConnections: true,
+    });
+    try {
+      await server.listen({ port, host: TEST_HOST });
+      process.env.DATA_ROOT = path.resolve(dir);
+      const { findByUsername } = await import('../src/idp/accounts.js');
+      const account = await findByUsername('me');
+      assert.strictEqual(account, null, 'no account should be seeded without a password');
+      // Pod itself must still exist — server starts up regardless.
+      const profileExists = await fs.pathExists(path.join(dir, 'me/profile/card.jsonld'));
+      assert.ok(profileExists, 'pod should still be created');
+    } finally {
+      await server.close();
+      await fs.remove(dir);
+    }
+  });
+
+  it('is idempotent — restarting does not duplicate or error', async () => {
+    const dir = './test-data-su-pw-idempotent';
+    await fs.remove(dir);
+    await fs.ensureDir(dir);
+    const port = await getAvailablePort();
+    const baseUrl = `http://${TEST_HOST}:${port}`;
+    const startOnce = async () => {
+      const s = createServer({
+        logger: false,
+        root: dir,
+        idp: true,
+        idpIssuer: baseUrl,
+        singleUser: true,
+        singleUserName: 'me',
+        singleUserPassword: 'idem-pw',
+        forceCloseConnections: true,
+      });
+      await s.listen({ port, host: TEST_HOST });
+      return s;
+    };
+    let s1, s2;
+    try {
+      s1 = await startOnce();
+      await s1.close();
+      s2 = await startOnce();
+      process.env.DATA_ROOT = path.resolve(dir);
+      const { findByUsername, authenticate } = await import('../src/idp/accounts.js');
+      const account = await findByUsername('me');
+      assert.ok(account, 'account from first run should still exist');
+      // Original password still valid (we didn't overwrite on the second run).
+      const authed = await authenticate('me', 'idem-pw');
+      assert.ok(authed);
+    } finally {
+      if (s2) await s2.close();
+      await fs.remove(dir);
+    }
+  });
+
+  it('does not seed when --idp is off', async () => {
+    const dir = './test-data-su-pw-no-idp';
+    await fs.remove(dir);
+    await fs.ensureDir(dir);
+    const port = await getAvailablePort();
+    const server = createServer({
+      logger: false,
+      root: dir,
+      idp: false,
+      singleUser: true,
+      singleUserName: 'me',
+      singleUserPassword: 'should-be-ignored',
+      forceCloseConnections: true,
+    });
+    try {
+      await server.listen({ port, host: TEST_HOST });
+      // No .idp directory should exist when idp is disabled.
+      const idpDirExists = await fs.pathExists(path.join(dir, '.idp'));
+      assert.strictEqual(idpDirExists, false, 'no .idp directory when --idp off');
+    } finally {
+      await server.close();
+      await fs.remove(dir);
+    }
+  });
+});

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -719,7 +719,7 @@ describe('Identity Provider - Credentials Endpoint', () => {
 // disabled in single-user mode and there's no pre-existing account.
 // Regression for #323.
 describe('Identity Provider — single-user password seeding (#323)', () => {
-  // Save/restore DATA_ROOT and stdin.isTTY around each test so we don't
+  // Save/restore DATA_ROOT and stdin.isTTY around this suite so we don't
   // leak global state into other tests in the same `node --test` run.
   // For isTTY we capture the *property descriptor* so we can correctly
   // restore an inherited (prototype) accessor — Object.defineProperty

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -719,6 +719,23 @@ describe('Identity Provider - Credentials Endpoint', () => {
 // disabled in single-user mode and there's no pre-existing account.
 // Regression for #323.
 describe('Identity Provider — single-user password seeding (#323)', () => {
+  // Save/restore DATA_ROOT and stdin.isTTY around each test so we don't
+  // leak global state into other tests in the same `node --test` run.
+  let originalDataRoot;
+  let originalIsTTY;
+  before(() => {
+    originalDataRoot = process.env.DATA_ROOT;
+    originalIsTTY = process.stdin.isTTY;
+    // Force non-TTY so the no-password test never blocks on an
+    // unanswerable prompt when the suite is run from an interactive shell.
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+  });
+  after(() => {
+    if (originalDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = originalDataRoot;
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+  });
+
   it('seeds an IDP account when singleUserPassword is provided', async () => {
     const dir = './test-data-su-pw-provided';
     await fs.remove(dir);
@@ -736,9 +753,9 @@ describe('Identity Provider — single-user password seeding (#323)', () => {
       forceCloseConnections: true,
     });
     try {
+      // createServer already sets DATA_ROOT when `root` is provided;
+      // import accounts.js after listen() so it picks up the right path.
       await server.listen({ port, host: TEST_HOST });
-      // Set DATA_ROOT for the dynamically-imported accounts module.
-      process.env.DATA_ROOT = path.resolve(dir);
       const { findByUsername, authenticate } = await import('../src/idp/accounts.js');
       const account = await findByUsername('me');
       assert.ok(account, 'IDP account for single-user "me" should exist');
@@ -753,8 +770,8 @@ describe('Identity Provider — single-user password seeding (#323)', () => {
   });
 
   it('skips seeding (no error) when no password and not on a TTY', async () => {
-    // In CI / `npm test`, stdin is not a TTY — the seed step should warn
-    // and skip rather than block on an unanswerable prompt.
+    // The before() hook stubs stdin.isTTY=false so the seed step warns
+    // and skips rather than blocking on an unanswerable prompt.
     const dir = './test-data-su-pw-missing';
     await fs.remove(dir);
     await fs.ensureDir(dir);
@@ -772,7 +789,6 @@ describe('Identity Provider — single-user password seeding (#323)', () => {
     });
     try {
       await server.listen({ port, host: TEST_HOST });
-      process.env.DATA_ROOT = path.resolve(dir);
       const { findByUsername } = await import('../src/idp/accounts.js');
       const account = await findByUsername('me');
       assert.strictEqual(account, null, 'no account should be seeded without a password');
@@ -810,7 +826,6 @@ describe('Identity Provider — single-user password seeding (#323)', () => {
       s1 = await startOnce();
       await s1.close();
       s2 = await startOnce();
-      process.env.DATA_ROOT = path.resolve(dir);
       const { findByUsername, authenticate } = await import('../src/idp/accounts.js');
       const account = await findByUsername('me');
       assert.ok(account, 'account from first run should still exist');


### PR DESCRIPTION
## Summary
`jss start --single-user --idp` produced a pod with no way to log in: registration is disabled in single-user mode (correctly), `jss passwd` errors with `User not found`, and the WebID has no Schnorr/TLS bootstrap. Adds a one-time IDP account seed during single-user pod creation.

## Behaviour

- **`--single-user-password <pw>`** (also via `JSS_SINGLE_USER_PASSWORD` env var) — seed the account non-interactively. Ideal for systemd / containers / CI.
- **TTY** with no password supplied — interactive no-echo prompt.
- **Non-TTY** with no password — server starts, but logs a clear warning explaining how to set one (no silent failure, no blocked startup).
- **Idempotent** — restarting finds the existing account and skips. Existing passwords are not overwritten.
- **Gated on `--idp`** — the password is ignored when the IDP is off.
- **Out of scope** — root-pod case (`singleUserName === '/'`); skipped here, can be a follow-up.

## Test plan
- [x] `singleUserPassword` provided → account seeded, `authenticate(name, pw)` returns the account.
- [x] No password + non-TTY → no account seeded, pod still up, no error.
- [x] Restart with same options → idempotent, original password still valid.
- [x] `--idp` off → no `.idp` directory created.
- [x] Full suite green (453/453).
- [x] **Live smoke test** of the user's exact repro: `JSS_SINGLE_USER_PASSWORD=hunter2 jss start --single-user --idp …` → `POST /idp/credentials {username:"me", password:"hunter2"}` returns a bearer token with the right `webid` claim. Wrong password returns 401.

## Files
- `bin/jss.js` — `--single-user-password` option, threaded into `createServer`.
- `src/config.js` — default + `JSS_SINGLE_USER_PASSWORD` env mapping.
- `src/server.js` — `seedSingleUserIdpAccount` + `promptPasswordOnce` helpers, called from the existing single-user `onReady` hook after pod creation.
- `test/idp.test.js` — four targeted tests covering each branch above.

Fixes #323.