### PR TITLE
Update footer links to https://jss.live/ (#329)

### DIFF
--- a/src/auth/middleware.js
+++ b/src/auth/middleware.js
@@ -385,8 +385,8 @@ function getErrorPage(statusCode, isAuthenticated, request) {
     </div>
 
     <p class="footer">
-      Powered by <a href="https://sandy-mount.com">Sandymount</a> •
-      <a href="https://solidproject.org">Learn about Solid</a>
+      Powered by <a href="https://jss.live/">JSS</a> •
+      <a href="https://jss.live/docs/">Docs</a>
     </p>
   </div>
 </body>


### PR DESCRIPTION
## Summary

Updates the auth-page footer in `src/auth/middleware.js` to point to `https://jss.live/` (the canonical JSS project home and docs hub).

Closes #329.

## Change

```diff
     <p class="footer">
-      Powered by <a href="https://sandy-mount.com">Sandymount</a> •
-      <a href="https://solidproject.org">Learn about Solid</a>
+      Powered by <a href="https://jss.live/">JSS</a> •
+      <a href="https://jss.live/docs/">Docs</a>
     </p>
```

## Why

- `jss.live` is now the canonical project home and docs hub
- Aligns the auth-page footer with the LWS-aligned positioning announced on `public-solid` (April 23, 2026)
- Project-focused footer; removes orphaned references to hosts that are no longer the primary identity

## Scope

- Single file changed
- No behavioural changes
- Auth-page error/login templates only
- Two link updates

## Test plan

- [x] Verified diff matches the issue's proposed change
- [ ] Manually browse a 401 page to confirm footer renders with new links (post-merge / on next deploy)
- [ ] Confirm `https://jss.live/` and `https://jss.live/docs/` resolve

## Closes

Closes #329