### PR TITLE
git handler: allow Git-Protocol in CORS preflight (#371)

### DIFF
--- a/src/handlers/git.js
+++ b/src/handlers/git.js
@@ -97,7 +97,7 @@ export async function handleGit(request, reply) {
   if (request.method === 'OPTIONS') {
     reply.header('Access-Control-Allow-Origin', '*');
     reply.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    reply.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    reply.header('Access-Control-Allow-Headers', 'Content-Type, Authorization, Git-Protocol');
     return reply.code(200).send();
   }
 
@@ -217,7 +217,7 @@ export async function handleGit(request, reply) {
           // Add CORS headers for browser git clients
           reply.raw.setHeader('Access-Control-Allow-Origin', '*');
           reply.raw.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-          reply.raw.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+          reply.raw.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, Git-Protocol');
 
           reply.raw.writeHead(statusCode);
           headersSent = true;


### PR DESCRIPTION
Closes #371.

## Summary
- Adds \`Git-Protocol\` to \`Access-Control-Allow-Headers\` at both callsites in \`src/handlers/git.js\` (the OPTIONS preflight at line 100, and the streaming-response header block at line 220).
- Unblocks browser git clients (isomorphic-git, etc.) using smart-HTTP protocol v2, which sends \`Git-Protocol: version=2\` on every request.
- Frontend at jss.live/git/ can drop its \`protocolVersion: 1\` workaround once a server with this fix is deployed.

## Test plan
- [ ] \`npm test\` passes
- [ ] \`OPTIONS /alice/repo/info/refs\` returns \`Access-Control-Allow-Headers: Content-Type, Authorization, Git-Protocol\`
- [ ] Browser fetch with the \`Git-Protocol\` header survives preflight