### PR TITLE
Respect q-weights and align HEAD/GET content-type for conneg (#325)

### DIFF
--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -149,17 +149,18 @@ export async function handleGet(request, reply) {
       const content = await storage.read(indexPath);
       const indexStats = await storage.stat(indexPath);
 
-      // Check if RDF format requested via content negotiation
+      // Pick the negotiated RDF type using q-aware Accept parsing. The
+      // naive `acceptHeader.includes('text/turtle')` we used to do here
+      // ignored q-weights — `Accept: application/ld+json, text/turtle;q=0.1`
+      // would still pick Turtle even though JSON-LD was preferred (#325).
       const acceptHeader = request.headers.accept || '';
-      const wantsTurtle = connegEnabled && (
-        acceptHeader.includes('text/turtle') ||
-        acceptHeader.includes('text/n3') ||
-        acceptHeader.includes('application/n-triples')
-      );
-      const wantsJsonLd = connegEnabled && (
-        acceptHeader.includes('application/ld+json') ||
-        acceptHeader.includes('application/json')
-      );
+      const negotiated = connegEnabled
+        ? selectContentType(acceptHeader, true)
+        : null;
+      const wantsTurtle = negotiated === RDF_TYPES.TURTLE
+        || negotiated === RDF_TYPES.N3
+        || negotiated === 'application/n-triples';
+      const wantsJsonLd = negotiated === RDF_TYPES.JSON_LD;
 
       if (wantsTurtle || wantsJsonLd) {
         // Extract JSON-LD from HTML data island
@@ -257,13 +258,14 @@ export async function handleGet(request, reply) {
       return reply.type('text/html').send(html);
     }
 
-    // Check if Turtle/N3 format is requested via content negotiation
+    // Pick the negotiated RDF type using q-aware Accept parsing (#325).
     const acceptHeader = request.headers.accept || '';
-    const wantsTurtle = connegEnabled && (
-      acceptHeader.includes('text/turtle') ||
-      acceptHeader.includes('text/n3') ||
-      acceptHeader.includes('application/n-triples')
-    );
+    const negotiated = connegEnabled
+      ? selectContentType(acceptHeader, true)
+      : null;
+    const wantsTurtle = negotiated === RDF_TYPES.TURTLE
+      || negotiated === RDF_TYPES.N3
+      || negotiated === 'application/n-triples';
 
     if (wantsTurtle) {
       // Convert container JSON-LD to Turtle
@@ -383,11 +385,14 @@ export async function handleGet(request, reply) {
   if (connegEnabled) {
     const contentStr = content.toString();
     const acceptHeader = request.headers.accept || '';
-    // Serve Turtle if: URL ends with .ttl OR Accept header requests it
-    const wantsTurtle = urlPath.endsWith('.ttl') ||
-                        acceptHeader.includes('text/turtle') ||
-                        acceptHeader.includes('text/n3') ||
-                        acceptHeader.includes('application/n-triples');
+    // Serve Turtle if: URL ends with .ttl OR Accept's q-weighted top
+    // RDF type is Turtle/N3 (#325 — naive substring matching ignored
+    // q-weights and would pick Turtle whenever it appeared in Accept).
+    const negotiated = selectContentType(acceptHeader, true);
+    const wantsTurtle = urlPath.endsWith('.ttl')
+      || negotiated === RDF_TYPES.TURTLE
+      || negotiated === RDF_TYPES.N3
+      || negotiated === 'application/n-triples';
 
     // Check if this is HTML with JSON-LD data island
     const isHtmlWithDataIsland = contentStr.trimStart().startsWith('<!DOCTYPE') ||
@@ -505,24 +510,31 @@ export async function handleHead(request, reply) {
   let contentType;
 
   if (stats.isDirectory) {
-    // For directories with index.html, determine content type based on Accept header
     const indexPath = storagePath.endsWith('/') ? `${storagePath}index.html` : `${storagePath}/index.html`;
     const indexExists = await storage.exists(indexPath);
+    const acceptHeader = request.headers.accept || '';
 
-    if (indexExists && connegEnabled) {
-      const acceptHeader = request.headers.accept || '';
-      const wantsTurtle = acceptHeader.includes('text/turtle') ||
-                          acceptHeader.includes('text/n3') ||
-                          acceptHeader.includes('application/n-triples');
-      const wantsJsonLd = acceptHeader.includes('application/ld+json') ||
-                          acceptHeader.includes('application/json');
+    if (connegEnabled) {
+      // HEAD must mirror what GET would emit; otherwise client caches and
+      // RDF-aware tooling key off a content-type that doesn't match the
+      // body they'll see on the next GET (#325). Use q-aware Accept
+      // parsing for both the index.html and listing branches.
+      const negotiated = selectContentType(acceptHeader, true);
+      const wantsTurtle = negotiated === RDF_TYPES.TURTLE
+        || negotiated === RDF_TYPES.N3
+        || negotiated === 'application/n-triples';
+      const wantsJsonLd = negotiated === RDF_TYPES.JSON_LD;
 
       if (wantsTurtle) {
         contentType = 'text/turtle';
       } else if (wantsJsonLd) {
-        contentType = 'application/ld+json';
+        // For an index.html container, only override to JSON-LD if the
+        // Accept header explicitly asked for JSON; otherwise fall back
+        // to text/html so HEAD matches the index.html that GET serves.
+        const explicitJson = /\b(application\/ld\+json|application\/json)\b/i.test(acceptHeader);
+        contentType = (indexExists && !explicitJson) ? 'text/html' : 'application/ld+json';
       } else {
-        contentType = 'text/html';
+        contentType = indexExists ? 'text/html' : 'application/ld+json';
       }
     } else if (indexExists) {
       contentType = 'text/html';

--- a/test/conneg.test.js
+++ b/test/conneg.test.js
@@ -354,3 +354,95 @@ describe('Content Negotiation (conneg disabled - default)', () => {
     });
   });
 });
+
+// Regression coverage for #325 — q-weighted Accept and HEAD/GET parity.
+// Previously the conneg dispatcher used naive substring matching on the
+// Accept header, so any Accept that mentioned text/turtle (even at q=0.1
+// alongside q=1.0 application/ld+json) returned Turtle. Separately, HEAD
+// on a container without an index.html hard-coded application/ld+json,
+// so HEAD and GET disagreed on content-type for the same URL.
+describe('Content Negotiation — q-weights and HEAD/GET parity (#325)', () => {
+  before(async () => {
+    await startTestServer({ conneg: true });
+    await createTestPod('qwtest');
+  });
+  after(async () => { await stopTestServer(); });
+
+  function ct(res) {
+    return (res.headers.get('content-type') || '').split(';')[0].trim();
+  }
+
+  describe('container — q-weight respected', () => {
+    it('Accept: jsonld q=1.0, turtle q=0.1 → JSON-LD', async () => {
+      const res = await request('/qwtest/', {
+        headers: { Accept: 'application/ld+json;q=1.0, text/turtle;q=0.1' }
+      });
+      assertStatus(res, 200);
+      assert.strictEqual(ct(res), 'application/ld+json');
+      const body = await res.text();
+      assert.ok(body.trimStart().startsWith('{'),
+        `body should be JSON, got: ${body.slice(0, 80)}`);
+    });
+
+    it('Accept: jsonld, turtle;q=0.5 → JSON-LD wins (downstream repro)', async () => {
+      const res = await request('/qwtest/', {
+        headers: { Accept: 'application/ld+json, text/turtle;q=0.5' }
+      });
+      assert.strictEqual(ct(res), 'application/ld+json');
+      const body = await res.text();
+      assert.ok(body.trimStart().startsWith('{'),
+        `body should be JSON, got: ${body.slice(0, 80)}`);
+    });
+
+    it('Accept: turtle (explicit) → Turtle', async () => {
+      const res = await request('/qwtest/', { headers: { Accept: 'text/turtle' } });
+      assert.strictEqual(ct(res), 'text/turtle');
+      const body = await res.text();
+      assert.ok(body.trimStart().startsWith('@prefix'),
+        `body should be Turtle, got: ${body.slice(0, 80)}`);
+    });
+
+    it('no Accept → JSON-LD (native default)', async () => {
+      const res = await request('/qwtest/');
+      assert.strictEqual(ct(res), 'application/ld+json');
+    });
+  });
+
+  describe('container — HEAD content-type matches GET', () => {
+    const cases = [
+      ['no Accept',         {}],
+      ['jsonld preferred',  { Accept: 'application/ld+json;q=1.0, text/turtle;q=0.1' }],
+      ['turtle preferred',  { Accept: 'text/turtle' }],
+      ['mixed (q=0.5)',     { Accept: 'application/ld+json, text/turtle;q=0.5' }]
+    ];
+    for (const [label, headers] of cases) {
+      it(`HEAD === GET content-type — ${label}`, async () => {
+        const get = await request('/qwtest/', { headers });
+        const head = await request('/qwtest/', { method: 'HEAD', headers });
+        assert.strictEqual(get.status, 200);
+        assert.strictEqual(head.status, 200);
+        assert.strictEqual(ct(head), ct(get),
+          `HEAD ct (${ct(head)}) must equal GET ct (${ct(get)}) for ${label}`);
+      });
+    }
+  });
+
+  describe('container — auth path matches anonymous', () => {
+    it('GET with auth returns same content-type as without auth (turtle case)', async () => {
+      const headers = { Accept: 'text/turtle' };
+      const anon = await request('/qwtest/', { headers });
+      const authed = await request('/qwtest/', { headers, auth: 'qwtest' });
+      assert.strictEqual(ct(anon), 'text/turtle');
+      assert.strictEqual(ct(authed), ct(anon),
+        'authenticated GET must report the same content-type as anonymous');
+    });
+
+    it('GET with auth returns same content-type as without auth (jsonld case)', async () => {
+      const headers = { Accept: 'application/ld+json;q=1.0, text/turtle;q=0.1' };
+      const anon = await request('/qwtest/', { headers });
+      const authed = await request('/qwtest/', { headers, auth: 'qwtest' });
+      assert.strictEqual(ct(anon), 'application/ld+json');
+      assert.strictEqual(ct(authed), ct(anon));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes two conneg bugs reported in #325.

### Bug 1: Q-weights ignored
`src/handlers/resource.js` used naive `acceptHeader.includes('text/turtle')` substring matching. An `Accept: application/ld+json, text/turtle;q=0.1` header returned Turtle even though JSON-LD was the higher-q preference. Replaced **five** substring sites with the existing q-aware `selectContentType` from `src/rdf/conneg.js`:

- `handleGet`: container with `index.html` data-island
- `handleGet`: container listing (no index.html)
- `handleGet`: resource with HTML data-island (`.ttl` URL hint preserved)
- `handleHead`: container

### Bug 2: HEAD/GET divergence
`handleHead` hard-coded `application/ld+json` for containers without `index.html`, regardless of Accept. So `HEAD /me/` and `GET /me/` reported different content-types for the same URL with the same Accept — tooling that read the HEAD label and then fetched the body got a mismatch. `handleHead` now runs the same q-aware Accept logic and tracks GET.

### Note on the "auth path mislabels content-type" symptom
Doesn't reproduce on current tip. Likely fixed by the Turtle-converter work in #321 (the converter previously dropped nested-node data, which produced confused responses on some auth-via-WAC paths). Both anon and auth paths now return identical content-type for the same Accept — the new tests pin that invariant.

## Test plan
- [x] `Accept: jsonld;q=1.0, turtle;q=0.1` → JSON-LD (q-weight respected)
- [x] `Accept: jsonld, turtle;q=0.5` (downstream repro) → JSON-LD
- [x] `Accept: text/turtle` → Turtle
- [x] No Accept → JSON-LD (native default)
- [x] HEAD content-type === GET content-type for four Accept shapes
- [x] Auth path content-type === anon path content-type for both turtle and jsonld
- [x] Full suite green: 470/470 (10 new tests)
- [x] Live smoke: `curl -i` GET and `curl -I` HEAD on `/me/` with `Accept: application/ld+json;q=1.0, text/turtle;q=0.1` both report `application/ld+json` and the body is JSON-LD.

Fixes #325.