### PR TITLE
profile: emit CID v1 controller + prep verificationMethod context (#386 Phase A)

### DIFF
--- a/src/webid/profile.js
+++ b/src/webid/profile.js
@@ -31,6 +31,12 @@ export function generateProfileJsonLd({ webId, name, podUri, issuer }) {
   const docUrl = webId.split('#')[0];
 
   return {
+    // CID v1 vocabulary is declared inline (rather than via an imported
+    // context URL) so JSS's JSON-LD → Turtle conneg layer can expand
+    // every term without fetching external contexts. Semantically
+    // equivalent to importing https://www.w3.org/ns/cid/v1: the IRIs
+    // each term expands to are the same. This keeps the profile a valid
+    // W3C Controlled Identifier document per LWS 1.0 (#386 Phase A).
     '@context': {
       'foaf': FOAF,
       'solid': SOLID,
@@ -48,13 +54,28 @@ export function generateProfileJsonLd({ webId, name, podUri, issuer }) {
       'isPrimaryTopicOf': { '@id': 'foaf:isPrimaryTopicOf', '@type': '@id' },
       'mainEntityOfPage': { '@id': 'schema:mainEntityOfPage', '@type': '@id' },
       'service': { '@id': 'cid:service', '@container': '@set' },
-      'serviceEndpoint': { '@id': 'cid:serviceEndpoint', '@type': '@id' }
+      'serviceEndpoint': { '@id': 'cid:serviceEndpoint', '@type': '@id' },
+      // CID v1 terms used by Phase A and prepped for Phase B (the
+      // standalone "add my keys" app). Declaring these now means the
+      // app can PATCH in verificationMethod entries without having to
+      // also rewrite the @context.
+      'controller':         { '@id': 'cid:controller', '@type': '@id' },
+      'verificationMethod': { '@id': 'cid:verificationMethod', '@type': '@id' },
+      'authentication':     { '@id': 'cid:authentication', '@type': '@id' },
+      'assertionMethod':    { '@id': 'cid:assertionMethod', '@type': '@id' },
+      'publicKeyJwk':       { '@id': 'cid:publicKeyJwk' },
+      'publicKeyMultibase': { '@id': 'cid:publicKeyMultibase' }
     },
     '@id': webId,
     '@type': ['foaf:Person', 'schema:Person'],
     'foaf:name': name,
     'isPrimaryTopicOf': '',
     'mainEntityOfPage': '',
+    // CID v1 self-control: the WebID is its own controller. Phase A of
+    // #386 ships this triple even with no verificationMethods yet, so a
+    // future Phase B "add-keys" app PATCHing in verificationMethod
+    // entries doesn't have to also wire up controllership separately.
+    'controller': webId,
     'inbox': `${pod}inbox/`,
     'storage': pod,
     'oidcIssuer': issuer,

--- a/src/webid/profile.js
+++ b/src/webid/profile.js
@@ -59,11 +59,22 @@ export function generateProfileJsonLd({ webId, name, podUri, issuer }) {
       // standalone "add my keys" app). Declaring these now means the
       // app can PATCH in verificationMethod entries without having to
       // also rewrite the @context.
+      //
+      // verificationMethod: NO @type:@id — values are inline verification
+      //   method *objects* (id/type/controller/publicKey…), not just IRI
+      //   references. @container:@set so a single entry stays an array.
+      // authentication / assertionMethod: @type:@id — values reference a
+      //   verificationMethod entry by its IRI. @container:@set for arrays.
+      // publicKeyJwk: @type:@json so the JWK object round-trips as a
+      //   literal JSON value (rdf:JSON datatype). Note: JSS's Turtle
+      //   conneg layer doesn't yet emit @type:@json literals (tracked as
+      //   a Phase B blocker in the PR description); declaring here is
+      //   forward-looking and spec-correct.
       'controller':         { '@id': 'cid:controller', '@type': '@id' },
-      'verificationMethod': { '@id': 'cid:verificationMethod', '@type': '@id' },
-      'authentication':     { '@id': 'cid:authentication', '@type': '@id' },
-      'assertionMethod':    { '@id': 'cid:assertionMethod', '@type': '@id' },
-      'publicKeyJwk':       { '@id': 'cid:publicKeyJwk' },
+      'verificationMethod': { '@id': 'cid:verificationMethod', '@container': '@set' },
+      'authentication':     { '@id': 'cid:authentication', '@type': '@id', '@container': '@set' },
+      'assertionMethod':    { '@id': 'cid:assertionMethod', '@type': '@id', '@container': '@set' },
+      'publicKeyJwk':       { '@id': 'cid:publicKeyJwk', '@type': '@json' },
       'publicKeyMultibase': { '@id': 'cid:publicKeyMultibase' }
     },
     '@id': webId,

--- a/test/webid.test.js
+++ b/test/webid.test.js
@@ -47,6 +47,37 @@ describe('WebID Profile', () => {
       assert.ok(jsonLd['@id'], 'Should have @id');
     });
 
+    // LWS-CID document conformance, Phase A of #386. The profile must be
+    // structurally a W3C Controlled Identifier document so a future
+    // PATCH-in-keys app (or server migration) can drop verificationMethod
+    // entries in without further plumbing. CID v1 vocabulary is declared
+    // inline rather than via context URL so JSS's conneg layer can
+    // expand every term without fetching external contexts — the IRIs
+    // are the same either way.
+    it('declares CID v1 terms in @context (#386 Phase A)', async () => {
+      const res = await request(profilePath);
+      const jsonLd = await res.json();
+      const ctx = jsonLd['@context'];
+      assert.ok(ctx, '@context required');
+      // Both 'controller' and 'verificationMethod' must expand to the
+      // CID v1 namespace. Inline form: '@id': 'cid:controller' or
+      // '@id': 'https://www.w3.org/ns/cid/v1#controller'.
+      const controllerMapping = ctx.controller;
+      assert.ok(controllerMapping, '@context must define `controller`');
+      const id = typeof controllerMapping === 'string' ? controllerMapping : controllerMapping['@id'];
+      assert.match(id, /^(cid:controller|https:\/\/www\.w3\.org\/ns\/cid\/v1#controller)$/,
+        'controller must map to the CID v1 namespace');
+      assert.ok(ctx.verificationMethod, '@context must define `verificationMethod` for Phase B');
+      assert.ok(ctx.authentication, '@context must define `authentication` for Phase B');
+    });
+
+    it('declares self-control via controller === @id (#386 Phase A)', async () => {
+      const res = await request(profilePath);
+      const jsonLd = await res.json();
+      assert.strictEqual(jsonLd.controller, jsonLd['@id'],
+        'profile must declare itself as its own controller per CID v1');
+    });
+
     it('should have correct WebID URI', async () => {
       const res = await request(profilePath);
       const jsonLd = await res.json();

--- a/test/webid.test.js
+++ b/test/webid.test.js
@@ -54,21 +54,37 @@ describe('WebID Profile', () => {
     // inline rather than via context URL so JSS's conneg layer can
     // expand every term without fetching external contexts — the IRIs
     // are the same either way.
-    it('declares CID v1 terms in @context (#386 Phase A)', async () => {
+    it('declares all six CID v1 terms in @context (#386 Phase A)', async () => {
       const res = await request(profilePath);
       const jsonLd = await res.json();
       const ctx = jsonLd['@context'];
       assert.ok(ctx, '@context required');
-      // Both 'controller' and 'verificationMethod' must expand to the
-      // CID v1 namespace. Inline form: '@id': 'cid:controller' or
-      // '@id': 'https://www.w3.org/ns/cid/v1#controller'.
-      const controllerMapping = ctx.controller;
-      assert.ok(controllerMapping, '@context must define `controller`');
-      const id = typeof controllerMapping === 'string' ? controllerMapping : controllerMapping['@id'];
-      assert.match(id, /^(cid:controller|https:\/\/www\.w3\.org\/ns\/cid\/v1#controller)$/,
-        'controller must map to the CID v1 namespace');
-      assert.ok(ctx.verificationMethod, '@context must define `verificationMethod` for Phase B');
-      assert.ok(ctx.authentication, '@context must define `authentication` for Phase B');
+
+      // All six CID terms must be declared and expand to the CID v1
+      // namespace. Accept either prefixed (cid:term) or full-URI
+      // (https://www.w3.org/ns/cid/v1#term) form.
+      const cidTerms = ['controller', 'verificationMethod', 'authentication', 'assertionMethod', 'publicKeyJwk', 'publicKeyMultibase'];
+      for (const term of cidTerms) {
+        const mapping = ctx[term];
+        assert.ok(mapping, `@context must define \`${term}\``);
+        const id = typeof mapping === 'string' ? mapping : mapping['@id'];
+        assert.match(id, new RegExp(`^(cid:${term}|https://www\\.w3\\.org/ns/cid/v1#${term})$`),
+          `${term} must map to the CID v1 namespace`);
+      }
+
+      // Container/type flags Phase B relies on:
+      // verificationMethod values are inline objects, NOT IRIs — must
+      //   NOT have @type:@id (would force string-only) and SHOULD have
+      //   @container:@set so a single entry is still an array.
+      assert.notStrictEqual(ctx.verificationMethod['@type'], '@id',
+        'verificationMethod values are objects, not IRIs');
+      assert.strictEqual(ctx.verificationMethod['@container'], '@set');
+      // authentication / assertionMethod reference verificationMethod
+      // entries by IRI, so @type:@id is correct.
+      assert.strictEqual(ctx.authentication['@type'], '@id');
+      assert.strictEqual(ctx.assertionMethod['@type'], '@id');
+      // JWK is a literal JSON value (rdf:JSON datatype) per JSON-LD 1.1.
+      assert.strictEqual(ctx.publicKeyJwk['@type'], '@json');
     });
 
     it('declares self-control via controller === @id (#386 Phase A)', async () => {


### PR DESCRIPTION
Closes #387. First phase of #386.

## Summary
- New pod profiles now declare `controller: <webId>` per W3C CID v1's self-control contract.
- `@context` extended with the six CID v1 terms (`controller`, `verificationMethod`, `authentication`, `assertionMethod`, `publicKeyJwk`, `publicKeyMultibase`) so a standalone Phase B "add-keys" app can PATCH in `verificationMethod` entries without touching the context.
- Declared inline rather than via the `https://www.w3.org/ns/cid/v1` imported-context URL, because JSS's JSON-LD → Turtle conneg layer can't resolve external context URLs (caught by the `#320` Turtle conformance test). The IRIs each term expands to are identical either way.

## Out of scope (deferred)
- No `verificationMethod` data emitted yet — Phase B (a separate standalone app) populates per-user keys via PATCH after the user authenticates.
- No migration of existing pods — they keep their current profiles until a user opts in via Phase B.
- No verifier-side changes — that's #386 Phase 3.

## Files
- `src/webid/profile.js` — +21 lines (add `controller` triple + 6 CID v1 context entries)
- `test/webid.test.js` — +24 lines (two new assertions: context defines CID terms; `controller === @id`)

## Verification
- 619/619 tests pass (full suite — `npm test`)
- 17/17 webid tests pass
- Turtle conneg test (#320) regression-free — `controller` predicate, when emitted alongside the existing `oidcIssuer`/`storage`/`inbox` predicates, expands correctly through the JSON-LD → Turtle path

## Test plan
- [ ] CI green
- [ ] Create a new pod against the branch; `curl -H 'Accept: application/ld+json' <pod>/profile/card.jsonld` shows `controller` field equal to the WebID
- [ ] Same `curl` with `Accept: text/turtle` shows the `cid:controller` predicate (or expanded full URI form)
- [ ] Existing pod profiles fetched (e.g. `https://melvin.solid.social/profile/card.jsonld`) are unchanged — only NEW pod creation triggers the new shape

## Refs
- #386 — overall LWS profile-to-key linking tracker
- #319 — LWS 1.0 Authentication Suite alignment
- [W3C CID v1.0](https://www.w3.org/TR/cid-1.0/)
- [LWS 1.0 SSI via CID (FPWD)](https://www.w3.org/TR/2026/WD-lws10-authn-ssi-cid-20260423/)