### PR TITLE
idp: add 'Sign in as a different user' on consent page (#384)

### DIFF
--- a/src/idp/index.js
+++ b/src/idp/index.js
@@ -11,6 +11,7 @@ import {
   handleLogin,
   handleConsent,
   handleAbort,
+  handleSwitchAccount,
   handleRegisterGet,
   handleRegisterPost,
   handlePasskeyComplete,
@@ -322,6 +323,13 @@ export async function idpPlugin(fastify, options) {
   // POST abort
   fastify.post('/idp/interaction/:uid/abort', async (request, reply) => {
     return handleAbort(request, reply, provider);
+  });
+
+  // POST "Sign in as a different user" (#384) — destroys the OIDC
+  // session and bounces back to the login prompt while preserving the
+  // in-flight authz request.
+  fastify.post('/idp/interaction/:uid/switch', async (request, reply) => {
+    return handleSwitchAccount(request, reply, provider);
   });
 
   // Registration routes (disabled in single-user mode)

--- a/src/idp/interactions.js
+++ b/src/idp/interactions.js
@@ -348,18 +348,21 @@ export async function handleSwitchAccount(request, reply, provider) {
     const ttl = Math.max(1, interaction.exp - Math.floor(Date.now() / 1000));
     await interaction.save(ttl);
 
-    // Clear the user-agent's session cookie too. Default oidc-provider
-    // cookie name is `_session`; the `.legacy` and `.sig` variants are
-    // created during identifier rotation. JSS doesn't register
-    // @fastify/cookie, so we emit Set-Cookie headers directly with an
-    // expired Expires + Max-Age=0 to instruct the UA to drop them.
-    // Server-side state is already gone via session.destroy() above —
-    // this is just to keep the browser tidy.
+    // Clear the user-agent's session cookie too. The IdP runs with
+    // signed cookies (provider.js cookies.long.signed = true), so each
+    // session cookie has a paired `.sig`. The `.legacy` variant is
+    // created during identifier rotation and likewise has its own
+    // `.sig`. Clearing all four keeps the browser fully tidy. JSS
+    // doesn't register @fastify/cookie, so we emit Set-Cookie headers
+    // directly with an expired Expires + Max-Age=0. Server-side state
+    // is already gone via session.destroy() above — these expirations
+    // are belt-and-suspenders.
     const expired = 'Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly';
     reply.header('Set-Cookie', [
       `_session=; ${expired}`,
-      `_session.legacy=; ${expired}`,
       `_session.sig=; ${expired}`,
+      `_session.legacy=; ${expired}`,
+      `_session.legacy.sig=; ${expired}`,
     ]);
 
     // 303 See Other — explicitly forces the UA to issue GET on the

--- a/src/idp/interactions.js
+++ b/src/idp/interactions.js
@@ -318,6 +318,13 @@ export async function handleSwitchAccount(request, reply, provider) {
       return reply.code(404).type('text/html').send(errorPage('Interaction not found', 'This interaction may have expired. Try signing in again from your app.'));
     }
 
+    // The UI entrypoint is the consent page only. Refusing on other
+    // prompt states (login, passkey, etc.) prevents a crafted request
+    // from corrupting an in-flight non-consent interaction.
+    if (interaction.prompt?.name !== 'consent') {
+      return reply.code(400).type('text/html').send(errorPage('Cannot switch account here', 'Account switching is only available from the consent page.'));
+    }
+
     // Destroy the bound session so the new login starts cold. The cookie
     // becomes a stale reference; oidc-provider's Session.get treats a
     // missing session blob as "new browser", which is the shape we want.
@@ -327,11 +334,15 @@ export async function handleSwitchAccount(request, reply, provider) {
     }
 
     // Reset the interaction back to the login prompt, dropping the
-    // session reference. `prompt` and `session` are both in the
-    // oidc-provider Interaction IN_PAYLOAD allowlist, so this persists
-    // through the adapter. Original `params` (client_id, redirect_uri,
-    // state, etc.) are untouched, so resume picks them up after login.
+    // session reference and any prior `result` snapshot. `prompt`,
+    // `session`, and `result` are all in the oidc-provider Interaction
+    // IN_PAYLOAD allowlist, so the mutations persist through the
+    // adapter. Original `params` (client_id, redirect_uri, state, etc.)
+    // are untouched, so resume picks them up after login. Clearing
+    // `result` prevents a stale `result.login` from a previous identity
+    // influencing the next resume.
     interaction.session = undefined;
+    interaction.result = undefined;
     interaction.prompt = { name: 'login', reasons: ['no_session'], details: {} };
     interaction.lastError = undefined;
     const ttl = Math.max(1, interaction.exp - Math.floor(Date.now() / 1000));
@@ -339,16 +350,25 @@ export async function handleSwitchAccount(request, reply, provider) {
 
     // Clear the user-agent's session cookie too. Default oidc-provider
     // cookie name is `_session`; the `.legacy` and `.sig` variants are
-    // created during identifier rotation. Clearing all of them is safe
-    // — server-side state is already gone via session.destroy().
-    reply.clearCookie('_session', { path: '/' });
-    reply.clearCookie('_session.legacy', { path: '/' });
-    reply.clearCookie('_session.sig', { path: '/' });
+    // created during identifier rotation. JSS doesn't register
+    // @fastify/cookie, so we emit Set-Cookie headers directly with an
+    // expired Expires + Max-Age=0 to instruct the UA to drop them.
+    // Server-side state is already gone via session.destroy() above —
+    // this is just to keep the browser tidy.
+    const expired = 'Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly';
+    reply.header('Set-Cookie', [
+      `_session=; ${expired}`,
+      `_session.legacy=; ${expired}`,
+      `_session.sig=; ${expired}`,
+    ]);
 
     return reply.redirect(`/idp/interaction/${uid}`);
   } catch (err) {
     request.log.error(err, 'Switch-account error');
-    return reply.code(500).type('text/html').send(errorPage('Error', err.message));
+    // Don't surface raw err.message — adapter errors and stack-leaking
+    // strings on an auth endpoint are a soft info-leak. Full error is
+    // already in the server log via request.log.error above.
+    return reply.code(500).type('text/html').send(errorPage('Error', 'Something went wrong. Please try signing in again.'));
   }
 }
 

--- a/src/idp/interactions.js
+++ b/src/idp/interactions.js
@@ -362,7 +362,10 @@ export async function handleSwitchAccount(request, reply, provider) {
       `_session.sig=; ${expired}`,
     ]);
 
-    return reply.redirect(`/idp/interaction/${uid}`);
+    // 303 See Other — explicitly forces the UA to issue GET on the
+    // Location target. 302 leaves it ambiguous (and some legacy UAs
+    // repeat the POST), which would re-trigger this handler in a loop.
+    return reply.redirect(`/idp/interaction/${uid}`, 303);
   } catch (err) {
     request.log.error(err, 'Switch-account error');
     // Don't surface raw err.message — adapter errors and stack-leaking

--- a/src/idp/interactions.js
+++ b/src/idp/interactions.js
@@ -298,6 +298,61 @@ export async function handleConsent(request, reply, provider) {
 }
 
 /**
+ * Handle POST /idp/interaction/:uid/switch
+ *
+ * "Sign in as a different user" from the consent page (#384). Destroys
+ * the current OIDC session, mutates the in-flight interaction back to
+ * the login prompt, and redirects the user to the same /idp/interaction
+ * URL — which `handleInteractionGet` will render as the login page.
+ *
+ * Re-using the same interaction uid (rather than starting a fresh
+ * /idp/auth flow) preserves the original authz request params so the
+ * caller's redirect_uri / state / nonce all flow through unchanged.
+ */
+export async function handleSwitchAccount(request, reply, provider) {
+  const { uid } = request.params;
+
+  try {
+    const interaction = await provider.Interaction.find(uid);
+    if (!interaction) {
+      return reply.code(404).type('text/html').send(errorPage('Interaction not found', 'This interaction may have expired. Try signing in again from your app.'));
+    }
+
+    // Destroy the bound session so the new login starts cold. The cookie
+    // becomes a stale reference; oidc-provider's Session.get treats a
+    // missing session blob as "new browser", which is the shape we want.
+    if (interaction.session?.uid) {
+      const sess = await provider.Session.findByUid(interaction.session.uid);
+      if (sess) await sess.destroy();
+    }
+
+    // Reset the interaction back to the login prompt, dropping the
+    // session reference. `prompt` and `session` are both in the
+    // oidc-provider Interaction IN_PAYLOAD allowlist, so this persists
+    // through the adapter. Original `params` (client_id, redirect_uri,
+    // state, etc.) are untouched, so resume picks them up after login.
+    interaction.session = undefined;
+    interaction.prompt = { name: 'login', reasons: ['no_session'], details: {} };
+    interaction.lastError = undefined;
+    const ttl = Math.max(1, interaction.exp - Math.floor(Date.now() / 1000));
+    await interaction.save(ttl);
+
+    // Clear the user-agent's session cookie too. Default oidc-provider
+    // cookie name is `_session`; the `.legacy` and `.sig` variants are
+    // created during identifier rotation. Clearing all of them is safe
+    // — server-side state is already gone via session.destroy().
+    reply.clearCookie('_session', { path: '/' });
+    reply.clearCookie('_session.legacy', { path: '/' });
+    reply.clearCookie('_session.sig', { path: '/' });
+
+    return reply.redirect(`/idp/interaction/${uid}`);
+  } catch (err) {
+    request.log.error(err, 'Switch-account error');
+    return reply.code(500).type('text/html').send(errorPage('Error', err.message));
+  }
+}
+
+/**
  * Handle POST /idp/interaction/:uid/abort
  * User cancelled the flow
  */

--- a/src/idp/interactions.js
+++ b/src/idp/interactions.js
@@ -368,7 +368,9 @@ export async function handleSwitchAccount(request, reply, provider) {
     // 303 See Other — explicitly forces the UA to issue GET on the
     // Location target. 302 leaves it ambiguous (and some legacy UAs
     // repeat the POST), which would re-trigger this handler in a loop.
-    return reply.redirect(`/idp/interaction/${uid}`, 303);
+    // Status-then-URL arg order matches the rest of the codebase
+    // (src/server.js:637, src/tunnel/index.js:222).
+    return reply.redirect(303, `/idp/interaction/${uid}`);
   } catch (err) {
     request.log.error(err, 'Switch-account error');
     // Don't surface raw err.message — adapter errors and stack-leaking

--- a/src/idp/views.js
+++ b/src/idp/views.js
@@ -503,7 +503,15 @@ export function consentPage(uid, client, params, account) {
       ${clientUri ? `<div class="client-uri">${escapeHtml(clientUri)}</div>` : ''}
     </div>
 
-    ${account ? `<p>Signed in as <strong>${escapeHtml(account.email)}</strong></p>` : ''}
+    ${account ? `
+      <p style="display: flex; align-items: center; justify-content: center; gap: 8px; flex-wrap: wrap;">
+        <span>Signed in as <strong>${escapeHtml(account.email)}</strong></span>
+        <span style="color: #94a3b8;">·</span>
+        <form method="POST" action="/idp/interaction/${uid}/switch" style="display: inline; margin: 0;">
+          <button type="submit" style="background: none; border: 0; padding: 0; color: #2563eb; font: inherit; cursor: pointer; text-decoration: underline;">Sign in as a different user</button>
+        </form>
+      </p>
+    ` : ''}
 
     <div class="scopes">
       <label>This app is requesting access to:</label>

--- a/src/idp/views.js
+++ b/src/idp/views.js
@@ -504,13 +504,13 @@ export function consentPage(uid, client, params, account) {
     </div>
 
     ${account ? `
-      <p style="display: flex; align-items: center; justify-content: center; gap: 8px; flex-wrap: wrap;">
+      <div style="display: flex; align-items: center; justify-content: center; gap: 8px; flex-wrap: wrap; margin: 12px 0;">
         <span>Signed in as <strong>${escapeHtml(account.email)}</strong></span>
         <span style="color: #94a3b8;">·</span>
         <form method="POST" action="/idp/interaction/${uid}/switch" style="display: inline; margin: 0;">
           <button type="submit" style="background: none; border: 0; padding: 0; color: #2563eb; font: inherit; cursor: pointer; text-decoration: underline;">Sign in as a different user</button>
         </form>
-      </p>
+      </div>
     ` : ''}
 
     <div class="scopes">

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -4,6 +4,7 @@
 
 import { describe, it, before, after, beforeEach } from 'node:test';
 import assert from 'node:assert';
+import http from 'node:http';
 import { createServer } from '../src/server.js';
 import fs from 'fs-extra';
 import path from 'path';
@@ -205,6 +206,33 @@ describe('Identity Provider', () => {
       return fs.outputJson(`${interactionDir}/${uid}.json`, data, { spaces: 2 });
     }
 
+    // Use node:http directly for the cookie-clearing assertion. fetch's
+    // Headers.getSetCookie() is only available on Node 19.7+, but the
+    // package declares engines.node >= 18. http.request gives us
+    // res.headers['set-cookie'] as a real array on every supported
+    // Node version, no version-gated branches needed.
+    function rawPost(urlString) {
+      return new Promise((resolve, reject) => {
+        const u = new URL(urlString);
+        const req = http.request({
+          method: 'POST',
+          hostname: u.hostname,
+          port: u.port,
+          path: u.pathname + u.search,
+        }, (res) => {
+          let body = '';
+          res.on('data', (c) => body += c);
+          res.on('end', () => resolve({
+            statusCode: res.statusCode,
+            headers: res.headers,
+            body,
+          }));
+        });
+        req.on('error', reject);
+        req.end();
+      });
+    }
+
     it('redirects back to /idp/interaction/:uid and resets the prompt to login', async () => {
       const uid = 'test-switch-' + Math.random().toString(36).slice(2);
       await writeInteraction(uid, {
@@ -213,15 +241,12 @@ describe('Identity Provider', () => {
         params: { client_id: 'test-client', redirect_uri: 'http://localhost', state: 'xyz' },
       });
 
-      const res = await fetch(`${baseUrl}/idp/interaction/${uid}/switch`, {
-        method: 'POST',
-        redirect: 'manual',
-      });
+      const res = await rawPost(`${baseUrl}/idp/interaction/${uid}/switch`);
 
       // 303 See Other — forces UA to GET the Location target so a
       // (broken) UA can't loop by re-POSTing to /switch.
-      assert.strictEqual(res.status, 303);
-      assert.strictEqual(res.headers.get('location'), `/idp/interaction/${uid}`);
+      assert.strictEqual(res.statusCode, 303);
+      assert.strictEqual(res.headers.location, `/idp/interaction/${uid}`);
 
       // Verify the interaction was mutated as expected.
       const saved = await fs.readJson(`${interactionDir}/${uid}.json`);
@@ -233,14 +258,9 @@ describe('Identity Provider', () => {
       assert.strictEqual(saved.params.state, 'xyz');
 
       // Cookies should be cleared so the user's UA forgets the prior
-      // session. Per the Fetch spec, Set-Cookie is a forbidden header
-      // name on .get(); use the array-returning getSetCookie() helper.
-      // Available on Node 19.7+ (we don't fall back silently — if the
-      // method is missing the test should fail loudly so we know to
-      // adjust rather than passing on an empty array).
-      assert.strictEqual(typeof res.headers.getSetCookie, 'function',
-        'Headers.getSetCookie() unavailable — needs Node 19.7+; bump engines.node or adjust this test');
-      const setCookies = res.headers.getSetCookie();
+      // session. Node's http module gives Set-Cookie as an array on
+      // every supported version, so no Node 19.7+ gating needed.
+      const setCookies = Array.isArray(res.headers['set-cookie']) ? res.headers['set-cookie'] : [];
       assert.ok(setCookies.length >= 4, `expected at least 4 Set-Cookie headers, got ${setCookies.length}`);
       // All four signed-cookie names should be cleared:
       // _session + _session.sig + _session.legacy + _session.legacy.sig.

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -182,6 +182,86 @@ describe('Identity Provider', () => {
     });
   });
 
+  // Regression coverage for #384 — "Sign in as a different user" on consent
+  describe('Switch account on consent (#384)', () => {
+    // The IDP's filesystem adapter stores Interaction records as JSON at
+    // <DATA_ROOT>/.idp/interaction/<uid>.json (model name "Interaction"
+    // → dir "interaction" via the adapter's modelToDir camelCase split).
+    // Tests write a synthetic interaction directly so we don't have to
+    // walk a full OIDC client flow to set up state.
+    const interactionDir = `${DATA_DIR}/.idp/interaction`;
+
+    function writeInteraction(uid, payload) {
+      const ttlSec = 3600;
+      const data = {
+        ...payload,
+        kind: 'Interaction',
+        jti: uid,
+        exp: Math.floor(Date.now() / 1000) + ttlSec,
+        iat: Math.floor(Date.now() / 1000),
+        _id: uid,
+        _expiresAt: Date.now() + ttlSec * 1000,
+      };
+      return fs.outputJson(`${interactionDir}/${uid}.json`, data, { spaces: 2 });
+    }
+
+    it('redirects back to /idp/interaction/:uid and resets the prompt to login', async () => {
+      const uid = 'test-switch-' + Math.random().toString(36).slice(2);
+      await writeInteraction(uid, {
+        prompt: { name: 'consent', reasons: [], details: {} },
+        session: { uid: 'fake-session-uid', accountId: 'acct-foo' },
+        params: { client_id: 'test-client', redirect_uri: 'http://localhost', state: 'xyz' },
+      });
+
+      const res = await fetch(`${baseUrl}/idp/interaction/${uid}/switch`, {
+        method: 'POST',
+        redirect: 'manual',
+      });
+
+      assert.strictEqual(res.status, 302);
+      assert.strictEqual(res.headers.get('location'), `/idp/interaction/${uid}`);
+
+      // Verify the interaction was mutated as expected.
+      const saved = await fs.readJson(`${interactionDir}/${uid}.json`);
+      assert.strictEqual(saved.prompt.name, 'login');
+      assert.ok(saved.session === undefined || saved.session === null,
+        'session should be cleared');
+      // Original params survive so resume can continue the authz request.
+      assert.strictEqual(saved.params.client_id, 'test-client');
+      assert.strictEqual(saved.params.state, 'xyz');
+
+      // Cookies should be cleared so the user's UA forgets the prior session.
+      const setCookie = res.headers.get('set-cookie') || '';
+      assert.match(setCookie, /_session/);
+    });
+
+    it('returns 400 when the interaction is not on the consent prompt', async () => {
+      const uid = 'test-switch-bad-' + Math.random().toString(36).slice(2);
+      await writeInteraction(uid, {
+        prompt: { name: 'login', reasons: ['no_session'], details: {} },
+        params: { client_id: 'test-client' },
+      });
+
+      const res = await fetch(`${baseUrl}/idp/interaction/${uid}/switch`, {
+        method: 'POST',
+        redirect: 'manual',
+      });
+
+      assert.strictEqual(res.status, 400);
+      // Original interaction should be untouched.
+      const saved = await fs.readJson(`${interactionDir}/${uid}.json`);
+      assert.strictEqual(saved.prompt.name, 'login');
+    });
+
+    it('returns 404 for an unknown interaction uid', async () => {
+      const res = await fetch(`${baseUrl}/idp/interaction/does-not-exist-${Date.now()}/switch`, {
+        method: 'POST',
+        redirect: 'manual',
+      });
+      assert.strictEqual(res.status, 404);
+    });
+  });
+
   // Regression coverage for #286 — friendly /idp landing + /idp/auth guard.
   describe('Landing page', () => {
     it('GET /idp returns the landing HTML', async () => {

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -235,7 +235,12 @@ describe('Identity Provider', () => {
       // Cookies should be cleared so the user's UA forgets the prior
       // session. Per the Fetch spec, Set-Cookie is a forbidden header
       // name on .get(); use the array-returning getSetCookie() helper.
-      const setCookies = res.headers.getSetCookie?.() || [];
+      // Available on Node 19.7+ (we don't fall back silently — if the
+      // method is missing the test should fail loudly so we know to
+      // adjust rather than passing on an empty array).
+      assert.strictEqual(typeof res.headers.getSetCookie, 'function',
+        'Headers.getSetCookie() unavailable — needs Node 19.7+; bump engines.node or adjust this test');
+      const setCookies = res.headers.getSetCookie();
       assert.ok(setCookies.length >= 4, `expected at least 4 Set-Cookie headers, got ${setCookies.length}`);
       // All four signed-cookie names should be cleared:
       // _session + _session.sig + _session.legacy + _session.legacy.sig.

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -218,7 +218,9 @@ describe('Identity Provider', () => {
         redirect: 'manual',
       });
 
-      assert.strictEqual(res.status, 302);
+      // 303 See Other — forces UA to GET the Location target so a
+      // (broken) UA can't loop by re-POSTing to /switch.
+      assert.strictEqual(res.status, 303);
       assert.strictEqual(res.headers.get('location'), `/idp/interaction/${uid}`);
 
       // Verify the interaction was mutated as expected.
@@ -230,9 +232,14 @@ describe('Identity Provider', () => {
       assert.strictEqual(saved.params.client_id, 'test-client');
       assert.strictEqual(saved.params.state, 'xyz');
 
-      // Cookies should be cleared so the user's UA forgets the prior session.
-      const setCookie = res.headers.get('set-cookie') || '';
-      assert.match(setCookie, /_session/);
+      // Cookies should be cleared so the user's UA forgets the prior
+      // session. Per the Fetch spec, Set-Cookie is a forbidden header
+      // name on .get(); use the array-returning getSetCookie() helper.
+      const setCookies = res.headers.getSetCookie?.() || [];
+      assert.ok(setCookies.length >= 3, `expected at least 3 Set-Cookie headers, got ${setCookies.length}`);
+      assert.ok(setCookies.some(c => c.startsWith('_session=')), 'should clear _session');
+      assert.ok(setCookies.every(c => /Max-Age=0|Expires=Thu, 01 Jan 1970/.test(c)),
+        'all Set-Cookies should be expirations');
     });
 
     it('returns 400 when the interaction is not on the consent prompt', async () => {

--- a/test/idp.test.js
+++ b/test/idp.test.js
@@ -236,8 +236,13 @@ describe('Identity Provider', () => {
       // session. Per the Fetch spec, Set-Cookie is a forbidden header
       // name on .get(); use the array-returning getSetCookie() helper.
       const setCookies = res.headers.getSetCookie?.() || [];
-      assert.ok(setCookies.length >= 3, `expected at least 3 Set-Cookie headers, got ${setCookies.length}`);
-      assert.ok(setCookies.some(c => c.startsWith('_session=')), 'should clear _session');
+      assert.ok(setCookies.length >= 4, `expected at least 4 Set-Cookie headers, got ${setCookies.length}`);
+      // All four signed-cookie names should be cleared:
+      // _session + _session.sig + _session.legacy + _session.legacy.sig.
+      for (const name of ['_session=', '_session.sig=', '_session.legacy=', '_session.legacy.sig=']) {
+        assert.ok(setCookies.some(c => c.startsWith(name)),
+          `should clear ${name.slice(0, -1)}`);
+      }
       assert.ok(setCookies.every(c => /Max-Age=0|Expires=Thu, 01 Jan 1970/.test(c)),
         'all Set-Cookies should be expirations');
     });


### PR DESCRIPTION
Closes #384.

## What this does

When a user lands on the OIDC **Authorize Access** consent page (`/idp/interaction/<uid>` with `prompt.name === 'consent'`), there's now a small "Sign in as a different user" link next to the "Signed in as <email>" line. Clicking it:

1. Looks up the in-flight Interaction by uid
2. Destroys the oidc-provider Session via `provider.Session.findByUid(...).destroy()`
3. Mutates the interaction's `prompt` back to `{ name: 'login' }` and drops the `session` reference (`prompt` and `session` are both in Interaction's `IN_PAYLOAD`, so the mutation persists)
4. Clears the user-agent's `_session` / `_session.legacy` / `_session.sig` cookies
5. Redirects back to `/idp/interaction/<uid>` — `handleInteractionGet` now sees `prompt.name === 'login'` and renders the login page
6. After successful login, the standard resume flow at `/idp/auth/<uid>` picks up the original authz params (state, nonce, PKCE challenge, redirect_uri) untouched

Re-using the same interaction `uid` (rather than aborting and issuing a fresh `/idp/auth`) preserves the requesting app's flow — its `state` / `redirect_uri` / etc. survive the identity switch, and we don't risk `loadExistingGrant` silently auto-approving from another stale grant.

## Files changed (~72 insertions across 3)

| File | Change |
|---|---|
| `src/idp/interactions.js` | New `handleSwitchAccount()` (~50 LOC including doc + error handling) |
| `src/idp/index.js` | Import + register `POST /idp/interaction/:uid/switch` (~7 LOC) |
| `src/idp/views.js` | Add the link inside the "Signed in as <email>" paragraph in `consentPage` (~10 LOC, inline-styled to keep all changes in one file) |

## Local verification

- `npm test -- idp.test.js` → **48 / 48 pass**, no regressions
- Boot smoke test on a single-user pod (`--idp`):
  - `POST /idp/interaction/nonexistent/switch` → **404** (cleaner than abort's 500 on the same input)
  - `/idp` landing renders 200, no boot-time errors
- Static analysis of the oidc-provider 9.6 internals:
  - `Session.findByUid` + `.destroy()` — confirmed at `node_modules/oidc-provider/lib/models/session.js:41,112`
  - `IN_PAYLOAD` contains `prompt` and `session` — `node_modules/oidc-provider/lib/models/interaction.js:60-72`
  - Resume action only checks `result.login.accountId`, doesn't re-validate prompts — `lib/actions/authorization/resume.js:94-104`

## Out of scope / possible follow-ups

- **CSRF tokens** on the consent forms. The new switch button matches the existing confirm/abort threat model — the interaction `uid` is the unguessable token. A CSRF audit across all three forms could be a follow-up.
- **Multi-account picker** (vs a hard switch) for users with several stored sessions. v2 territory.

## Test plan
- [ ] `npm test` passes in CI
- [ ] Walk a real OIDC client (e.g. `pilot` from the IDP landing) through: login as user A → consent page renders → click "Sign in as a different user" → login form appears → log in as user B → consent page now shows user B's email → Allow → app receives auth code bound to user B
- [ ] After "Sign in as a different user", browser cookies for `_session*` are cleared

## Refs
- `node_modules/oidc-provider/lib/models/session.js`
- `node_modules/oidc-provider/lib/models/interaction.js`
- `node_modules/oidc-provider/lib/actions/authorization/resume.js`
- `src/idp/interactions.js` (handleAbort handler — same shape as the new handler)