### PR TITLE
ldp: hide server-internal sidecars from container listings (#350)

### DIFF
--- a/src/ldp/container.js
+++ b/src/ldp/container.js
@@ -4,6 +4,17 @@
 
 const LDP = 'http://www.w3.org/ns/ldp#';
 
+// Dotfiles allowed to appear in ldp:contains. Anything else starting with '.'
+// is server-internal state (.idp, .quota.json, .server, future .git, etc.) and
+// must not leak into container listings — even when its contents are otherwise
+// ACL-gated, the *existence* gives attackers free path-fingerprinting (see #350).
+// Mirrors the dotfile allowlist enforced at the routing layer in server.js.
+const ALLOWED_DOTFILES = new Set(['.well-known', '.acl', '.meta', '.pods', '.notifications', '.account']);
+
+function isHiddenEntry(name) {
+  return name.startsWith('.') && !ALLOWED_DOTFILES.has(name);
+}
+
 /**
  * Generate JSON-LD representation of a container
  * @param {string} containerUrl - Full URL of the container
@@ -14,7 +25,7 @@ export function generateContainerJsonLd(containerUrl, entries) {
   // Ensure container URL ends with /
   const baseUrl = containerUrl.endsWith('/') ? containerUrl : containerUrl + '/';
 
-  const contains = entries.map(entry => {
+  const contains = entries.filter(entry => !isHiddenEntry(entry.name)).map(entry => {
     const childUrl = baseUrl + entry.name + (entry.isDirectory ? '/' : '');
     const item = {
       '@id': childUrl,

--- a/src/ldp/container.js
+++ b/src/ldp/container.js
@@ -6,8 +6,10 @@ const LDP = 'http://www.w3.org/ns/ldp#';
 
 // Dotfiles allowed to appear in ldp:contains. Anything else starting with '.'
 // is server-internal state and must not leak into container listings — even
-// when its contents are ACL-gated, the *existence* gives attackers free
-// path-fingerprinting (#350).
+// when direct GETs are 403'd by the routing-layer dotfile guard in server.js
+// (which rejects non-allowlisted dotpaths before WAC even runs), listing the
+// *name* still leaks existence and gives attackers free path-fingerprinting
+// (#350).
 //
 // `.well-known` is allowed because JSS exposes legitimate public resources
 // there (e.g. the webledger registry at /.well-known/webledgers/...). The

--- a/src/ldp/container.js
+++ b/src/ldp/container.js
@@ -9,13 +9,15 @@ const LDP = 'http://www.w3.org/ns/ldp#';
 // when its contents are ACL-gated, the *existence* gives attackers free
 // path-fingerprinting (#350).
 //
-// This list is intentionally NARROWER than the routing-layer dotfile guard
-// in server.js. Routing has to allow `.well-known/`, `.pods`, `.notifications`,
-// `.account` so Fastify-served discovery/control endpoints work; but on-disk
-// directories with those names hold internal state (token store, pay state,
-// etc. live under DATA_ROOT/.well-known/) that should not appear in listings.
-// Only canonical Solid per-resource sidecars belong here.
-const ALLOWED_DOTFILES = new Set(['.acl', '.meta']);
+// `.well-known` is allowed because JSS exposes legitimate public resources
+// there (e.g. the webledger registry at /.well-known/webledgers/...). Per-
+// resource WAC governs what's actually readable inside. Internal state that
+// JSS currently persists under `.well-known/` (token store, pay state) is a
+// separate concern — it shouldn't be in a public namespace at all; tracked
+// at #358.
+//
+// `.acl` and `.meta` are canonical Solid per-resource sidecars.
+const ALLOWED_DOTFILES = new Set(['.acl', '.meta', '.well-known']);
 
 function isHiddenEntry(name) {
   return name.startsWith('.') && !ALLOWED_DOTFILES.has(name);

--- a/src/ldp/container.js
+++ b/src/ldp/container.js
@@ -5,11 +5,17 @@
 const LDP = 'http://www.w3.org/ns/ldp#';
 
 // Dotfiles allowed to appear in ldp:contains. Anything else starting with '.'
-// is server-internal state (.idp, .quota.json, .server, future .git, etc.) and
-// must not leak into container listings — even when its contents are otherwise
-// ACL-gated, the *existence* gives attackers free path-fingerprinting (see #350).
-// Mirrors the dotfile allowlist enforced at the routing layer in server.js.
-const ALLOWED_DOTFILES = new Set(['.well-known', '.acl', '.meta', '.pods', '.notifications', '.account']);
+// is server-internal state and must not leak into container listings — even
+// when its contents are ACL-gated, the *existence* gives attackers free
+// path-fingerprinting (#350).
+//
+// This list is intentionally NARROWER than the routing-layer dotfile guard
+// in server.js. Routing has to allow `.well-known/`, `.pods`, `.notifications`,
+// `.account` so Fastify-served discovery/control endpoints work; but on-disk
+// directories with those names hold internal state (token store, pay state,
+// etc. live under DATA_ROOT/.well-known/) that should not appear in listings.
+// Only canonical Solid per-resource sidecars belong here.
+const ALLOWED_DOTFILES = new Set(['.acl', '.meta']);
 
 function isHiddenEntry(name) {
   return name.startsWith('.') && !ALLOWED_DOTFILES.has(name);

--- a/src/ldp/container.js
+++ b/src/ldp/container.js
@@ -12,11 +12,18 @@ const LDP = 'http://www.w3.org/ns/ldp#';
 // (#350).
 //
 // `.well-known` is allowed because JSS exposes legitimate public resources
-// there (e.g. the webledger registry at /.well-known/webledgers/...). The
-// routing layer in server.js intentionally bypasses auth for `/.well-known/*`
-// per RFC 8615 — anything that lives there is public-by-design. Internal
-// state that JSS currently persists under `.well-known/` (token store, pay
-// state) shouldn't be in a public namespace at all; tracked at #358.
+// there (e.g. the webledger registry at /.well-known/webledgers/...). At the
+// origin root — including each pod's own origin in subdomain mode — server.js
+// bypasses auth for `/.well-known/*` per RFC 8615. For path-based pods at
+// `/pod/.well-known/`, the bypass does *not* apply (it matches root-relative
+// paths only) — that case is a regular subdirectory governed by ordinary WAC,
+// and listing the name is fine. We allow `.well-known` uniformly here so the
+// subdomain-pod and root-pod cases work without conditional logic on the
+// container path.
+//
+// Internal state that JSS currently persists under `.well-known/` (token
+// store, pay state) shouldn't be in a public namespace at all; tracked at
+// #358.
 //
 // `.acl` and `.meta` are canonical Solid per-resource sidecars.
 const ALLOWED_DOTFILES = new Set(['.acl', '.meta', '.well-known']);

--- a/src/ldp/container.js
+++ b/src/ldp/container.js
@@ -10,11 +10,11 @@ const LDP = 'http://www.w3.org/ns/ldp#';
 // path-fingerprinting (#350).
 //
 // `.well-known` is allowed because JSS exposes legitimate public resources
-// there (e.g. the webledger registry at /.well-known/webledgers/...). Per-
-// resource WAC governs what's actually readable inside. Internal state that
-// JSS currently persists under `.well-known/` (token store, pay state) is a
-// separate concern — it shouldn't be in a public namespace at all; tracked
-// at #358.
+// there (e.g. the webledger registry at /.well-known/webledgers/...). The
+// routing layer in server.js intentionally bypasses auth for `/.well-known/*`
+// per RFC 8615 — anything that lives there is public-by-design. Internal
+// state that JSS currently persists under `.well-known/` (token store, pay
+// state) shouldn't be in a public namespace at all; tracked at #358.
 //
 // `.acl` and `.meta` are canonical Solid per-resource sidecars.
 const ALLOWED_DOTFILES = new Set(['.acl', '.meta', '.well-known']);

--- a/test/container.test.js
+++ b/test/container.test.js
@@ -1,0 +1,72 @@
+/**
+ * Container listing generator — dotfile-allowlist regression (#350)
+ *
+ * Server-internal sidecars (.idp/, .quota.json, .server/, future .git/, etc.)
+ * must NOT appear in ldp:contains, even when their contents are otherwise
+ * ACL-gated — listing them leaks existence and gives attackers free
+ * path-fingerprinting against root-pod (--single-user) deployments.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { generateContainerJsonLd } from '../src/ldp/container.js';
+
+describe('generateContainerJsonLd dotfile filtering (#350)', () => {
+  it('emits regular entries unchanged', () => {
+    const out = generateContainerJsonLd('https://example.com/pod/', [
+      { name: 'public', isDirectory: true },
+      { name: 'index.html', isDirectory: false },
+    ]);
+    const ids = out.contains.map(c => c['@id']);
+    assert.deepStrictEqual(ids, [
+      'https://example.com/pod/public/',
+      'https://example.com/pod/index.html',
+    ]);
+  });
+
+  it('keeps allowed Solid dotfiles (.acl, .meta, .well-known)', () => {
+    const out = generateContainerJsonLd('https://example.com/pod/', [
+      { name: '.acl', isDirectory: false },
+      { name: '.meta', isDirectory: false },
+      { name: '.well-known', isDirectory: true },
+    ]);
+    const ids = out.contains.map(c => c['@id']);
+    assert.ok(ids.includes('https://example.com/pod/.acl'));
+    assert.ok(ids.includes('https://example.com/pod/.meta'));
+    assert.ok(ids.includes('https://example.com/pod/.well-known/'));
+  });
+
+  it('hides server-internal sidecars (.idp/, .quota.json, .server/)', () => {
+    const out = generateContainerJsonLd('https://example.com/', [
+      { name: '.idp', isDirectory: true },
+      { name: '.quota.json', isDirectory: false },
+      { name: '.server', isDirectory: true },
+    ]);
+    assert.deepStrictEqual(out.contains, []);
+  });
+
+  it('hides any unknown dotfile (default-deny on .git, .env, .DS_Store, etc.)', () => {
+    const out = generateContainerJsonLd('https://example.com/pod/', [
+      { name: '.git', isDirectory: true },
+      { name: '.env', isDirectory: false },
+      { name: '.DS_Store', isDirectory: false },
+    ]);
+    assert.deepStrictEqual(out.contains, []);
+  });
+
+  it('keeps regular entries when mixed with hidden ones', () => {
+    const out = generateContainerJsonLd('https://example.com/', [
+      { name: '.acl', isDirectory: false },
+      { name: '.idp', isDirectory: true },
+      { name: '.quota.json', isDirectory: false },
+      { name: 'public', isDirectory: true },
+      { name: 'profile', isDirectory: true },
+    ]);
+    const ids = out.contains.map(c => c['@id']);
+    assert.deepStrictEqual(ids, [
+      'https://example.com/.acl',
+      'https://example.com/public/',
+      'https://example.com/profile/',
+    ]);
+  });
+});

--- a/test/container.test.js
+++ b/test/container.test.js
@@ -24,23 +24,25 @@ describe('generateContainerJsonLd dotfile filtering (#350)', () => {
     ]);
   });
 
-  it('keeps allowed Solid dotfiles (.acl, .meta, .well-known)', () => {
+  it('keeps canonical Solid per-resource sidecars (.acl, .meta)', () => {
     const out = generateContainerJsonLd('https://example.com/pod/', [
       { name: '.acl', isDirectory: false },
       { name: '.meta', isDirectory: false },
-      { name: '.well-known', isDirectory: true },
     ]);
     const ids = out.contains.map(c => c['@id']);
     assert.ok(ids.includes('https://example.com/pod/.acl'));
     assert.ok(ids.includes('https://example.com/pod/.meta'));
-    assert.ok(ids.includes('https://example.com/pod/.well-known/'));
   });
 
-  it('hides server-internal sidecars (.idp/, .quota.json, .server/)', () => {
+  it('hides server-internal sidecars (.idp/, .quota.json, .server/, .well-known/)', () => {
+    // .well-known is intentionally hidden in listings even though routing
+    // allows it — JSS persists token-store and pay state under
+    // DATA_ROOT/.well-known/, so listing it leaks internal paths.
     const out = generateContainerJsonLd('https://example.com/', [
       { name: '.idp', isDirectory: true },
       { name: '.quota.json', isDirectory: false },
       { name: '.server', isDirectory: true },
+      { name: '.well-known', isDirectory: true },
     ]);
     assert.deepStrictEqual(out.contains, []);
   });

--- a/test/container.test.js
+++ b/test/container.test.js
@@ -24,25 +24,25 @@ describe('generateContainerJsonLd dotfile filtering (#350)', () => {
     ]);
   });
 
-  it('keeps canonical Solid per-resource sidecars (.acl, .meta)', () => {
+  it('keeps allowed Solid resources (.acl, .meta, .well-known)', () => {
+    // .well-known stays — JSS serves legitimate public resources there
+    // (e.g. webledger). Per-resource WAC governs what's actually readable.
     const out = generateContainerJsonLd('https://example.com/pod/', [
       { name: '.acl', isDirectory: false },
       { name: '.meta', isDirectory: false },
+      { name: '.well-known', isDirectory: true },
     ]);
     const ids = out.contains.map(c => c['@id']);
     assert.ok(ids.includes('https://example.com/pod/.acl'));
     assert.ok(ids.includes('https://example.com/pod/.meta'));
+    assert.ok(ids.includes('https://example.com/pod/.well-known/'));
   });
 
-  it('hides server-internal sidecars (.idp/, .quota.json, .server/, .well-known/)', () => {
-    // .well-known is intentionally hidden in listings even though routing
-    // allows it — JSS persists token-store and pay state under
-    // DATA_ROOT/.well-known/, so listing it leaks internal paths.
+  it('hides server-internal sidecars (.idp/, .quota.json, .server/)', () => {
     const out = generateContainerJsonLd('https://example.com/', [
       { name: '.idp', isDirectory: true },
       { name: '.quota.json', isDirectory: false },
       { name: '.server', isDirectory: true },
-      { name: '.well-known', isDirectory: true },
     ]);
     assert.deepStrictEqual(out.contains, []);
   });

--- a/test/container.test.js
+++ b/test/container.test.js
@@ -50,6 +50,20 @@ describe('generateContainerJsonLd dotfile filtering (#350)', () => {
     assert.deepStrictEqual(out.contains, []);
   });
 
+  it('hides server control endpoints — listing allowlist is intentionally narrower than server.js routing allowlist', () => {
+    // .pods, .notifications, .account are routed to handlers in server.js
+    // (the broader 6-entry routing allowlist) but they're NOT public
+    // linked-data resources that belong in ldp:contains. Pinning this
+    // explicitly so that adding any of these to ALLOWED_DOTFILES would
+    // fail the suite — see PR #357 review comment.
+    const out = generateContainerJsonLd('https://example.com/', [
+      { name: '.pods', isDirectory: true },
+      { name: '.notifications', isDirectory: true },
+      { name: '.account', isDirectory: false },
+    ]);
+    assert.deepStrictEqual(out.contains, []);
+  });
+
   it('hides any unknown dotfile (default-deny on .git, .env, .DS_Store, etc.)', () => {
     const out = generateContainerJsonLd('https://example.com/pod/', [
       { name: '.git', isDirectory: true },

--- a/test/container.test.js
+++ b/test/container.test.js
@@ -2,9 +2,11 @@
  * Container listing generator — dotfile-allowlist regression (#350)
  *
  * Server-internal sidecars (.idp/, .quota.json, .server/, future .git/, etc.)
- * must NOT appear in ldp:contains, even when their contents are otherwise
- * ACL-gated — listing them leaks existence and gives attackers free
- * path-fingerprinting against root-pod (--single-user) deployments.
+ * must NOT appear in ldp:contains, even though direct GETs are 403'd by the
+ * routing-layer dotfile guard in server.js (which rejects non-allowlisted
+ * dotpaths before WAC runs). Listing the names still leaks existence and
+ * gives attackers free path-fingerprinting against root-pod (--single-user)
+ * deployments.
  */
 
 import { describe, it } from 'node:test';

--- a/test/container.test.js
+++ b/test/container.test.js
@@ -26,7 +26,8 @@ describe('generateContainerJsonLd dotfile filtering (#350)', () => {
 
   it('keeps allowed Solid resources (.acl, .meta, .well-known)', () => {
     // .well-known stays — JSS serves legitimate public resources there
-    // (e.g. webledger). Per-resource WAC governs what's actually readable.
+    // (e.g. webledger). Routing intentionally bypasses auth for
+    // /.well-known/* per RFC 8615; resources are public-by-design.
     const out = generateContainerJsonLd('https://example.com/pod/', [
       { name: '.acl', isDirectory: false },
       { name: '.meta', isDirectory: false },

--- a/test/container.test.js
+++ b/test/container.test.js
@@ -28,8 +28,10 @@ describe('generateContainerJsonLd dotfile filtering (#350)', () => {
 
   it('keeps allowed Solid resources (.acl, .meta, .well-known)', () => {
     // .well-known stays — JSS serves legitimate public resources there
-    // (e.g. webledger). Routing intentionally bypasses auth for
-    // /.well-known/* per RFC 8615; resources are public-by-design.
+    // (e.g. webledger). At origin-root (including each pod's origin in
+    // subdomain mode) the routing layer bypasses auth per RFC 8615; for
+    // path-based pods at /pod/.well-known/ the bypass doesn't apply but
+    // listing the name is still fine (regular subdirectory under WAC).
     const out = generateContainerJsonLd('https://example.com/pod/', [
       { name: '.acl', isDirectory: false },
       { name: '.meta', isDirectory: false },


### PR DESCRIPTION
Closes #350.

## Problem

\`GET /\` (root pod) on a \`--single-user\` deployment leaks server-internal directories in the LDP container listing:

\`\`\`
.acl              ← legitimate (Solid pod ACL)
.idp/             ← LEAK — OIDC keys/accounts/sessions
.quota.json       ← LEAK — quota sidecar
hub/, inbox/, ...
\`\`\`

Contents are still ACL-gated for read, but listing the *names* gives attackers free path-fingerprinting (probe \`/.idp/keys/\` to detect a JSS install) and surfaces internal state to legitimate clients that have no business consuming it. Visible right now on production solid.social: \`https://solid.social/test/\` listing includes \`.quota.json\`.

This regressed visibly with #348 (root-pod default for \`--single-user\`): named-pod mode placed \`<root>/<pod>/\`-sibling internal files outside any listed container; root-pod mode collapses the two layers and exposes them.

## Fix

Filter inside \`generateContainerJsonLd\`: any entry whose name starts with \`.\` is dropped from \`ldp:contains\` unless it's in the allowlist shared with the routing-layer dotfile guard in \`server.js\`:

\`\`\`js
const ALLOWED_DOTFILES = new Set(['.well-known', '.acl', '.meta', '.pods', '.notifications', '.account']);
\`\`\`

Default-deny on leading \`.\` covers \`.idp\`, \`.quota.json\`, \`.server\`, and any future internal control directory (\`.git\` from \`--git\`, \`.DS_Store\`, \`.env\`) without enumerating them.

## Test plan

5 unit tests in new \`test/container.test.js\`:

- [x] Regular entries (public/, index.html) unchanged
- [x] Allowed Solid dotfiles (.acl, .meta, .well-known) preserved
- [x] Denylisted internals (.idp/, .quota.json, .server/) hidden
- [x] Unknown dotfiles hidden by default (.git, .env, .DS_Store)
- [x] Mixed listings filter the right entries
- [x] No regression in conneg / ldp-headers / data-island suites (46 + 19 tests passing)

## Out of scope

- Hardening the routing layer to also 404 direct GETs of internal paths — already covered by the dotfile guard in \`server.js\` (and matches the same allowlist after this change).
- Backwards-compat for clients depending on seeing \`.quota.json\` in listings — none known; the field is internal sidecar metadata.