### PR TITLE
Reject non-JSON-LD PUT on .acl resources (#295)

### DIFF
--- a/src/handlers/container.js
+++ b/src/handlers/container.js
@@ -42,11 +42,16 @@ export async function handlePost(request, reply) {
 
   // Check if we can accept this input type
   if (!canAcceptInput(contentType, connegEnabled)) {
+    const acceptValue = connegEnabled
+      ? 'application/ld+json, application/json, text/turtle, text/n3'
+      : 'application/ld+json, application/json';
+    reply.header('Accept', acceptValue);
+    reply.header('Accept-Post', acceptValue);
     return reply.code(415).send({
       error: 'Unsupported Media Type',
       message: connegEnabled
-        ? 'Supported types: application/ld+json, text/turtle, text/n3'
-        : 'Supported type: application/ld+json (enable conneg for Turtle support)'
+        ? 'Supported types: application/ld+json, application/json, text/turtle, text/n3'
+        : 'Supported types: application/ld+json, application/json (enable conneg for Turtle/N3 support)'
     });
   }
 

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -614,6 +614,22 @@ export async function handlePut(request, reply) {
 
   const contentType = request.headers['content-type'] || '';
 
+  // ACL resources require application/ld+json: round-trip serialization
+  // between JSON-LD and Turtle representations has limitations that can
+  // cause data loss when a client PUTs Turtle and later requests Turtle.
+  // Other RDF resources are unaffected.
+  const ctMain = contentType.split(';')[0].trim().toLowerCase();
+  const isJsonLd = ctMain === 'application/ld+json' || ctMain === 'application/json';
+  if (urlPath.endsWith('.acl') && contentType && !isJsonLd) {
+    reply.header('Accept', 'application/ld+json');
+    reply.header('Accept-Post', 'application/ld+json');
+    reply.header('Accept-Patch', 'application/ld+json');
+    return reply.code(415).send({
+      error: 'Unsupported Media Type',
+      message: 'ACL resources must be sent as application/ld+json.'
+    });
+  }
+
   // Check if we can accept this input type
   if (!canAcceptInput(contentType, connegEnabled)) {
     return reply.code(415).send({

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -624,8 +624,7 @@ export async function handlePut(request, reply) {
   const isJsonLd = ctMain === 'application/ld+json' || ctMain === 'application/json';
   if (urlPath.endsWith('.acl') && !isJsonLd) {
     reply.header('Accept', 'application/ld+json, application/json');
-    reply.header('Accept-Post', 'application/ld+json, application/json');
-    reply.header('Accept-Patch', 'application/ld+json, application/json');
+    reply.header('Accept-Put', 'application/ld+json, application/json');
     return reply.code(415).send({
       error: 'Unsupported Media Type',
       message: 'ACL resources must be sent as application/ld+json or application/json.'

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -636,8 +636,8 @@ export async function handlePut(request, reply) {
     return reply.code(415).send({
       error: 'Unsupported Media Type',
       message: connegEnabled
-        ? 'Supported types: application/ld+json, text/turtle, text/n3'
-        : 'Supported type: application/ld+json (enable conneg for Turtle support)'
+        ? 'Supported types: application/ld+json, application/json, text/turtle, text/n3'
+        : 'Supported types: application/ld+json, application/json (enable conneg for Turtle support)'
     });
   }
 

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -633,6 +633,11 @@ export async function handlePut(request, reply) {
 
   // Check if we can accept this input type
   if (!canAcceptInput(contentType, connegEnabled)) {
+    const acceptValue = connegEnabled
+      ? 'application/ld+json, application/json, text/turtle, text/n3'
+      : 'application/ld+json, application/json';
+    reply.header('Accept', acceptValue);
+    reply.header('Accept-Put', acceptValue);
     return reply.code(415).send({
       error: 'Unsupported Media Type',
       message: connegEnabled

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -614,19 +614,21 @@ export async function handlePut(request, reply) {
 
   const contentType = request.headers['content-type'] || '';
 
-  // ACL resources require application/ld+json: round-trip serialization
-  // between JSON-LD and Turtle representations has limitations that can
-  // cause data loss when a client PUTs Turtle and later requests Turtle.
-  // Other RDF resources are unaffected.
+  // ACL resources require a JSON-LD payload (application/ld+json or
+  // application/json). Round-trip serialization between JSON-LD and
+  // Turtle representations has limitations that can cause data loss
+  // when a client PUTs Turtle and later requests Turtle.
+  // Other RDF resources are unaffected. The guard fires regardless
+  // of conneg setting and also when Content-Type is missing.
   const ctMain = contentType.split(';')[0].trim().toLowerCase();
   const isJsonLd = ctMain === 'application/ld+json' || ctMain === 'application/json';
-  if (urlPath.endsWith('.acl') && contentType && !isJsonLd) {
-    reply.header('Accept', 'application/ld+json');
-    reply.header('Accept-Post', 'application/ld+json');
-    reply.header('Accept-Patch', 'application/ld+json');
+  if (urlPath.endsWith('.acl') && !isJsonLd) {
+    reply.header('Accept', 'application/ld+json, application/json');
+    reply.header('Accept-Post', 'application/ld+json, application/json');
+    reply.header('Accept-Patch', 'application/ld+json, application/json');
     return reply.code(415).send({
       error: 'Unsupported Media Type',
-      message: 'ACL resources must be sent as application/ld+json.'
+      message: 'ACL resources must be sent as application/ld+json or application/json.'
     });
   }
 

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -637,7 +637,7 @@ export async function handlePut(request, reply) {
       error: 'Unsupported Media Type',
       message: connegEnabled
         ? 'Supported types: application/ld+json, application/json, text/turtle, text/n3'
-        : 'Supported types: application/ld+json, application/json (enable conneg for Turtle support)'
+        : 'Supported types: application/ld+json, application/json (enable conneg for Turtle/N3 support)'
     });
   }
 

--- a/src/rdf/conneg.js
+++ b/src/rdf/conneg.js
@@ -207,12 +207,18 @@ export function getVaryHeader(connegEnabled, mashlibEnabled = false) {
 /**
  * Get Accept-* headers for responses.
  *
- * Advertised types match canAcceptInput()'s accepted set so clients
- * can discover support consistently:
+ * The explicitly listed RDF types are aligned with the formats this
+ * module accepts so clients can discover support consistently:
  *   - JSON-LD (application/ld+json) and JSON (application/json alias)
  *     are advertised in all conneg modes.
  *   - Turtle (text/turtle) and N3 (text/n3) are advertised only when
  *     conneg is enabled (SUPPORTED_INPUT in this file).
+ *
+ * Note: a wildcard (asterisk-slash-asterisk) is included as a broad
+ * interoperability hint for generic clients and proxies. It is not a
+ * strict contract that every media type matching the wildcard will be
+ * accepted by canAcceptInput() (e.g., application/n-triples and
+ * application/rdf+xml are not accepted).
  */
 export function getAcceptHeaders(connegEnabled, isContainer = false) {
   const headers = {};

--- a/src/rdf/conneg.js
+++ b/src/rdf/conneg.js
@@ -205,20 +205,24 @@ export function getVaryHeader(connegEnabled, mashlibEnabled = false) {
 }
 
 /**
- * Get Accept-* headers for responses
+ * Get Accept-* headers for responses.
+ *
+ * canAcceptInput() treats application/json as a JSON-LD alias, so it
+ * is advertised alongside application/ld+json to match the actual
+ * accepted set (clients can discover support consistently).
  */
 export function getAcceptHeaders(connegEnabled, isContainer = false) {
   const headers = {};
 
   if (isContainer) {
     headers['Accept-Post'] = connegEnabled
-      ? `${RDF_TYPES.JSON_LD}, ${RDF_TYPES.TURTLE}, */*`
-      : `${RDF_TYPES.JSON_LD}, */*`;
+      ? `${RDF_TYPES.JSON_LD}, application/json, ${RDF_TYPES.TURTLE}, */*`
+      : `${RDF_TYPES.JSON_LD}, application/json, */*`;
   }
 
   headers['Accept-Put'] = connegEnabled
-    ? `${RDF_TYPES.JSON_LD}, ${RDF_TYPES.TURTLE}, */*`
-    : `${RDF_TYPES.JSON_LD}, */*`;
+    ? `${RDF_TYPES.JSON_LD}, application/json, ${RDF_TYPES.TURTLE}, */*`
+    : `${RDF_TYPES.JSON_LD}, application/json, */*`;
 
   headers['Accept-Patch'] = 'text/n3, application/sparql-update';
 

--- a/src/rdf/conneg.js
+++ b/src/rdf/conneg.js
@@ -207,21 +207,24 @@ export function getVaryHeader(connegEnabled, mashlibEnabled = false) {
 /**
  * Get Accept-* headers for responses.
  *
- * canAcceptInput() treats application/json as a JSON-LD alias, so it
- * is advertised alongside application/ld+json to match the actual
- * accepted set (clients can discover support consistently).
+ * Advertised types match canAcceptInput()'s accepted set so clients
+ * can discover support consistently:
+ *   - JSON-LD (application/ld+json) and JSON (application/json alias)
+ *     are advertised in all conneg modes.
+ *   - Turtle (text/turtle) and N3 (text/n3) are advertised only when
+ *     conneg is enabled (SUPPORTED_INPUT in this file).
  */
 export function getAcceptHeaders(connegEnabled, isContainer = false) {
   const headers = {};
 
   if (isContainer) {
     headers['Accept-Post'] = connegEnabled
-      ? `${RDF_TYPES.JSON_LD}, application/json, ${RDF_TYPES.TURTLE}, */*`
+      ? `${RDF_TYPES.JSON_LD}, application/json, ${RDF_TYPES.TURTLE}, ${RDF_TYPES.N3}, */*`
       : `${RDF_TYPES.JSON_LD}, application/json, */*`;
   }
 
   headers['Accept-Put'] = connegEnabled
-    ? `${RDF_TYPES.JSON_LD}, application/json, ${RDF_TYPES.TURTLE}, */*`
+    ? `${RDF_TYPES.JSON_LD}, application/json, ${RDF_TYPES.TURTLE}, ${RDF_TYPES.N3}, */*`
     : `${RDF_TYPES.JSON_LD}, application/json, */*`;
 
   headers['Accept-Patch'] = 'text/n3, application/sparql-update';

--- a/test/conneg.test.js
+++ b/test/conneg.test.js
@@ -193,6 +193,34 @@ describe('Content Negotiation (conneg enabled)', () => {
       assert.ok(acceptPost && acceptPost.includes('text/turtle'),
         'Accept-Post should include text/turtle');
     });
+
+    it('should advertise N3 support in Accept-Put when conneg enabled', async () => {
+      const res = await request('/connegtest/public/alice.json');
+      const acceptPut = res.headers.get('Accept-Put');
+      assert.ok(acceptPut && acceptPut.includes('text/n3'),
+        'Accept-Put should include text/n3 (canAcceptInput accepts it under conneg)');
+    });
+
+    it('should advertise N3 support in Accept-Post for containers when conneg enabled', async () => {
+      const res = await request('/connegtest/public/');
+      const acceptPost = res.headers.get('Accept-Post');
+      assert.ok(acceptPost && acceptPost.includes('text/n3'),
+        'Accept-Post should include text/n3 (canAcceptInput accepts it under conneg)');
+    });
+
+    it('should advertise application/json in Accept-Put', async () => {
+      const res = await request('/connegtest/public/alice.json');
+      const acceptPut = res.headers.get('Accept-Put');
+      assert.ok(acceptPut && acceptPut.includes('application/json'),
+        'Accept-Put should include application/json (canAcceptInput treats it as a JSON-LD alias)');
+    });
+
+    it('should advertise application/json in Accept-Post for containers', async () => {
+      const res = await request('/connegtest/public/');
+      const acceptPost = res.headers.get('Accept-Post');
+      assert.ok(acceptPost && acceptPost.includes('application/json'),
+        'Accept-Post should include application/json (canAcceptInput treats it as a JSON-LD alias)');
+    });
   });
 
   // Regression coverage for #294 — Solid convention dotfiles (.acl, .meta)
@@ -452,6 +480,20 @@ describe('Content Negotiation (conneg disabled - default)', () => {
         'Accept-Put should include application/ld+json');
       assert.ok(!acceptPut || !acceptPut.includes('text/turtle'),
         'Accept-Put should NOT include text/turtle when conneg disabled');
+    });
+
+    it('should advertise application/json in Accept-Put when conneg disabled', async () => {
+      const res = await request('/noconneg/public/');
+      const acceptPut = res.headers.get('Accept-Put');
+      assert.ok(acceptPut && acceptPut.includes('application/json'),
+        'Accept-Put should include application/json (canAcceptInput treats it as a JSON-LD alias)');
+    });
+
+    it('should not advertise text/n3 in Accept-Put when conneg disabled', async () => {
+      const res = await request('/noconneg/public/');
+      const acceptPut = res.headers.get('Accept-Put');
+      assert.ok(!acceptPut || !acceptPut.includes('text/n3'),
+        'Accept-Put should NOT include text/n3 when conneg disabled');
     });
   });
 

--- a/test/conneg.test.js
+++ b/test/conneg.test.js
@@ -261,6 +261,84 @@ describe('Content Negotiation (conneg enabled)', () => {
         'round-tripped JSON-LD should have at least one @-keyword');
     });
   });
+
+  // ACL resources require application/ld+json on PUT regardless of conneg
+  // setting: round-trip serialization between JSON-LD and Turtle has known
+  // limitations that can cause data loss. See #295.
+  describe('ACL content-type guard (#295)', () => {
+    const aclJsonLd = {
+      '@context': { acl: 'http://www.w3.org/ns/auth/acl#' },
+      '@graph': [
+        {
+          '@id': '#owner',
+          '@type': 'acl:Authorization',
+          'acl:agent': { '@id': '#me' },
+          'acl:accessTo': { '@id': './' },
+          'acl:mode': [{ '@id': 'acl:Read' }, { '@id': 'acl:Write' }, { '@id': 'acl:Control' }]
+        }
+      ]
+    };
+
+    it('rejects text/turtle PUT to .acl with 415', async () => {
+      const turtle = `
+        @prefix acl: <http://www.w3.org/ns/auth/acl#>.
+        <#owner> a acl:Authorization;
+          acl:mode acl:Read.
+      `;
+      const res = await request('/connegtest/public/turtle-reject.acl', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'text/turtle' },
+        body: turtle,
+        auth: 'connegtest'
+      });
+      assertStatus(res, 415);
+      assertHeader(res, 'Accept', 'application/ld+json');
+      assertHeader(res, 'Accept-Post', 'application/ld+json');
+      assertHeader(res, 'Accept-Patch', 'application/ld+json');
+    });
+
+    it('rejects text/n3 PUT to .acl with 415', async () => {
+      const res = await request('/connegtest/public/n3-reject.acl', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'text/n3' },
+        body: '@prefix acl: <http://www.w3.org/ns/auth/acl#>. <#x> a acl:Authorization.',
+        auth: 'connegtest'
+      });
+      assertStatus(res, 415);
+      assertHeader(res, 'Accept', 'application/ld+json');
+    });
+
+    it('rejects text/plain PUT to .acl with 415 (URL-extension protection)', async () => {
+      const res = await request('/connegtest/public/plain-reject.acl', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'text/plain' },
+        body: 'arbitrary text',
+        auth: 'connegtest'
+      });
+      assertStatus(res, 415);
+      assertHeader(res, 'Accept', 'application/ld+json');
+    });
+
+    it('accepts application/ld+json PUT to .acl', async () => {
+      const res = await request('/connegtest/public/jsonld-accept.acl', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/ld+json' },
+        body: JSON.stringify(aclJsonLd),
+        auth: 'connegtest'
+      });
+      assert.ok(res.status < 300, `JSON-LD PUT to .acl should succeed, got ${res.status}`);
+    });
+
+    it('accepts application/json PUT to .acl', async () => {
+      const res = await request('/connegtest/public/json-accept.acl', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(aclJsonLd),
+        auth: 'connegtest'
+      });
+      assert.ok(res.status < 300, `application/json PUT to .acl should succeed, got ${res.status}`);
+    });
+  });
 });
 
 describe('Content Negotiation (conneg disabled - default)', () => {

--- a/test/conneg.test.js
+++ b/test/conneg.test.js
@@ -294,7 +294,9 @@ describe('Content Negotiation (conneg enabled)', () => {
       });
       assertStatus(res, 415);
       assertHeaderContains(res, 'Accept', 'application/ld+json');
+      assertHeaderContains(res, 'Accept', 'application/json');
       assertHeaderContains(res, 'Accept-Put', 'application/ld+json');
+      assertHeaderContains(res, 'Accept-Put', 'application/json');
     });
 
     it('rejects text/n3 PUT to .acl with 415', async () => {
@@ -306,7 +308,9 @@ describe('Content Negotiation (conneg enabled)', () => {
       });
       assertStatus(res, 415);
       assertHeaderContains(res, 'Accept', 'application/ld+json');
+      assertHeaderContains(res, 'Accept', 'application/json');
       assertHeaderContains(res, 'Accept-Put', 'application/ld+json');
+      assertHeaderContains(res, 'Accept-Put', 'application/json');
     });
 
     it('rejects text/plain PUT to .acl with 415 (URL-extension protection)', async () => {
@@ -318,7 +322,9 @@ describe('Content Negotiation (conneg enabled)', () => {
       });
       assertStatus(res, 415);
       assertHeaderContains(res, 'Accept', 'application/ld+json');
+      assertHeaderContains(res, 'Accept', 'application/json');
       assertHeaderContains(res, 'Accept-Put', 'application/ld+json');
+      assertHeaderContains(res, 'Accept-Put', 'application/json');
     });
 
     it('rejects PUT to .acl with no Content-Type with 415', async () => {
@@ -331,7 +337,9 @@ describe('Content Negotiation (conneg enabled)', () => {
       });
       assertStatus(res, 415);
       assertHeaderContains(res, 'Accept', 'application/ld+json');
+      assertHeaderContains(res, 'Accept', 'application/json');
       assertHeaderContains(res, 'Accept-Put', 'application/ld+json');
+      assertHeaderContains(res, 'Accept-Put', 'application/json');
     });
 
     it('accepts application/ld+json PUT to .acl', async () => {
@@ -474,7 +482,9 @@ describe('Content Negotiation (conneg disabled - default)', () => {
       });
       assertStatus(res, 415);
       assertHeaderContains(res, 'Accept', 'application/ld+json');
+      assertHeaderContains(res, 'Accept', 'application/json');
       assertHeaderContains(res, 'Accept-Put', 'application/ld+json');
+      assertHeaderContains(res, 'Accept-Put', 'application/json');
     });
 
     it('rejects text/plain PUT to .acl with 415', async () => {
@@ -486,7 +496,9 @@ describe('Content Negotiation (conneg disabled - default)', () => {
       });
       assertStatus(res, 415);
       assertHeaderContains(res, 'Accept', 'application/ld+json');
+      assertHeaderContains(res, 'Accept', 'application/json');
       assertHeaderContains(res, 'Accept-Put', 'application/ld+json');
+      assertHeaderContains(res, 'Accept-Put', 'application/json');
     });
 
     it('rejects PUT to .acl with no Content-Type with 415', async () => {
@@ -499,7 +511,9 @@ describe('Content Negotiation (conneg disabled - default)', () => {
       });
       assertStatus(res, 415);
       assertHeaderContains(res, 'Accept', 'application/ld+json');
+      assertHeaderContains(res, 'Accept', 'application/json');
       assertHeaderContains(res, 'Accept-Put', 'application/ld+json');
+      assertHeaderContains(res, 'Accept-Put', 'application/json');
     });
 
     it('accepts application/ld+json PUT to .acl', async () => {

--- a/test/conneg.test.js
+++ b/test/conneg.test.js
@@ -294,8 +294,7 @@ describe('Content Negotiation (conneg enabled)', () => {
       });
       assertStatus(res, 415);
       assertHeaderContains(res, 'Accept', 'application/ld+json');
-      assertHeaderContains(res, 'Accept-Post', 'application/ld+json');
-      assertHeaderContains(res, 'Accept-Patch', 'application/ld+json');
+      assertHeaderContains(res, 'Accept-Put', 'application/ld+json');
     });
 
     it('rejects text/n3 PUT to .acl with 415', async () => {

--- a/test/conneg.test.js
+++ b/test/conneg.test.js
@@ -320,9 +320,11 @@ describe('Content Negotiation (conneg enabled)', () => {
     });
 
     it('rejects PUT to .acl with no Content-Type with 415', async () => {
+      // Use Uint8Array body so fetch() doesn't auto-set Content-Type
+      // (which it does for string bodies: text/plain;charset=UTF-8).
       const res = await request('/connegtest/public/no-ct-reject.acl', {
         method: 'PUT',
-        body: 'arbitrary bytes',
+        body: new Uint8Array([1, 2, 3, 4]),
         auth: 'connegtest'
       });
       assertStatus(res, 415);
@@ -470,9 +472,11 @@ describe('Content Negotiation (conneg disabled - default)', () => {
     });
 
     it('rejects PUT to .acl with no Content-Type with 415', async () => {
+      // Use Uint8Array body so fetch() doesn't auto-set Content-Type
+      // (which it does for string bodies: text/plain;charset=UTF-8).
       const res = await request('/noconneg/public/no-ct-reject.acl', {
         method: 'PUT',
-        body: 'arbitrary bytes',
+        body: new Uint8Array([1, 2, 3, 4]),
         auth: 'noconneg'
       });
       assertStatus(res, 415);

--- a/test/conneg.test.js
+++ b/test/conneg.test.js
@@ -306,6 +306,7 @@ describe('Content Negotiation (conneg enabled)', () => {
       });
       assertStatus(res, 415);
       assertHeaderContains(res, 'Accept', 'application/ld+json');
+      assertHeaderContains(res, 'Accept-Put', 'application/ld+json');
     });
 
     it('rejects text/plain PUT to .acl with 415 (URL-extension protection)', async () => {
@@ -317,6 +318,7 @@ describe('Content Negotiation (conneg enabled)', () => {
       });
       assertStatus(res, 415);
       assertHeaderContains(res, 'Accept', 'application/ld+json');
+      assertHeaderContains(res, 'Accept-Put', 'application/ld+json');
     });
 
     it('rejects PUT to .acl with no Content-Type with 415', async () => {
@@ -329,6 +331,7 @@ describe('Content Negotiation (conneg enabled)', () => {
       });
       assertStatus(res, 415);
       assertHeaderContains(res, 'Accept', 'application/ld+json');
+      assertHeaderContains(res, 'Accept-Put', 'application/ld+json');
     });
 
     it('accepts application/ld+json PUT to .acl', async () => {
@@ -448,6 +451,19 @@ describe('Content Negotiation (conneg disabled - default)', () => {
   // The default deployment configuration is conneg disabled, so ensure the
   // guard fires there too.
   describe('ACL content-type guard (#295) — conneg disabled', () => {
+    const aclJsonLd = {
+      '@context': { acl: 'http://www.w3.org/ns/auth/acl#' },
+      '@graph': [
+        {
+          '@id': '#owner',
+          '@type': 'acl:Authorization',
+          'acl:agent': { '@id': '#me' },
+          'acl:accessTo': { '@id': './' },
+          'acl:mode': [{ '@id': 'acl:Read' }, { '@id': 'acl:Write' }, { '@id': 'acl:Control' }]
+        }
+      ]
+    };
+
     it('rejects text/turtle PUT to .acl with 415', async () => {
       const turtle = `@prefix acl: <http://www.w3.org/ns/auth/acl#>. <#x> a acl:Authorization.`;
       const res = await request('/noconneg/public/turtle-reject.acl', {
@@ -458,6 +474,7 @@ describe('Content Negotiation (conneg disabled - default)', () => {
       });
       assertStatus(res, 415);
       assertHeaderContains(res, 'Accept', 'application/ld+json');
+      assertHeaderContains(res, 'Accept-Put', 'application/ld+json');
     });
 
     it('rejects text/plain PUT to .acl with 415', async () => {
@@ -469,6 +486,7 @@ describe('Content Negotiation (conneg disabled - default)', () => {
       });
       assertStatus(res, 415);
       assertHeaderContains(res, 'Accept', 'application/ld+json');
+      assertHeaderContains(res, 'Accept-Put', 'application/ld+json');
     });
 
     it('rejects PUT to .acl with no Content-Type with 415', async () => {
@@ -481,28 +499,27 @@ describe('Content Negotiation (conneg disabled - default)', () => {
       });
       assertStatus(res, 415);
       assertHeaderContains(res, 'Accept', 'application/ld+json');
+      assertHeaderContains(res, 'Accept-Put', 'application/ld+json');
     });
 
     it('accepts application/ld+json PUT to .acl', async () => {
-      const acl = {
-        '@context': { acl: 'http://www.w3.org/ns/auth/acl#' },
-        '@graph': [
-          {
-            '@id': '#owner',
-            '@type': 'acl:Authorization',
-            'acl:agent': { '@id': '#me' },
-            'acl:accessTo': { '@id': './' },
-            'acl:mode': [{ '@id': 'acl:Read' }, { '@id': 'acl:Write' }, { '@id': 'acl:Control' }]
-          }
-        ]
-      };
       const res = await request('/noconneg/public/jsonld-accept.acl', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/ld+json' },
-        body: JSON.stringify(acl),
+        body: JSON.stringify(aclJsonLd),
         auth: 'noconneg'
       });
       assert.ok(res.status < 300, `JSON-LD PUT to .acl should succeed, got ${res.status}`);
+    });
+
+    it('accepts application/json PUT to .acl', async () => {
+      const res = await request('/noconneg/public/json-accept.acl', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(aclJsonLd),
+        auth: 'noconneg'
+      });
+      assert.ok(res.status < 300, `application/json PUT to .acl should succeed, got ${res.status}`);
     });
   });
 });

--- a/test/conneg.test.js
+++ b/test/conneg.test.js
@@ -489,6 +489,13 @@ describe('Content Negotiation (conneg disabled - default)', () => {
         'Accept-Put should include application/json (canAcceptInput treats it as a JSON-LD alias)');
     });
 
+    it('should advertise application/json in Accept-Post when conneg disabled', async () => {
+      const res = await request('/noconneg/public/');
+      const acceptPost = res.headers.get('Accept-Post');
+      assert.ok(acceptPost && acceptPost.includes('application/json'),
+        'Accept-Post should include application/json (canAcceptInput treats it as a JSON-LD alias)');
+    });
+
     it('should not advertise text/n3 in Accept-Put when conneg disabled', async () => {
       const res = await request('/noconneg/public/');
       const acceptPut = res.headers.get('Accept-Put');

--- a/test/conneg.test.js
+++ b/test/conneg.test.js
@@ -262,9 +262,10 @@ describe('Content Negotiation (conneg enabled)', () => {
     });
   });
 
-  // ACL resources require application/ld+json on PUT regardless of conneg
-  // setting: round-trip serialization between JSON-LD and Turtle has known
-  // limitations that can cause data loss. See #295.
+  // ACL resources require a JSON-LD payload (application/ld+json or
+  // application/json) on PUT regardless of conneg setting: round-trip
+  // serialization between JSON-LD and Turtle has known limitations
+  // that can cause data loss. See #295.
   describe('ACL content-type guard (#295)', () => {
     const aclJsonLd = {
       '@context': { acl: 'http://www.w3.org/ns/auth/acl#' },
@@ -292,9 +293,9 @@ describe('Content Negotiation (conneg enabled)', () => {
         auth: 'connegtest'
       });
       assertStatus(res, 415);
-      assertHeader(res, 'Accept', 'application/ld+json');
-      assertHeader(res, 'Accept-Post', 'application/ld+json');
-      assertHeader(res, 'Accept-Patch', 'application/ld+json');
+      assertHeaderContains(res, 'Accept', 'application/ld+json');
+      assertHeaderContains(res, 'Accept-Post', 'application/ld+json');
+      assertHeaderContains(res, 'Accept-Patch', 'application/ld+json');
     });
 
     it('rejects text/n3 PUT to .acl with 415', async () => {
@@ -305,7 +306,7 @@ describe('Content Negotiation (conneg enabled)', () => {
         auth: 'connegtest'
       });
       assertStatus(res, 415);
-      assertHeader(res, 'Accept', 'application/ld+json');
+      assertHeaderContains(res, 'Accept', 'application/ld+json');
     });
 
     it('rejects text/plain PUT to .acl with 415 (URL-extension protection)', async () => {
@@ -316,7 +317,17 @@ describe('Content Negotiation (conneg enabled)', () => {
         auth: 'connegtest'
       });
       assertStatus(res, 415);
-      assertHeader(res, 'Accept', 'application/ld+json');
+      assertHeaderContains(res, 'Accept', 'application/ld+json');
+    });
+
+    it('rejects PUT to .acl with no Content-Type with 415', async () => {
+      const res = await request('/connegtest/public/no-ct-reject.acl', {
+        method: 'PUT',
+        body: 'arbitrary bytes',
+        auth: 'connegtest'
+      });
+      assertStatus(res, 415);
+      assertHeaderContains(res, 'Accept', 'application/ld+json');
     });
 
     it('accepts application/ld+json PUT to .acl', async () => {
@@ -429,6 +440,66 @@ describe('Content Negotiation (conneg disabled - default)', () => {
         'Accept-Put should include application/ld+json');
       assert.ok(!acceptPut || !acceptPut.includes('text/turtle'),
         'Accept-Put should NOT include text/turtle when conneg disabled');
+    });
+  });
+
+  // The .acl content-type guard applies regardless of conneg setting (#295).
+  // The default deployment configuration is conneg disabled, so ensure the
+  // guard fires there too.
+  describe('ACL content-type guard (#295) — conneg disabled', () => {
+    it('rejects text/turtle PUT to .acl with 415', async () => {
+      const turtle = `@prefix acl: <http://www.w3.org/ns/auth/acl#>. <#x> a acl:Authorization.`;
+      const res = await request('/noconneg/public/turtle-reject.acl', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'text/turtle' },
+        body: turtle,
+        auth: 'noconneg'
+      });
+      assertStatus(res, 415);
+      assertHeaderContains(res, 'Accept', 'application/ld+json');
+    });
+
+    it('rejects text/plain PUT to .acl with 415', async () => {
+      const res = await request('/noconneg/public/plain-reject.acl', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'text/plain' },
+        body: 'arbitrary text',
+        auth: 'noconneg'
+      });
+      assertStatus(res, 415);
+      assertHeaderContains(res, 'Accept', 'application/ld+json');
+    });
+
+    it('rejects PUT to .acl with no Content-Type with 415', async () => {
+      const res = await request('/noconneg/public/no-ct-reject.acl', {
+        method: 'PUT',
+        body: 'arbitrary bytes',
+        auth: 'noconneg'
+      });
+      assertStatus(res, 415);
+      assertHeaderContains(res, 'Accept', 'application/ld+json');
+    });
+
+    it('accepts application/ld+json PUT to .acl', async () => {
+      const acl = {
+        '@context': { acl: 'http://www.w3.org/ns/auth/acl#' },
+        '@graph': [
+          {
+            '@id': '#owner',
+            '@type': 'acl:Authorization',
+            'acl:agent': { '@id': '#me' },
+            'acl:accessTo': { '@id': './' },
+            'acl:mode': [{ '@id': 'acl:Read' }, { '@id': 'acl:Write' }, { '@id': 'acl:Control' }]
+          }
+        ]
+      };
+      const res = await request('/noconneg/public/jsonld-accept.acl', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/ld+json' },
+        body: JSON.stringify(acl),
+        auth: 'noconneg'
+      });
+      assert.ok(res.status < 300, `JSON-LD PUT to .acl should succeed, got ${res.status}`);
     });
   });
 });


