### PR TITLE
README: add E2EE bullet under did:nostr capabilities (#368)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A minimal, fast, JSON-LD native Solid server.
 - **Git HTTP Backend** — Clone and push to pod containers
 - **Nostr Relay** — Integrated NIP-01 relay (`wss://your.pod/relay`)
 - **Nostr Auth** — NIP-98 signatures, did:nostr → WebID resolution
+- **End-to-End Encryption** — Encrypt pod content client-side via NIP-44 / NIP-04 using `did:nostr` keys ([docs](https://jss.live/docs/features/e2ee/), zero server-side changes)
 - **ActivityPub** — Fediverse federation with Mastodon-compatible API
 - **remoteStorage** — [draft-dejong-remotestorage-22](https://remotestorage.io/spec/) file sync
 - **MongoDB Storage** — Optional `/db/` route for JSON-LD at scale


### PR DESCRIPTION
Closes #368. Addresses the README checkbox in #365.

## Summary
- One-line addition to the Features list, immediately after **Nostr Auth**, surfacing E2EE as a downstream capability of \`did:nostr\` and linking to https://jss.live/docs/features/e2ee/.

## Test plan
- [ ] README renders cleanly on the GitHub repo page
- [ ] Link resolves to the docs page