### PR TITLE
idp landing: link to solidproject.org/apps next to pilot (#364)

### DIFF
--- a/src/idp/views.js
+++ b/src/idp/views.js
@@ -620,7 +620,7 @@ export function landingPage(ctx = {}) {
       : '<a href="/idp/register" class="btn btn-primary" style="text-decoration: none;">Create Account</a>'}
 
     <div class="signin-note">
-      <strong>${singleUser ? 'Sign in' : 'Already have an account?'}</strong> ${singleUser ? 'from' : 'Sign in from'} a Solid app — for example, <a href="https://solid-apps.github.io/pilot/" target="_blank" rel="noopener">pilot</a> is a minimal console you can open right now. Point it at this server and click Sign In.
+      <strong>${singleUser ? 'Sign in' : 'Already have an account?'}</strong> ${singleUser ? 'from' : 'Sign in from'} a Solid app — for example, <a href="https://solid-apps.github.io/pilot/" target="_blank" rel="noopener">pilot</a> is a minimal console you can open right now. Point it at this server and click Sign In. Or <a href="https://solidproject.org/apps" target="_blank" rel="noopener">browse other Solid apps</a>.
     </div>
 
     ${issuer ? `<div class="issuer">Issuer: ${escapeHtml(issuer.replace(/\/$/, ''))}</div>` : ''}


### PR DESCRIPTION
Closes #364.

## Summary
- Adds "Or [browse other Solid apps](https://solidproject.org/apps)." next to the existing pilot recommendation in the IDP landing page.
- One-line change in `src/idp/views.js`. No layout regression — same `<div class="signin-note">`, same `target="_blank" rel="noopener"` pattern.
- Single-user and multi-user variants both pick up the change (the link sits after the shared `${singleUser ? ... : ...}` switch).

## Test plan
- [ ] `npm test` passes
- [ ] Visit `/idp` on a multi-user dev server: link renders, opens https://solidproject.org/apps in a new tab
- [ ] Visit `/idp` on a single-user server: same result, no layout shift