### PR DESCRIPTION
## Summary

ACL resources have round-trip serialization limitations between JSON-LD and Turtle representations. To prevent data loss from clients sending Turtle that cannot be reliably round-tripped, require a JSON-LD payload (`application/ld+json` or `application/json`) on `.acl` URLs.

Other RDF resources (`.meta`, regular `.jsonld`) are unaffected; existing Turtle PUT translation feature is preserved for non-ACL resources.

Returns `415 Unsupported Media Type` with `Accept` and `Accept-Put` headers indicating the supported content types.

## Changes

- `src/handlers/resource.js`: guard `handlePut` to reject non-JSON-LD content types on `.acl` URLs before the existing `canAcceptInput` check. Guard fires regardless of conneg setting and also when `Content-Type` is missing. The fall-through `canAcceptInput` 415 message updated to mention both `application/ld+json` and `application/json` (matching `canAcceptInput`'s actual accepted set).
- `src/rdf/conneg.js`: global `Accept-Post` / `Accept-Put` advertisement now includes `application/json` alongside `application/ld+json`, so the server's advertised contract matches `canAcceptInput`'s actual accepted set.
- `test/conneg.test.js`: add an "ACL content-type guard (#295)" describe block under conneg-enabled, plus an "ACL content-type guard (#295) — conneg disabled" describe block under conneg-disabled. Each rejection test asserts both `Accept` and `Accept-Put` contain both `application/ld+json` and `application/json`.

Test cases added (11 total):

**Conneg enabled (6):**
- rejects `text/turtle` PUT to `.acl` with 415
- rejects `text/n3` PUT to `.acl` with 415
- rejects `text/plain` PUT to `.acl` with 415 (URL-extension protection)
- rejects PUT to `.acl` with no `Content-Type` with 415
- accepts `application/ld+json` PUT to `.acl`
- accepts `application/json` PUT to `.acl`

**Conneg disabled (5):**
- rejects `text/turtle` PUT to `.acl` with 415
- rejects `text/plain` PUT to `.acl` with 415
- rejects PUT to `.acl` with no `Content-Type` with 415
- accepts `application/ld+json` PUT to `.acl`
- accepts `application/json` PUT to `.acl`

## Test plan

- [x] All 39 conneg tests pass (existing 28 + 11 new)
- [x] All 27 LDP tests pass (which exercise the global Accept-* headers)
- [x] All 44 WAC + auth tests pass (which exercise `.acl` files)
- [x] Existing Turtle PUT to `.meta` still works (translation feature preserved)

## Review iterations

- Round 1: dropped `contentType &&` check (guard now fires on missing Content-Type), advertised both `application/ld+json` and `application/json` in Accept headers, updated comments, added conneg-disabled test coverage.
- Round 2: replaced `Accept-Post` / `Accept-Patch` on the 415 response with `Accept-Put`. `Accept-Patch` with `application/ld+json` was misleading because the server's actual PATCH media types are `text/n3, application/sparql-update`; `Accept-Post` was irrelevant for a PUT response.
- Round 3: switched no-Content-Type tests to `Uint8Array` body (string bodies caused `fetch()` to auto-set `Content-Type: text/plain;charset=UTF-8`, so the missing-Content-Type guard branch wasn't actually being exercised).
- Round 4: added `Accept-Put` assertions to all rejection tests and `application/json` acceptance test in the conneg-disabled block.
- Round 5: aligned the `canAcceptInput` 415 error message with its actual accepted set (now lists both `application/ld+json` and `application/json`); added `application/json` substring assertions to all rejection tests' Accept and Accept-Put header checks.
- Round 6: aligned global `Accept-Post` / `Accept-Put` advertisement with `canAcceptInput`'s actual accepted set (now lists `application/json` alongside `application/ld+json`).

Closes #295.