### PR TITLE
url: strip all leading slashes — fixes 500 on //foo bot probes (#131)

### DIFF
--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -22,8 +22,11 @@ export function updateDataRoot() {
  * @throws {Error} - If path traversal is detected
  */
 export function urlToPath(urlPath) {
-  // Normalize: remove leading slash, decode URI
-  let normalized = urlPath.startsWith('/') ? urlPath.slice(1) : urlPath;
+  // Normalize: strip all leading slashes (#131 — `//foo` from bot probes
+  // would otherwise leave `/foo`, and path.resolve(root, '/foo') would
+  // treat the second arg as absolute, escape dataRoot, and trip the
+  // traversal guard with a 500 instead of resolving cleanly to a 404).
+  let normalized = urlPath.replace(/^\/+/, '');
   normalized = decodeURIComponent(normalized);
 
   // Security: remove path traversal attempts (multiple passes for ....// bypass)
@@ -54,8 +57,8 @@ export function urlToPath(urlPath) {
  * @throws {Error} - If path traversal is detected
  */
 export function urlToPathWithPod(urlPath, podName) {
-  // Normalize: remove leading slash, decode URI
-  let normalized = urlPath.startsWith('/') ? urlPath.slice(1) : urlPath;
+  // Normalize: strip all leading slashes (#131 — see urlToPath for context).
+  let normalized = urlPath.replace(/^\/+/, '');
   normalized = decodeURIComponent(normalized);
 
   // Security: remove path traversal attempts (multiple passes for ....// bypass)

--- a/test/url.test.js
+++ b/test/url.test.js
@@ -7,7 +7,8 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { getPodName, getContentType } from '../src/utils/url.js';
+import path from 'path';
+import { getPodName, getContentType, urlToPath, urlToPathWithPod } from '../src/utils/url.js';
 
 describe('getPodName', () => {
   describe('subdomain mode', () => {
@@ -123,6 +124,45 @@ describe('getContentType', () => {
 
     it('treats *.meta (extension) as application/ld+json', () => {
       assert.strictEqual(getContentType('/alice/resource.meta'), 'application/ld+json');
+    });
+  });
+});
+
+describe('urlToPath / urlToPathWithPod (#131 — leading-slash normalization)', () => {
+  // Bot probes hammer JSS with `//foo`, `///wp-admin/...`, etc. Without
+  // multi-slash stripping these used to escape dataRoot via path.resolve
+  // (which treats `/foo` as absolute) and 500 with "Path traversal detected"
+  // instead of the expected 404.
+  const dataRoot = path.resolve('./data');
+
+  describe('urlToPath', () => {
+    it('resolves a normal path inside dataRoot', () => {
+      assert.strictEqual(urlToPath('/alice/profile/card'), path.join(dataRoot, 'alice/profile/card'));
+    });
+
+    it('handles double leading slash without throwing (#131)', () => {
+      assert.strictEqual(urlToPath('//about.php'), path.join(dataRoot, 'about.php'));
+    });
+
+    it('handles many leading slashes (#131)', () => {
+      assert.strictEqual(urlToPath('////wp-admin/index.php'), path.join(dataRoot, 'wp-admin/index.php'));
+    });
+
+    it('still rejects real `..` traversal that escapes after normalization', () => {
+      // Security must be preserved: `/../etc/passwd` → strip leading slash →
+      // `../etc/passwd` → strip `..` → `/etc/passwd` (absolute residue) →
+      // path.resolve escapes dataRoot → guard fires.
+      assert.throws(() => urlToPath('/../etc/passwd'), /Path traversal/);
+    });
+  });
+
+  describe('urlToPathWithPod', () => {
+    it('resolves into the pod dir', () => {
+      assert.strictEqual(urlToPathWithPod('/profile/card', 'alice'), path.join(dataRoot, 'alice/profile/card'));
+    });
+
+    it('handles double leading slash (#131)', () => {
+      assert.strictEqual(urlToPathWithPod('//about.php', 'alice'), path.join(dataRoot, 'alice/about.php'));
     });
   });
 });

--- a/test/url.test.js
+++ b/test/url.test.js
@@ -5,7 +5,7 @@
  * Regression guard for #278 (single-user root-pod PUT → ENOTDIR).
  */
 
-import { describe, it } from 'node:test';
+import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
 import path from 'path';
 import { getPodName, getContentType, urlToPath, urlToPathWithPod } from '../src/utils/url.js';
@@ -133,6 +133,20 @@ describe('urlToPath / urlToPathWithPod (#131 — leading-slash normalization)', 
   // multi-slash stripping these used to escape dataRoot via path.resolve
   // (which treats `/foo` as absolute) and 500 with "Path traversal detected"
   // instead of the expected 404.
+
+  // Save/restore DATA_ROOT — other test suites mutate process.env.DATA_ROOT
+  // (via createServer's root option) and don't always restore it. Pinning
+  // to './data' keeps the assertions stable across run order.
+  let originalDataRoot;
+  before(() => {
+    originalDataRoot = process.env.DATA_ROOT;
+    delete process.env.DATA_ROOT;  // forces getDataRoot() default of './data'
+  });
+  after(() => {
+    if (originalDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = originalDataRoot;
+  });
+
   const dataRoot = path.resolve('./data');
 
   describe('urlToPath', () => {


### PR DESCRIPTION
Closes #131.

## Problem

URLs with multiple leading slashes (typical bot probes — \`//about.php\`, \`//wp-admin/...\`, \`//cgi-bin/...\`) returned **500 Internal Server Error** instead of 404. On production, this was 100% of 5xx traffic (~2,130/week on melvin.me), inflating monitoring noise without representing real errors.

Reproduce against any current JSS:

\`\`\`
$ curl -s https://solid.social//about.php
{"statusCode":500,"error":"Internal Server Error","message":"Path traversal detected"}
\`\`\`

## Root cause

In \`src/utils/url.js\`:

\`\`\`js
let normalized = urlPath.startsWith('/') ? urlPath.slice(1) : urlPath;
\`\`\`

\`slice(1)\` only strips one leading slash. With input \`//about.php\`:

1. After slice → \`/about.php\`
2. After \`..\` strip → \`/about.php\` (unchanged)
3. \`path.resolve(dataRoot, "/about.php")\` → \`/about.php\` (absolute argument wins)
4. Resolved path doesn't start with \`dataRoot\` → throws \`"Path traversal detected"\`

The traversal guard fires not because traversal occurred, but because the absolute residue escaped \`dataRoot\` accidentally.

## Fix

Replace \`slice(1)\` with \`replace(/^\\/+/, '')\` in both \`urlToPath\` and \`urlToPathWithPod\`. Strips any number of leading slashes; \`//about.php\` → \`about.php\` → resolves to \`dataRoot/about.php\` → file doesn't exist → existing 404 path takes over.

## Security

Real \`..\` traversal is **still rejected**. The fix only changes what happens to leading slashes — internal \`..\` segments still strip down to absolute residues that the guard catches. Tested explicitly:

\`\`\`js
it('still rejects real \`..\` traversal that escapes after normalization', () => {
  assert.throws(() => urlToPath('/../etc/passwd'), /Path traversal/);
});
\`\`\`

## Test plan

6 new unit tests in \`test/url.test.js\` covering:

- [x] Normal path resolves inside dataRoot (regression baseline)
- [x] \`//about.php\` resolves cleanly (#131)
- [x] \`////wp-admin/index.php\` (many slashes) resolves cleanly (#131)
- [x] Real \`..\` traversal still throws (security baseline)
- [x] Pod-aware variant (\`urlToPathWithPod\`) handles double slash too
- [x] All 26 url tests pass; no regression in conneg / data-island / container suites

## Deploy / verify

After merge + 0.0.167 publish + solid.social upgrade:

\`\`\`
$ curl -s -o /dev/null -w "%{http_code}\\n" https://solid.social//about.php
404
\`\`\`