### PR TITLE
Default --single-user to root pod (#348)

### DIFF
--- a/bin/jss.js
+++ b/bin/jss.js
@@ -126,7 +126,7 @@ program
   .option('--invite-only', 'Require invite code for registration')
   .option('--no-invite-only', 'Allow open registration')
   .option('--single-user', 'Single-user mode (creates pod on startup, disables registration)')
-  .option('--single-user-name <name>', 'Username for single-user mode (default: me)')
+  .option('--single-user-name <name>', 'Mount the pod at /<name>/ instead of at the server root (default: root pod at /)')
   .option('--single-user-password <pw>', 'Initial IDP password to seed when creating the single-user pod (or set JSS_SINGLE_USER_PASSWORD)')
   .option('--webid-tls', 'Enable WebID-TLS client certificate authentication')
   .option('--no-webid-tls', 'Disable WebID-TLS authentication')

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -286,8 +286,16 @@ JSS_SINGLE_USER=true jss start --idp
 - Proper ACLs generated automatically
 
 **Upgrading from a pre-#348 install:** if your existing pod was created with the old default (data lives under `<root>/me/`), JSS no longer auto-detects it — restarting plain `jss start --single-user` will start seeding a fresh empty root pod alongside your legacy `/me/` data, and your existing IDP account will keep authenticating against `/me/`. Pick one path on the next restart:
-- Add `--single-user-name me` to keep the legacy `/me/` layout exactly as before.
-- Move `<root>/me/*` to `<root>/`, delete the IDP account for `me` (so the new root pod's `me` account can be seeded), then restart without the name flag.
+- **Keep the legacy layout:** add `--single-user-name me` to your launch command. No data movement needed.
+- **Migrate to root pod:** move the *entire* contents of `<root>/me/` (including dotfiles like `.acl`, `.meta`, `.quota.json` — a plain `mv <root>/me/* <root>/` skips them) to `<root>/`, delete the IDP account for `me` (so the new root pod's `me` account can be seeded), then restart without the name flag. Use one of:
+
+  ```bash
+  # Option A: rsync handles dotfiles correctly with the trailing slash.
+  rsync -a <root>/me/ <root>/ && rm -rf <root>/me
+
+  # Option B: bash with dotglob enabled so * matches dotfiles too.
+  shopt -s dotglob && mv <root>/me/* <root>/ && rmdir <root>/me
+  ```
 
 **Initial password sources, in priority order:**
 1. `--single-user-password <pw>` CLI flag

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -285,6 +285,10 @@ JSS_SINGLE_USER=true jss start --idp
 - Login works for the single user via password (`POST /idp/credentials`) or any other configured method
 - Proper ACLs generated automatically
 
+**Upgrading from a pre-#348 install:** if your existing pod was created with the old default (data lives under `<root>/me/`), JSS no longer auto-detects it — restarting plain `jss start --single-user` will start seeding a fresh empty root pod alongside your legacy `/me/` data, and your existing IDP account will keep authenticating against `/me/`. Pick one path on the next restart:
+- Add `--single-user-name me` to keep the legacy `/me/` layout exactly as before.
+- Move `<root>/me/*` to `<root>/`, delete the IDP account for `me` (so the new root pod's `me` account can be seeded), then restart without the name flag.
+
 **Initial password sources, in priority order:**
 1. `--single-user-password <pw>` CLI flag
 2. `JSS_SINGLE_USER_PASSWORD` env var

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -258,19 +258,21 @@ Response:
 For personal pod servers where only one user needs access:
 
 ```bash
-# Basic single-user mode (creates pod at /me/)
-# On first run JSS will prompt for an initial password (TTY only).
+# Default: pod served at server root (#348). WebID is /profile/card#me;
+# the IDP login username is "me". On first run JSS will prompt for an
+# initial password (TTY only).
 jss start --single-user --idp
 
 # Provide the initial IDP password non-interactively (systemd, containers, CI):
 jss start --single-user --idp --single-user-password 'choose-a-good-one'
 JSS_SINGLE_USER_PASSWORD='choose-a-good-one' jss start --single-user --idp
 
-# Custom username
+# Mount the pod at a named path instead of the origin. WebID becomes
+# /alice/profile/card#me; login as "alice".
 jss start --single-user --single-user-name alice --idp
 
-# Root-level pod (pod at /, WebID at /profile/card#me)
-jss start --single-user --single-user-name '' --idp
+# Legacy /me/ pod — same as the old default before #348.
+jss start --single-user --single-user-name me --idp
 
 # Via environment
 JSS_SINGLE_USER=true jss start --idp

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -258,9 +258,9 @@ Response:
 For personal pod servers where only one user needs access:
 
 ```bash
-# Default: pod served at server root (#348). WebID is /profile/card#me;
-# the IDP login username is "me". On first run JSS will prompt for an
-# initial password (TTY only).
+# Default: pod served at server root (#348). WebID is
+# /profile/card.jsonld#me; the IDP login username is "me". On first
+# run JSS will prompt for an initial password (TTY only).
 jss start --single-user --idp
 
 # Provide the initial IDP password non-interactively (systemd, containers, CI):
@@ -268,7 +268,7 @@ jss start --single-user --idp --single-user-password 'choose-a-good-one'
 JSS_SINGLE_USER_PASSWORD='choose-a-good-one' jss start --single-user --idp
 
 # Mount the pod at a named path instead of the origin. WebID becomes
-# /alice/profile/card#me; login as "alice".
+# /alice/profile/card.jsonld#me; login as "alice".
 jss start --single-user --single-user-name alice --idp
 
 # Legacy /me/ pod — same as the old default before #348.

--- a/src/config.js
+++ b/src/config.js
@@ -74,9 +74,10 @@ export const defaults = {
 
   // Single-user mode (personal pod server)
   singleUser: false,
-  // null = root pod (mounted at server origin, WebID at /profile/card#me).
-  // A string mounts the pod at /<name>/ — useful when more than one Solid
-  // identity coexists on the same origin (#348).
+  // null = root pod (mounted at server origin, WebID at
+  // /profile/card.jsonld#me). A string mounts the pod at /<name>/ —
+  // useful when more than one Solid identity coexists on the same
+  // origin, or when the operator wants the pre-#348 /me/ shape.
   singleUserName: null,
   // Initial IDP password seeded on first single-user pod creation. If
   // unset and --idp is enabled, the server prompts on a TTY or logs a
@@ -403,10 +404,12 @@ export function printConfig(config) {
   console.log(`  Multi-user:    ${config.multiuser}`);
   if (config.singleUser) {
     const isRootPod = config.singleUserName === '/' || !config.singleUserName;
-    // Root pod (#348) seeds the IDP account under the username 'me' —
-    // the same login flow as a named pod, just at a different mount.
-    let details = isRootPod ? '/ (root pod, login as "me")' : config.singleUserName;
+    let details = isRootPod ? '/ (root pod)' : config.singleUserName;
+    // The "login as me" hint and password line only make sense when
+    // the built-in IdP is on. With --no-idp / external issuer there's
+    // no built-in login form, so don't imply one exists.
     if (config.idp) {
+      if (isRootPod) details += ', login as "me"';
       const pwSource = config.singleUserPassword
         ? 'provided'
         : (process.stdin.isTTY ? 'will prompt at startup' : 'missing — login disabled');

--- a/src/config.js
+++ b/src/config.js
@@ -74,7 +74,10 @@ export const defaults = {
 
   // Single-user mode (personal pod server)
   singleUser: false,
-  singleUserName: 'me',
+  // null = root pod (mounted at server origin, WebID at /profile/card#me).
+  // A string mounts the pod at /<name>/ — useful when more than one Solid
+  // identity coexists on the same origin (#348).
+  singleUserName: null,
   // Initial IDP password seeded on first single-user pod creation. If
   // unset and --idp is enabled, the server prompts on a TTY or logs a
   // warning and continues startup on non-TTY (so the pod is created but
@@ -399,14 +402,15 @@ export function printConfig(config) {
   console.log(`  SSL:           ${config.ssl ? 'enabled' : 'disabled'}`);
   console.log(`  Multi-user:    ${config.multiuser}`);
   if (config.singleUser) {
-    let details = `${config.singleUserName}`;
+    const isRootPod = config.singleUserName === '/' || !config.singleUserName;
     // Password seeding only runs when --idp is on AND the pod isn't the
-    // root-level case ('/'). Reflect both gates in the printed line so
+    // root-level case. Reflect both gates in the printed line so
     // operators don't see a misleading "missing — login disabled" when
     // login isn't governed by an IDP password at all.
+    let details = isRootPod ? '/ (root pod)' : config.singleUserName;
     if (config.idp) {
-      if (config.singleUserName === '/' || !config.singleUserName) {
-        details += ' (root pod; password not seeded)';
+      if (isRootPod) {
+        details += ' (password not seeded)';
       } else {
         const pwSource = config.singleUserPassword
           ? 'provided'

--- a/src/config.js
+++ b/src/config.js
@@ -403,20 +403,14 @@ export function printConfig(config) {
   console.log(`  Multi-user:    ${config.multiuser}`);
   if (config.singleUser) {
     const isRootPod = config.singleUserName === '/' || !config.singleUserName;
-    // Password seeding only runs when --idp is on AND the pod isn't the
-    // root-level case. Reflect both gates in the printed line so
-    // operators don't see a misleading "missing — login disabled" when
-    // login isn't governed by an IDP password at all.
-    let details = isRootPod ? '/ (root pod)' : config.singleUserName;
+    // Root pod (#348) seeds the IDP account under the username 'me' —
+    // the same login flow as a named pod, just at a different mount.
+    let details = isRootPod ? '/ (root pod, login as "me")' : config.singleUserName;
     if (config.idp) {
-      if (isRootPod) {
-        details += ' (password not seeded)';
-      } else {
-        const pwSource = config.singleUserPassword
-          ? 'provided'
-          : (process.stdin.isTTY ? 'will prompt at startup' : 'missing — login disabled');
-        details += ` (password: ${pwSource})`;
-      }
+      const pwSource = config.singleUserPassword
+        ? 'provided'
+        : (process.stdin.isTTY ? 'will prompt at startup' : 'missing — login disabled');
+      details += ` (password: ${pwSource})`;
     }
     console.log(`  Single-user:   ${details}`);
   }

--- a/src/server.js
+++ b/src/server.js
@@ -617,11 +617,17 @@ export function createServer(options = {}) {
       // still needs *some* username for the login form. Default to 'me'
       // — matches the WebID fragment, fits the historical convention.
       if (idpEnabled) {
+        // The IDP also persists `podName` and surfaces it as the
+        // `name` claim under the OIDC `profile` scope (see
+        // src/idp/accounts.js). For root pods we use 'me' here too —
+        // a null podName would leak through as a null/missing
+        // profile.name on every login, which OIDC clients expect to
+        // be a non-empty human-readable string.
         await seedSingleUserIdpAccount({
           fastify,
           username: isRootPod ? 'me' : singleUserName,
           webId,
-          podName: isRootPod ? null : singleUserName,
+          podName: isRootPod ? 'me' : singleUserName,
           providedPassword: singleUserPassword
         });
       }

--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,6 @@
 import Fastify from 'fastify';
 import rateLimit from '@fastify/rate-limit';
 import { readFile } from 'fs/promises';
-import { existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { handleGet, handleHead, handlePut, handleDelete, handleOptions, handlePatch } from './handlers/resource.js';
@@ -98,34 +97,18 @@ export function createServer(options = {}) {
   // to mount the pod at /<name>/ instead. Normalize the
   // historical `'/'` / `''` forms to null up front so downstream
   // code (remoteStoragePlugin, decorators, etc.) doesn't have to
-  // re-check for the same three shapes — see PR #349 review.
+  // re-check for the same three shapes.
+  //
+  // Pre-#348 installs (default 'me') that upgrade in place will see
+  // a fresh empty root pod alongside their /me/ data. The fix is to
+  // pass `--single-user-name me` on restart (or move data/me/* out
+  // to the data root). At v0.0.x we accept that one-time
+  // intervention rather than carrying detection magic in the code.
   const rawSingleUserName = options.singleUserName ?? null;
-  const normalizedName =
+  const singleUserName =
     (rawSingleUserName === '/' || rawSingleUserName === '')
       ? null
       : rawSingleUserName;
-
-  // #348 backwards-compat for in-place upgrades: if the operator
-  // didn't pass --single-user-name and a /me/ pod from a pre-#348
-  // install already exists on disk, fall back to the legacy 'me'
-  // name so the existing pod and IDP account stay live. Without
-  // this, the new default would seed an empty root pod alongside
-  // the still-served /me/ data — a split-brain state where the
-  // operator has no way to log in to the new pod (the 'me' IDP
-  // account still points at /me/profile/card) and clients keep
-  // reading/writing the legacy one. The disk check is sync because
-  // remoteStoragePlugin captures the username at registration time
-  // (before onReady fires).
-  const dataRoot = options.root || process.env.DATA_ROOT || './data';
-  let singleUserName = normalizedName;
-  let migratedFromMeDefault = false;
-  if (singleUser && singleUserName === null) {
-    if (existsSync(join(dataRoot, 'me/profile/card.jsonld')) ||
-        existsSync(join(dataRoot, 'me/profile/card'))) {
-      singleUserName = 'me';
-      migratedFromMeDefault = true;
-    }
-  }
   const singleUserPassword = options.singleUserPassword ?? null;
   // Default storage quota per pod (50MB default, 0 = unlimited)
   const defaultQuota = options.defaultQuota ?? 50 * 1024 * 1024;
@@ -611,20 +594,6 @@ export function createServer(options = {}) {
                           : 'profile/card.jsonld'; // fresh pod default
       const webId = `${podUri}${profileFile}#me`;
       const profileExists = hasJsonLd || hasLegacy;
-
-      if (migratedFromMeDefault) {
-        // Surface the auto-fallback once at startup so operators
-        // know why their pod is at /me/ instead of /. This is
-        // backwards-compat for pre-#348 installs — the new default
-        // (root pod) only kicks in when no /me/ data exists.
-        fastify.log.warn(
-          'Detected pre-existing /me/ pod data. Falling back to ' +
-          '--single-user-name me for backwards compatibility (#348 ' +
-          'changed the default pod path from /me/ to /). To opt into ' +
-          'the new default root pod, move data/me/* to data/* and ' +
-          'remove the IDP account for "me" before restarting.'
-        );
-      }
 
       if (!profileExists) {
         fastify.log.info(`Creating single-user pod at ${podUri}...`);

--- a/src/server.js
+++ b/src/server.js
@@ -597,12 +597,16 @@ export function createServer(options = {}) {
       // this, single-user + --idp produces a pod but no credential, and
       // registration is intentionally disabled in single-user mode — so
       // the pod is unloggable until a password is set externally (#323).
-      if (idpEnabled && !isRootPod) {
+      //
+      // Root pods (#348) need this too: the pod has no name, but the IDP
+      // still needs *some* username for the login form. Default to 'me'
+      // — matches the WebID fragment, fits the historical convention.
+      if (idpEnabled) {
         await seedSingleUserIdpAccount({
           fastify,
-          username: singleUserName,
+          username: isRootPod ? 'me' : singleUserName,
           webId,
-          podName: singleUserName,
+          podName: isRootPod ? null : singleUserName,
           providedPassword: singleUserPassword
         });
       }

--- a/src/server.js
+++ b/src/server.js
@@ -94,8 +94,15 @@ export function createServer(options = {}) {
   // Single-user mode - creates pod on startup, disables registration
   const singleUser = options.singleUser ?? false;
   // Default null = root pod (#348). Pass an explicit singleUserName
-  // to mount the pod at /<name>/ instead.
-  const singleUserName = options.singleUserName ?? null;
+  // to mount the pod at /<name>/ instead. Normalize the
+  // historical `'/'` / `''` forms to null up front so downstream
+  // code (remoteStoragePlugin, decorators, etc.) doesn't have to
+  // re-check for the same three shapes — see PR #349 review.
+  const rawSingleUserName = options.singleUserName ?? null;
+  const singleUserName =
+    (rawSingleUserName === '/' || rawSingleUserName === '')
+      ? null
+      : rawSingleUserName;
   const singleUserPassword = options.singleUserPassword ?? null;
   // Default storage quota per pod (50MB default, 0 = unlimited)
   const defaultQuota = options.defaultQuota ?? 50 * 1024 * 1024;
@@ -560,8 +567,10 @@ export function createServer(options = {}) {
       const baseUrl = idpIssuer?.replace(/\/$/, '') || `${protocol}://${host}:${port}`;
       const issuer = idpIssuer || `${baseUrl}/`;
 
-      // Root-level pod (empty or '/' name) vs named pod
-      const isRootPod = !singleUserName || singleUserName === '/';
+      // Root pod (no name) vs named pod. After the singleUserName
+      // normalization at the top of createServer(), null is the only
+      // root-pod shape we need to recognize here.
+      const isRootPod = !singleUserName;
       const podPath = isRootPod ? '/' : `/${singleUserName}/`;
       const podUri = isRootPod ? `${baseUrl}/` : `${baseUrl}/${singleUserName}/`;
       const displayName = isRootPod ? 'me' : singleUserName;
@@ -581,6 +590,25 @@ export function createServer(options = {}) {
       const profileExists = hasJsonLd || hasLegacy;
 
       if (!profileExists) {
+        // Migration trap (#348 review round 2): if the operator is
+        // about to seed a fresh root pod but a `/me/` pod already
+        // exists, they probably upgraded an old `--single-user`
+        // (default 'me') install without realizing the default
+        // changed. The new pod will be empty and the existing
+        // /me/ data unreferenced. Warn loudly so they don't silently
+        // end up with two half-functional pods.
+        if (isRootPod) {
+          const meHasJsonLd = await storage.exists('/me/profile/card.jsonld');
+          const meHasLegacy = !meHasJsonLd && await storage.exists('/me/profile/card');
+          if (meHasJsonLd || meHasLegacy) {
+            fastify.log.warn(
+              'Found existing /me/ pod data while seeding the new default root pod. ' +
+              'The default single-user pod path changed to / (was /me/) — see #348. ' +
+              'To keep using your existing pod, restart with --single-user-name me. ' +
+              'Otherwise the new root pod will be empty and the /me/ data unreferenced.'
+            );
+          }
+        }
         fastify.log.info(`Creating single-user pod at ${podUri}...`);
 
         if (isRootPod) {

--- a/src/server.js
+++ b/src/server.js
@@ -93,7 +93,9 @@ export function createServer(options = {}) {
   const inviteOnly = options.inviteOnly ?? false;
   // Single-user mode - creates pod on startup, disables registration
   const singleUser = options.singleUser ?? false;
-  const singleUserName = options.singleUserName ?? 'me';
+  // Default null = root pod (#348). Pass an explicit singleUserName
+  // to mount the pod at /<name>/ instead.
+  const singleUserName = options.singleUserName ?? null;
   const singleUserPassword = options.singleUserPassword ?? null;
   // Default storage quota per pod (50MB default, 0 = unlimited)
   const defaultQuota = options.defaultQuota ?? 50 * 1024 * 1024;

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,7 @@
 import Fastify from 'fastify';
 import rateLimit from '@fastify/rate-limit';
 import { readFile } from 'fs/promises';
+import { existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { handleGet, handleHead, handlePut, handleDelete, handleOptions, handlePatch } from './handlers/resource.js';
@@ -99,10 +100,32 @@ export function createServer(options = {}) {
   // code (remoteStoragePlugin, decorators, etc.) doesn't have to
   // re-check for the same three shapes — see PR #349 review.
   const rawSingleUserName = options.singleUserName ?? null;
-  const singleUserName =
+  const normalizedName =
     (rawSingleUserName === '/' || rawSingleUserName === '')
       ? null
       : rawSingleUserName;
+
+  // #348 backwards-compat for in-place upgrades: if the operator
+  // didn't pass --single-user-name and a /me/ pod from a pre-#348
+  // install already exists on disk, fall back to the legacy 'me'
+  // name so the existing pod and IDP account stay live. Without
+  // this, the new default would seed an empty root pod alongside
+  // the still-served /me/ data — a split-brain state where the
+  // operator has no way to log in to the new pod (the 'me' IDP
+  // account still points at /me/profile/card) and clients keep
+  // reading/writing the legacy one. The disk check is sync because
+  // remoteStoragePlugin captures the username at registration time
+  // (before onReady fires).
+  const dataRoot = options.root || process.env.DATA_ROOT || './data';
+  let singleUserName = normalizedName;
+  let migratedFromMeDefault = false;
+  if (singleUser && singleUserName === null) {
+    if (existsSync(join(dataRoot, 'me/profile/card.jsonld')) ||
+        existsSync(join(dataRoot, 'me/profile/card'))) {
+      singleUserName = 'me';
+      migratedFromMeDefault = true;
+    }
+  }
   const singleUserPassword = options.singleUserPassword ?? null;
   // Default storage quota per pod (50MB default, 0 = unlimited)
   const defaultQuota = options.defaultQuota ?? 50 * 1024 * 1024;
@@ -589,26 +612,21 @@ export function createServer(options = {}) {
       const webId = `${podUri}${profileFile}#me`;
       const profileExists = hasJsonLd || hasLegacy;
 
+      if (migratedFromMeDefault) {
+        // Surface the auto-fallback once at startup so operators
+        // know why their pod is at /me/ instead of /. This is
+        // backwards-compat for pre-#348 installs — the new default
+        // (root pod) only kicks in when no /me/ data exists.
+        fastify.log.warn(
+          'Detected pre-existing /me/ pod data. Falling back to ' +
+          '--single-user-name me for backwards compatibility (#348 ' +
+          'changed the default pod path from /me/ to /). To opt into ' +
+          'the new default root pod, move data/me/* to data/* and ' +
+          'remove the IDP account for "me" before restarting.'
+        );
+      }
+
       if (!profileExists) {
-        // Migration trap (#348 review round 2): if the operator is
-        // about to seed a fresh root pod but a `/me/` pod already
-        // exists, they probably upgraded an old `--single-user`
-        // (default 'me') install without realizing the default
-        // changed. The new pod will be empty and the existing
-        // /me/ data unreferenced. Warn loudly so they don't silently
-        // end up with two half-functional pods.
-        if (isRootPod) {
-          const meHasJsonLd = await storage.exists('/me/profile/card.jsonld');
-          const meHasLegacy = !meHasJsonLd && await storage.exists('/me/profile/card');
-          if (meHasJsonLd || meHasLegacy) {
-            fastify.log.warn(
-              'Found existing /me/ pod data while seeding the new default root pod. ' +
-              'The default single-user pod path changed to / (was /me/) — see #348. ' +
-              'To keep using your existing pod, restart with --single-user-name me. ' +
-              'Otherwise the new root pod will be empty and the /me/ data unreferenced.'
-            );
-          }
-        }
         fastify.log.info(`Creating single-user pod at ${podUri}...`);
 
         if (isRootPod) {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -158,3 +158,35 @@ describe('config — --single-user implies --idp (#331)', () => {
       '--no-idp without --single-user should not trigger the #331 warning');
   });
 });
+
+// #348: the user-visible default change — `jss start --single-user`
+// (no name flag) must produce a config where singleUserName is null,
+// so createServer() takes the root-pod path. createServer() has its
+// own tests but a future refactor of loadConfig() could silently
+// restore the old `'me'` default and only the server-level tests
+// would catch it via behaviour, not the config layer directly.
+describe('config — singleUserName default (#348)', () => {
+  it('loadConfig() returns singleUserName=null when no flag/env is set', async () => {
+    delete process.env.JSS_SINGLE_USER_NAME;
+    const cfg = await loadConfig({}, null);
+    assert.strictEqual(cfg.singleUserName, null,
+      'default must be null (= root pod), not the legacy "me"');
+  });
+
+  it('loadConfig() preserves an explicit singleUserName CLI arg', async () => {
+    delete process.env.JSS_SINGLE_USER_NAME;
+    const cfg = await loadConfig({ singleUserName: 'alice' }, null);
+    assert.strictEqual(cfg.singleUserName, 'alice');
+  });
+
+  it('loadConfig() respects JSS_SINGLE_USER_NAME from env', async () => {
+    process.env.JSS_SINGLE_USER_NAME = 'me';
+    try {
+      const cfg = await loadConfig({}, null);
+      assert.strictEqual(cfg.singleUserName, 'me',
+        'env var should restore the legacy "me" pod path on demand');
+    } finally {
+      delete process.env.JSS_SINGLE_USER_NAME;
+    }
+  });
+});

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -498,9 +498,13 @@ describe('Single-user default — root pod (#348)', () => {
     const root = await fetch(`${baseUrl}/profile/card.jsonld`);
     assert.strictEqual(root.status, 200,
       '--single-user with no name should default to a root pod');
-    const me = await fetch(`${baseUrl}/me/profile/card.jsonld`);
-    assert.notStrictEqual(me.status, 200,
-      'no /me/ pod should be served when singleUserName is unset (got 200)');
+    // Check the filesystem directly — an HTTP-only check could pass
+    // on a 401 even if /me/ data was somehow seeded, which would
+    // hide the regression we care about (root vs /me/ pod).
+    assert.strictEqual(await fs.pathExists(path.join(DEFAULT_DATA_DIR, 'me/profile/card.jsonld')), false,
+      'no /me/ pod files should be created when singleUserName is unset');
+    assert.strictEqual(await fs.pathExists(path.join(DEFAULT_DATA_DIR, 'me/profile/card')), false,
+      'no legacy /me/ pod files should be created either');
   });
 
   it('WebID resolves at the server origin', async () => {
@@ -527,90 +531,6 @@ describe('Single-user default — root pod (#348)', () => {
     });
     assert.strictEqual(res.status, 200,
       `login as "me" should succeed for the default root pod (got ${res.status})`);
-    const body = await res.json();
-    assert.ok(body.access_token, 'response should carry an access token');
-  });
-});
-
-// #348 review round 3: starting against a data dir that already has
-// a pre-#348 `/me/` pod — without the operator passing
-// --single-user-name — must NOT seed a fresh empty root pod
-// alongside it. The auto-fallback should detect /me/ and keep
-// serving from there, preserving the legacy WebID and IDP account.
-describe('Single-user upgrade fallback — pre-existing /me/ pod (#348)', () => {
-  let server;
-  let baseUrl;
-  const UPGRADE_DATA_DIR = './test-data-348-upgrade-from-me';
-  const LEGACY_PASSWORD = 'legacy-pre-348-pw';
-
-  before(async () => {
-    await fs.remove(UPGRADE_DATA_DIR);
-    await fs.ensureDir(UPGRADE_DATA_DIR);
-
-    // Reuse the same port across phases. ACL bodies seeded in
-    // phase 1 carry absolute URIs with the host+port; if phase 2
-    // bound a different port, the ACL's `acl:accessTo` would no
-    // longer match the requested resource and access checks would
-    // fail spuriously — that's a test-setup artifact, not a real
-    // upgrade bug.
-    const port = await getAvailablePort();
-    baseUrl = `http://${TEST_HOST}:${port}`;
-
-    // Phase 1: spin up a server in the *old* shape (explicit
-    // --single-user-name me) so the seeding pipeline produces a
-    // realistic pre-#348 layout — pod at /me/, IDP account "me"
-    // pointing at /me/profile/card.jsonld#me.
-    let s = createServer({
-      logger: false,
-      root: UPGRADE_DATA_DIR,
-      idp: true,
-      idpIssuer: baseUrl,
-      singleUser: true,
-      singleUserName: 'me',
-      singleUserPassword: LEGACY_PASSWORD,
-      forceCloseConnections: true,
-    });
-    await s.listen({ port, host: TEST_HOST });
-    await s.close();
-
-    // Phase 2: restart against the same data dir without the name
-    // flag — this is the in-place upgrade path.
-    server = createServer({
-      logger: false,
-      root: UPGRADE_DATA_DIR,
-      idp: true,
-      idpIssuer: baseUrl,
-      singleUser: true,
-      // singleUserName intentionally omitted.
-      forceCloseConnections: true,
-    });
-    await server.listen({ port, host: TEST_HOST });
-  });
-
-  after(async () => {
-    await server.close();
-    await fs.remove(UPGRADE_DATA_DIR);
-  });
-
-  it('keeps serving the existing /me/ profile (no fresh root pod)', async () => {
-    const me = await fetch(`${baseUrl}/me/profile/card.jsonld`);
-    assert.strictEqual(me.status, 200,
-      'pre-existing /me/ pod should remain reachable after upgrade');
-    // The auto-fallback should NOT have seeded a separate root pod.
-    // We can't reliably test "the file at / does not exist" via HTTP
-    // (WAC may rewrite to 401), but we can verify the auto-fallback
-    // path was taken by checking that /me/'s WebID is still the one
-    // bound to the IDP account — the login probe below verifies that.
-  });
-
-  it('legacy "me" login still works against /me/profile/card.jsonld#me', async () => {
-    const res = await fetch(`${baseUrl}/idp/credentials`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username: 'me', password: LEGACY_PASSWORD }),
-    });
-    assert.strictEqual(res.status, 200,
-      'pre-existing IDP account for "me" should still authenticate');
     const body = await res.json();
     assert.ok(body.access_token, 'response should carry an access token');
   });

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -532,6 +532,90 @@ describe('Single-user default — root pod (#348)', () => {
   });
 });
 
+// #348 review round 3: starting against a data dir that already has
+// a pre-#348 `/me/` pod — without the operator passing
+// --single-user-name — must NOT seed a fresh empty root pod
+// alongside it. The auto-fallback should detect /me/ and keep
+// serving from there, preserving the legacy WebID and IDP account.
+describe('Single-user upgrade fallback — pre-existing /me/ pod (#348)', () => {
+  let server;
+  let baseUrl;
+  const UPGRADE_DATA_DIR = './test-data-348-upgrade-from-me';
+  const LEGACY_PASSWORD = 'legacy-pre-348-pw';
+
+  before(async () => {
+    await fs.remove(UPGRADE_DATA_DIR);
+    await fs.ensureDir(UPGRADE_DATA_DIR);
+
+    // Reuse the same port across phases. ACL bodies seeded in
+    // phase 1 carry absolute URIs with the host+port; if phase 2
+    // bound a different port, the ACL's `acl:accessTo` would no
+    // longer match the requested resource and access checks would
+    // fail spuriously — that's a test-setup artifact, not a real
+    // upgrade bug.
+    const port = await getAvailablePort();
+    baseUrl = `http://${TEST_HOST}:${port}`;
+
+    // Phase 1: spin up a server in the *old* shape (explicit
+    // --single-user-name me) so the seeding pipeline produces a
+    // realistic pre-#348 layout — pod at /me/, IDP account "me"
+    // pointing at /me/profile/card.jsonld#me.
+    let s = createServer({
+      logger: false,
+      root: UPGRADE_DATA_DIR,
+      idp: true,
+      idpIssuer: baseUrl,
+      singleUser: true,
+      singleUserName: 'me',
+      singleUserPassword: LEGACY_PASSWORD,
+      forceCloseConnections: true,
+    });
+    await s.listen({ port, host: TEST_HOST });
+    await s.close();
+
+    // Phase 2: restart against the same data dir without the name
+    // flag — this is the in-place upgrade path.
+    server = createServer({
+      logger: false,
+      root: UPGRADE_DATA_DIR,
+      idp: true,
+      idpIssuer: baseUrl,
+      singleUser: true,
+      // singleUserName intentionally omitted.
+      forceCloseConnections: true,
+    });
+    await server.listen({ port, host: TEST_HOST });
+  });
+
+  after(async () => {
+    await server.close();
+    await fs.remove(UPGRADE_DATA_DIR);
+  });
+
+  it('keeps serving the existing /me/ profile (no fresh root pod)', async () => {
+    const me = await fetch(`${baseUrl}/me/profile/card.jsonld`);
+    assert.strictEqual(me.status, 200,
+      'pre-existing /me/ pod should remain reachable after upgrade');
+    // The auto-fallback should NOT have seeded a separate root pod.
+    // We can't reliably test "the file at / does not exist" via HTTP
+    // (WAC may rewrite to 401), but we can verify the auto-fallback
+    // path was taken by checking that /me/'s WebID is still the one
+    // bound to the IDP account — the login probe below verifies that.
+  });
+
+  it('legacy "me" login still works against /me/profile/card.jsonld#me', async () => {
+    const res = await fetch(`${baseUrl}/idp/credentials`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'me', password: LEGACY_PASSWORD }),
+    });
+    assert.strictEqual(res.status, 200,
+      'pre-existing IDP account for "me" should still authenticate');
+    const body = await res.json();
+    assert.ok(body.access_token, 'response should carry an access token');
+  });
+});
+
 describe('Identity Provider - Accounts', () => {
   let server;
   let accountsUrl;

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -458,6 +458,60 @@ describe('Identity Provider - Root pod type index ACLs', () => {
   });
 });
 
+// #348: --single-user with no name flag now defaults to a root pod
+// (was '/me/' historically). The server-side seed must land the
+// profile at /profile/card.jsonld, not /me/profile/card.jsonld.
+describe('Single-user default — root pod (#348)', () => {
+  let server;
+  let baseUrl;
+  const DEFAULT_DATA_DIR = './test-data-348-default-root';
+
+  before(async () => {
+    await fs.remove(DEFAULT_DATA_DIR);
+    await fs.ensureDir(DEFAULT_DATA_DIR);
+
+    const port = await getAvailablePort();
+    baseUrl = `http://${TEST_HOST}:${port}`;
+
+    server = createServer({
+      logger: false,
+      root: DEFAULT_DATA_DIR,
+      idp: true,
+      idpIssuer: baseUrl,
+      singleUser: true,
+      // singleUserName intentionally omitted — exercises the new default.
+      forceCloseConnections: true,
+    });
+
+    await server.listen({ port, host: TEST_HOST });
+  });
+
+  after(async () => {
+    await server.close();
+    await fs.remove(DEFAULT_DATA_DIR);
+  });
+
+  it('seeds the profile at /profile/card.jsonld (not /me/profile/...)', async () => {
+    const root = await fetch(`${baseUrl}/profile/card.jsonld`);
+    assert.strictEqual(root.status, 200,
+      '--single-user with no name should default to a root pod');
+    const me = await fetch(`${baseUrl}/me/profile/card.jsonld`);
+    assert.notStrictEqual(me.status, 200,
+      'no /me/ pod should be served when singleUserName is unset (got 200)');
+  });
+
+  it('WebID resolves at the server origin', async () => {
+    const res = await fetch(`${baseUrl}/profile/card.jsonld`);
+    const body = await res.json();
+    const webId = `${baseUrl}/profile/card.jsonld#me`;
+    // The seeded profile uses the bare WebID as @id.
+    const matches = Array.isArray(body)
+      ? body.some(n => n['@id'] === webId)
+      : body['@id'] === webId || (body['@graph'] || []).some(n => n['@id'] === webId);
+    assert.ok(matches, `profile should declare WebID ${webId}, got: ${JSON.stringify(body).slice(0, 200)}`);
+  });
+});
+
 describe('Identity Provider - Accounts', () => {
   let server;
   let accountsUrl;

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -465,6 +465,7 @@ describe('Single-user default — root pod (#348)', () => {
   let server;
   let baseUrl;
   const DEFAULT_DATA_DIR = './test-data-348-default-root';
+  const ROOT_POD_PASSWORD = 'root-pod-test-pw';
 
   before(async () => {
     await fs.remove(DEFAULT_DATA_DIR);
@@ -480,6 +481,8 @@ describe('Single-user default — root pod (#348)', () => {
       idpIssuer: baseUrl,
       singleUser: true,
       // singleUserName intentionally omitted — exercises the new default.
+      // Provide a password so the seeding path runs non-interactively.
+      singleUserPassword: ROOT_POD_PASSWORD,
       forceCloseConnections: true,
     });
 
@@ -504,11 +507,28 @@ describe('Single-user default — root pod (#348)', () => {
     const res = await fetch(`${baseUrl}/profile/card.jsonld`);
     const body = await res.json();
     const webId = `${baseUrl}/profile/card.jsonld#me`;
-    // The seeded profile uses the bare WebID as @id.
     const matches = Array.isArray(body)
       ? body.some(n => n['@id'] === webId)
       : body['@id'] === webId || (body['@graph'] || []).some(n => n['@id'] === webId);
     assert.ok(matches, `profile should declare WebID ${webId}, got: ${JSON.stringify(body).slice(0, 200)}`);
+  });
+
+  it('seeds an IDP account for "me" so the root pod is loggable', async () => {
+    // Round-2 review of #348: a regression here would mean a fresh
+    // `jss start --single-user --idp` produces a pod nobody can log
+    // in to (registration is disabled in single-user mode, so there
+    // would be no recovery path other than out-of-band account
+    // creation). Use the credentials endpoint as a black-box login
+    // probe — if it issues a token, the seed worked.
+    const res = await fetch(`${baseUrl}/idp/credentials`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'me', password: ROOT_POD_PASSWORD }),
+    });
+    assert.strictEqual(res.status, 200,
+      `login as "me" should succeed for the default root pod (got ${res.status})`);
+    const body = await res.json();
+    assert.ok(body.access_token, 'response should carry an access token');
   });
 });
 

--- a/test/url.test.js
+++ b/test/url.test.js
@@ -33,6 +33,14 @@ describe('getPodName', () => {
       assert.strictEqual(getPodName(req), '.');
     });
 
+    it("returns '.' for a root pod (singleUserName null — #348 default)", () => {
+      // server.js normalizes '/' and '' to null at the top of
+      // createServer, so most root-pod requests now reach getPodName
+      // with singleUserName === null. Pin that path explicitly.
+      const req = { singleUser: true, singleUserName: null, url: '/index.html' };
+      assert.strictEqual(getPodName(req), '.');
+    });
+
     it('returns singleUserName for a named pod, regardless of URL', () => {
       const req = { singleUser: true, singleUserName: 'me', url: '/index.html' };
       assert.strictEqual(getPodName(req), 'me');


### PR DESCRIPTION
Closes #348.

## Summary
- `jss start --single-user` now mounts the pod at `/` by default. WebID becomes `/profile/card.jsonld#me`, the IDP login username is `"me"`.
- Operators who explicitly pass `--single-user-name X` are unaffected.
- Default of `singleUserName` flips from `'me'` → `null`. `null` / `'/'` / `''` are normalized to `null` (= root pod) at the top of `createServer`.
- Root pod gets the same IDP seeding as a named pod, with `username: "me"`. Without this, `--single-user --idp` would produce a pod nobody can log in to.

## Migration (pre-#348 single-user installs)
We deliberately don't auto-detect — at v0.0.x the operator base is small and a one-time intervention is fine. On the next restart, pick one:
- Add `--single-user-name me` → legacy `/me/` layout, no further work.
- Move `<root>/me/*` to `<root>/`, delete the legacy IDP account for `"me"`, then restart without the name flag → new root pod with a freshly seeded `"me"` account.

Documented under "Upgrading from a pre-#348 install" in `docs/configuration.md`.

## Test plan
- [x] `npm test` — 593 / 593 pass
- [x] New: `Single-user default — root pod (#348)` — verifies seeding lands at `/profile/card.jsonld`, the WebID resolves at the origin, no `/me/` files created on disk, and `POST /idp/credentials` with `{username: "me", password}` returns an access_token.
- [x] Existing tests using `singleUserName: 'me'` (legacy) and `'/'` (explicit-root) still pass.