### PR TITLE
Default the auth-required databrowser link to solidos.org/docs/browser/ (#362)

### DIFF
--- a/src/auth/middleware.js
+++ b/src/auth/middleware.js
@@ -362,7 +362,7 @@ function getErrorPage(statusCode, isAuthenticated, request) {
       <p class="subtitle">${subtitle}</p>
 
       <div class="actions">
-        ${is401 ? `<a href="https://solidos.solidcommunity.net/?uri=${encodeURIComponent(baseUrl + request.url)}" class="btn btn-primary">
+        ${is401 ? `<a href="https://solidos.org/docs/browser/?uri=${encodeURIComponent(baseUrl + request.url)}" class="btn btn-primary">
           Open in Data Browser
         </a>` : ''}
         <a href="${baseUrl}/" class="btn btn-secondary">


### PR DESCRIPTION
## Summary

Replaces the hardcoded `https://solidos.solidcommunity.net/?uri=...` link on the 401 / auth-required page (`src/auth/middleware.js:365`) with `https://solidos.org/docs/browser/?uri=...`, the SolidOS project's GitHub-Pages-hosted browser endpoint.

`solidos.org/docs/browser/` is hosted by the SolidOS project on stable GitHub Pages infrastructure and is independent of any single operator's domain. Verified live: returns HTTP 200 and honors the `?uri=` query parameter.

## Change

One-line URL replacement in `src/auth/middleware.js`. No new config, no CLI flag, no scope expansion — just a better default link.

## Verification

- Full test suite passes (614/614)
- No behavior change other than the link target

Closes #362.