### PR TITLE
idp: HTML form for self-service account deletion (#392)

### DIFF
--- a/src/idp/credentials.js
+++ b/src/idp/credentials.js
@@ -408,6 +408,14 @@ async function deleteAccountAndOptionallyPurge(request, account, purgeData) {
         request.log.error({ err, path: candidate, username: account.username },
           'Pod data purge failed after account deletion');
       }
+    } else {
+      // Belt-and-suspenders rejection — shouldn't trigger on registered
+      // pod names but logging it surfaces config drift (e.g. someone
+      // changed dataRoot, podName field is malformed, etc.) and makes
+      // the "purge did not complete" UX message diagnosable from the
+      // operator's logs without leaking the path to the client.
+      request.log.warn({ path: candidate, dataRoot: root, podName: account.podName, username: account.username },
+        'Pod data purge skipped: candidate path is not a proper child of dataRoot');
     }
   }
   return { purged };
@@ -484,10 +492,14 @@ export async function handleAccountDeleteForm(request, reply, options = {}) {
     }));
   }
 
-  // Destructive-action UX guard: typed username must match. Compare
-  // case-sensitively against the *typed* form value, not the resolved
-  // account — the user shouldn't be able to typo their way to a delete
-  // that hits a different (lowercased) record.
+  // Destructive-action UX guard: the user must type the same string
+  // twice. The string-equality check is case-sensitive on the typed
+  // form values; that's purely the typing-it-again confirmation
+  // pattern (catch typos / accidental submits). Note: findByUsername()
+  // lowercases internally, so "Alice" + "Alice" both resolve to the
+  // same account record as "alice" — the case-sensitive comparison
+  // here doesn't gate which record gets deleted, only whether the
+  // user typed the same thing twice.
   if (username !== confirmUsername) {
     return reply.type('text/html').send(accountDeletePage({
       error: 'Confirmation does not match the username you entered.',

--- a/src/idp/credentials.js
+++ b/src/idp/credentials.js
@@ -10,6 +10,7 @@ import path from 'path';
 import { authenticate, findByWebId, updatePassword, verifyPassword, deleteAccount } from './accounts.js';
 import { getJwks } from './keys.js';
 import { getWebIdFromRequestAsync } from '../auth/token.js';
+import { accountDeletePage } from './views.js';
 
 /**
  * Handle POST /idp/credentials
@@ -414,6 +415,121 @@ export async function handleDeleteAccount(request, reply, options = {}) {
     webid: account.webId,
     purged,
   };
+}
+
+/**
+ * Internal: delete an account record + optional pod-data purge.
+ * Shared between the JSON endpoint (handleDeleteAccount) and the
+ * form-driven endpoint (handleAccountDeletePost in #392).
+ *
+ * Best-effort purge — fs.remove can throw, but the account is already
+ * gone and we want a clean signal rather than a 500. Path is derived
+ * from account.podName (NOT username, which createAccount lowercases —
+ * pod dir on disk is original case, see #391 pass 2). Belt-and-
+ * suspenders path-relative check rejects ../traversal and works at FS
+ * roots (see #391 pass 3).
+ *
+ * @param {object} request - Fastify request, used only for log access
+ * @param {object} account - Account record (with username, podName, webId)
+ * @param {boolean} purgeData - If true, also remove the pod's filesystem tree
+ * @returns {Promise<{purged: boolean}>}
+ */
+async function deleteAccountAndOptionallyPurge(request, account, purgeData) {
+  await deleteAccount(account.id);
+
+  let purged = false;
+  if (purgeData) {
+    const dataRoot = process.env.DATA_ROOT || './data';
+    const candidate = path.resolve(dataRoot, account.podName || account.username);
+    const root = path.resolve(dataRoot);
+    const rel = path.relative(root, candidate);
+    const isProperChild = rel && rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+    if (isProperChild) {
+      try {
+        await fs.remove(candidate);
+        purged = true;
+      } catch (err) {
+        request.log.error({ err, path: candidate, username: account.username },
+          'Pod data purge failed after account deletion');
+      }
+    }
+  }
+  return { purged };
+}
+
+/**
+ * Handle POST /idp/account/delete (#392) — form-driven account deletion.
+ *
+ * Public unauthenticated endpoint that takes a form-encoded body with
+ * username + currentPassword + confirmUsername (+ optional purgeData
+ * checkbox). Authenticates the user via password directly (no Bearer
+ * token round-trip required), validates the destructive-action UX
+ * guard, then calls into the same deleteAccount logic as the JSON
+ * endpoint. Returns HTML — success page on completion, redirect back
+ * to the GET form with an error message on failure.
+ *
+ * Single-user mode: redirects to GET which renders the disabled
+ * message instead of the form. Same policy as the JSON endpoint.
+ *
+ * @param {object} request - Fastify request
+ * @param {object} reply - Fastify reply
+ * @param {object} options
+ * @param {boolean} [options.singleUser] - Single-user mode flag
+ */
+export async function handleAccountDeleteForm(request, reply, options = {}) {
+  if (options.singleUser) {
+    return reply.type('text/html').send(accountDeletePage({ singleUser: true }));
+  }
+
+  // Parse form-encoded body. Fastify with @fastify/formbody (registered
+  // for /idp/register etc.) puts fields directly on request.body.
+  let body = request.body;
+  if (Buffer.isBuffer(body)) body = body.toString('utf-8');
+  if (typeof body === 'string') {
+    // Manual urlencoded parse fallback if formbody isn't registered for
+    // this content-type on this route.
+    try {
+      const params = new URLSearchParams(body);
+      body = Object.fromEntries(params);
+    } catch { body = {}; }
+  }
+
+  const username = (body?.username || '').trim();
+  const currentPassword = body?.currentPassword || '';
+  const confirmUsername = (body?.confirmUsername || '').trim();
+  const purgeData = body?.purgeData === 'on' || body?.purgeData === true;
+
+  if (!username || !currentPassword || !confirmUsername) {
+    return reply.type('text/html').send(accountDeletePage({
+      error: 'All fields are required.',
+      username,
+    }));
+  }
+
+  // Destructive-action UX guard: typed username must match. Compare
+  // case-sensitively against the *typed* form value, not the resolved
+  // account — the user shouldn't be able to typo their way to a delete
+  // that hits a different (lowercased) record.
+  if (username !== confirmUsername) {
+    return reply.type('text/html').send(accountDeletePage({
+      error: 'Confirmation does not match the username you entered.',
+      username,
+    }));
+  }
+
+  // Authenticate. authenticate() looks up by username then by email,
+  // verifies bcrypt, and returns the account (sans password hash) or null.
+  const account = await authenticate(username, currentPassword);
+  if (!account) {
+    return reply.type('text/html').send(accountDeletePage({
+      error: 'Username or password is incorrect.',
+      username,
+    }));
+  }
+
+  await deleteAccountAndOptionallyPurge(request, account, purgeData);
+
+  return reply.type('text/html').send(accountDeletePage({ success: true }));
 }
 
 /**

--- a/src/idp/credentials.js
+++ b/src/idp/credentials.js
@@ -414,7 +414,7 @@ async function deleteAccountAndOptionallyPurge(request, account, purgeData) {
 }
 
 /**
- * Handle GET / POST /idp/account/delete (#392) — form-driven account deletion.
+ * Handle POST /idp/account/delete (#392) — form-driven account deletion.
  *
  * Public unauthenticated endpoint that takes a form-encoded body with
  * username + currentPassword + confirmUsername (+ optional purgeData
@@ -427,9 +427,13 @@ async function deleteAccountAndOptionallyPurge(request, account, purgeData) {
  *     username field pre-filled (no redirect — single response, status
  *     200 with the rendered form)
  *
- * Single-user mode: rendered as the disabled-message page instead of
- * the form, both on GET and POST. Same policy as the JSON endpoint
- * (which 403s with the equivalent message).
+ * GET /idp/account/delete is a separate route that just renders the
+ * form via accountDeletePage(); see src/idp/index.js. This handler is
+ * POST-only.
+ *
+ * Single-user mode: this handler short-circuits to the disabled-message
+ * page (matches the GET route's behavior). Same policy as the JSON
+ * endpoint, which 403s with the equivalent message.
  *
  * @param {object} request - Fastify request
  * @param {object} reply - Fastify reply

--- a/src/idp/credentials.js
+++ b/src/idp/credentials.js
@@ -445,13 +445,15 @@ export async function handleAccountDeleteForm(request, reply, options = {}) {
     return reply.type('text/html').send(accountDeletePage({ singleUser: true }));
   }
 
-  // Parse form-encoded body. Fastify with @fastify/formbody (registered
-  // for /idp/register etc.) puts fields directly on request.body.
+  // Parse form-encoded body. JSS registers a wildcard parseAs:'buffer'
+  // content parser (server.js:190), so request.body arrives here as a
+  // Buffer. We coerce to a string and parse the application/x-www-form-
+  // urlencoded shape via URLSearchParams. (No @fastify/formbody is
+  // installed; doing it inline keeps this self-contained and matches
+  // what handleChangePassword does for JSON.)
   let body = request.body;
   if (Buffer.isBuffer(body)) body = body.toString('utf-8');
   if (typeof body === 'string') {
-    // Manual urlencoded parse fallback if formbody isn't registered for
-    // this content-type on this route.
     try {
       const params = new URLSearchParams(body);
       body = Object.fromEntries(params);

--- a/src/idp/credentials.js
+++ b/src/idp/credentials.js
@@ -374,6 +374,26 @@ export async function handleDeleteAccount(request, reply, options = {}) {
 }
 
 /**
+ * Apply anti-clickjacking + no-store cache headers to a response.
+ * Used on every account-deletion HTML response (form, success, error
+ * re-render, disabled-message page) and on the corresponding routes.
+ *
+ *  - Cache-Control: no-store  — destructive form/success page should
+ *    never sit in a shared cache; if a token gets shared via the URL
+ *    the browser shouldn't replay the action from cache either.
+ *  - X-Frame-Options + frame-ancestors — block clickjacking.
+ *    Embedding this form in a hostile iframe and tricking a user into
+ *    submitting a captured action is exactly the threat shape these
+ *    headers exist to mitigate.
+ */
+export function setNoCacheClickjackHeaders(reply) {
+  reply.header('Cache-Control', 'no-store');
+  reply.header('Pragma', 'no-cache');
+  reply.header('X-Frame-Options', 'DENY');
+  reply.header('Content-Security-Policy', "frame-ancestors 'none'");
+}
+
+/**
  * Internal: delete an account record + optional pod-data purge.
  * Shared between the JSON endpoint (handleDeleteAccount) and the
  * form-driven endpoint (handleAccountDeleteForm in #392).
@@ -451,6 +471,10 @@ async function deleteAccountAndOptionallyPurge(request, account, purgeData) {
  * @param {boolean} [options.singleUser] - Single-user mode flag
  */
 export async function handleAccountDeleteForm(request, reply, options = {}) {
+  // Every response from this handler is a destructive-action surface
+  // that re-takes the user's password — never cache, never embed.
+  setNoCacheClickjackHeaders(reply);
+
   if (options.singleUser) {
     // 403 matches the GET route, /idp/register's disabled-route policy,
     // and the JSON DELETE endpoint's 403 — consistent status across

--- a/src/idp/credentials.js
+++ b/src/idp/credentials.js
@@ -7,7 +7,7 @@ import * as jose from 'jose';
 import crypto from 'crypto';
 import fs from 'fs-extra';
 import path from 'path';
-import { authenticate, findByWebId, updatePassword, verifyPassword, deleteAccount } from './accounts.js';
+import { authenticate, findByUsername, findByWebId, updatePassword, verifyPassword, deleteAccount } from './accounts.js';
 import { getJwks } from './keys.js';
 import { getWebIdFromRequestAsync } from '../auth/token.js';
 import { accountDeletePage } from './views.js';
@@ -417,11 +417,13 @@ async function deleteAccountAndOptionallyPurge(request, account, purgeData) {
  * Handle POST /idp/account/delete (#392) — form-driven account deletion.
  *
  * Public unauthenticated endpoint that takes a form-encoded body with
- * username + currentPassword + confirmUsername (+ optional purgeData
- * checkbox). Authenticates the user via password directly (no Bearer
- * token round-trip required), validates the destructive-action UX
- * guard, then calls into the same delete logic as the JSON endpoint
- * via deleteAccountAndOptionallyPurge. Returns HTML directly:
+ * username + currentPassword + confirmUsername (+ optional keepData
+ * opt-out checkbox; default behavior is purge-on for the leaving-user
+ * UX, opposite the JSON endpoint's purge-off default). Authenticates
+ * the user via password directly (no Bearer token round-trip), validates
+ * the destructive-action UX guard, then calls into the same delete
+ * logic as the JSON endpoint via deleteAccountAndOptionallyPurge.
+ * Returns HTML directly:
  *   - success → success page
  *   - any failure → the form re-rendered with an error message and the
  *     username field pre-filled (no redirect — single response, status
@@ -442,7 +444,10 @@ async function deleteAccountAndOptionallyPurge(request, account, purgeData) {
  */
 export async function handleAccountDeleteForm(request, reply, options = {}) {
   if (options.singleUser) {
-    return reply.type('text/html').send(accountDeletePage({ singleUser: true }));
+    // 403 matches the GET route, /idp/register's disabled-route policy,
+    // and the JSON DELETE endpoint's 403 — consistent status across
+    // every disabled-in-single-user surface.
+    return reply.code(403).type('text/html').send(accountDeletePage({ singleUser: true }));
   }
 
   // Parse form-encoded body. JSS registers a wildcard parseAs:'buffer'
@@ -463,7 +468,14 @@ export async function handleAccountDeleteForm(request, reply, options = {}) {
   const username = (body?.username || '').trim();
   const currentPassword = body?.currentPassword || '';
   const confirmUsername = (body?.confirmUsername || '').trim();
-  const purgeData = body?.purgeData === 'on' || body?.purgeData === true;
+  // Form field is `keepData` (inverse of the JSON endpoint's `purgeData`)
+  // so the form's default is purge-on: a user who is leaving the server
+  // probably wants their files gone too. Checking "Keep my pod data" is
+  // the opt-out. JSON endpoint (DELETE /idp/account) keeps the
+  // explicit `purgeData` shape that matches the CLI's default-off
+  // semantics for operator scripts; the form intentionally diverges.
+  const keepData = body?.keepData === 'on' || body?.keepData === true;
+  const purgeData = !keepData;
 
   if (!username || !currentPassword || !confirmUsername) {
     return reply.type('text/html').send(accountDeletePage({
@@ -483,10 +495,14 @@ export async function handleAccountDeleteForm(request, reply, options = {}) {
     }));
   }
 
-  // Authenticate. authenticate() looks up by username then by email,
-  // verifies bcrypt, and returns the account (sans password hash) or null.
-  const account = await authenticate(username, currentPassword);
-  if (!account) {
+  // Look up + verify password without side effects. authenticate() is
+  // tempting (looks up + verifies in one call) but writes lastLogin on
+  // success — wrong shape for a destructive proof-of-possession check
+  // (and would fail the deletion if the account file weren't writable).
+  // Mirrors handleChangePassword / handleDeleteAccount which both use
+  // verifyPassword for the same reason.
+  const account = await findByUsername(username);
+  if (!account || !(await verifyPassword(account, currentPassword))) {
     return reply.type('text/html').send(accountDeletePage({
       error: 'Username or password is incorrect.',
       username,

--- a/src/idp/credentials.js
+++ b/src/idp/credentials.js
@@ -359,54 +359,10 @@ export async function handleDeleteAccount(request, reply, options = {}) {
     });
   }
 
-  // 5. Delete the account record + indexes
-  await deleteAccount(account.id);
-
-  // 6. Optionally purge the pod's filesystem data. Mirrors the CLI
-  // `--purge` semantics. The path is `<dataRoot>/<podName>/`.
-  //
-  // Use account.podName, NOT account.username: createAccount normalizes
-  // username to lowercase (`username.toLowerCase().trim()`) but the pod
-  // directory on disk is created with the original case (per the input
-  // to handleCreatePod). On case-sensitive filesystems, deriving the
-  // purge path from username would either no-op (path doesn't exist)
-  // or hit a different directory if one exists at the lowercased name.
-  // Pod-name validation regex is /^[a-zA-Z0-9_-]+$/ (alphanum + dash +
-  // underscore; no dots, no traversal sequences) so podName is safe to
-  // join — defensive normalize stays as belt-and-suspenders.
-  //
-  // Best-effort: if fs.remove throws (permissions, transient FS error,
-  // race with another consumer), the account is already deleted and we
-  // shouldn't 500 over the leftover files. Log server-side and return
-  // purged: false so the caller knows pod data may still exist; an
-  // operator can finish the cleanup with a follow-up `rm -rf` or
-  // CLI `--purge` against the now-orphaned directory.
-  let purged = false;
-  if (purgeData) {
-    const dataRoot = process.env.DATA_ROOT || './data';
-    const candidate = path.resolve(dataRoot, account.podName || account.username);
-    const root = path.resolve(dataRoot);
-    // Belt-and-suspenders: refuse to remove anything that isn't a
-    // proper child of the data root. Won't trigger on registered pod
-    // names; protects against config drift / future bugs. Use
-    // path.relative so the check works when dataRoot is a filesystem
-    // root like `/` (where startsWith(root + path.sep) would compare
-    // against `//`, false-negative all valid children).
-    const rel = path.relative(root, candidate);
-    const isProperChild = rel && rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
-    if (isProperChild) {
-      try {
-        await fs.remove(candidate);
-        purged = true;
-      } catch (err) {
-        request.log.error({ err, path: candidate, username: account.username },
-          'Pod data purge failed after account deletion');
-        // Don't surface the raw error to the user (file paths,
-        // permission detail leak); response.purged signals the
-        // outcome.
-      }
-    }
-  }
+  // 5. Delete via the shared helper (also handles optional pod-data purge).
+  // See deleteAccountAndOptionallyPurge below for the purge semantics
+  // and rationale (#391 pass 2 / pass 3).
+  const { purged } = await deleteAccountAndOptionallyPurge(request, account, purgeData);
 
   reply.header('Cache-Control', 'no-store');
   reply.header('Pragma', 'no-cache');
@@ -458,18 +414,22 @@ async function deleteAccountAndOptionallyPurge(request, account, purgeData) {
 }
 
 /**
- * Handle POST /idp/account/delete (#392) — form-driven account deletion.
+ * Handle GET / POST /idp/account/delete (#392) — form-driven account deletion.
  *
  * Public unauthenticated endpoint that takes a form-encoded body with
  * username + currentPassword + confirmUsername (+ optional purgeData
  * checkbox). Authenticates the user via password directly (no Bearer
  * token round-trip required), validates the destructive-action UX
- * guard, then calls into the same deleteAccount logic as the JSON
- * endpoint. Returns HTML — success page on completion, redirect back
- * to the GET form with an error message on failure.
+ * guard, then calls into the same delete logic as the JSON endpoint
+ * via deleteAccountAndOptionallyPurge. Returns HTML directly:
+ *   - success → success page
+ *   - any failure → the form re-rendered with an error message and the
+ *     username field pre-filled (no redirect — single response, status
+ *     200 with the rendered form)
  *
- * Single-user mode: redirects to GET which renders the disabled
- * message instead of the form. Same policy as the JSON endpoint.
+ * Single-user mode: rendered as the disabled-message page instead of
+ * the form, both on GET and POST. Same policy as the JSON endpoint
+ * (which 403s with the equivalent message).
  *
  * @param {object} request - Fastify request
  * @param {object} reply - Fastify reply
@@ -527,9 +487,14 @@ export async function handleAccountDeleteForm(request, reply, options = {}) {
     }));
   }
 
-  await deleteAccountAndOptionallyPurge(request, account, purgeData);
+  const { purged } = await deleteAccountAndOptionallyPurge(request, account, purgeData);
 
-  return reply.type('text/html').send(accountDeletePage({ success: true }));
+  // If the user asked for a purge but it didn't run (fs.remove threw,
+  // path-relative check rejected, etc.), surface that on the success
+  // page. Account deletion succeeded — don't roll that back — but the
+  // operator may need to finish cleanup. Don't leak server paths.
+  const purgeFailed = purgeData && !purged;
+  return reply.type('text/html').send(accountDeletePage({ success: true, purgeFailed }));
 }
 
 /**

--- a/src/idp/credentials.js
+++ b/src/idp/credentials.js
@@ -376,7 +376,7 @@ export async function handleDeleteAccount(request, reply, options = {}) {
 /**
  * Internal: delete an account record + optional pod-data purge.
  * Shared between the JSON endpoint (handleDeleteAccount) and the
- * form-driven endpoint (handleAccountDeletePost in #392).
+ * form-driven endpoint (handleAccountDeleteForm in #392).
  *
  * Best-effort purge — fs.remove can throw, but the account is already
  * gone and we want a clean signal rather than a 500. Path is derived

--- a/src/idp/index.js
+++ b/src/idp/index.js
@@ -25,6 +25,7 @@ import {
   handleChangePassword,
   handleDeleteAccount,
   handleAccountDeleteForm,
+  setNoCacheClickjackHeaders,
 } from './credentials.js';
 import * as passkey from './passkey.js';
 import { addTrustedIssuer } from '../auth/solid-oidc.js';
@@ -301,8 +302,10 @@ export async function idpPlugin(fastify, options) {
   // Single-user mode returns 403 to stay consistent with /idp/register's
   // disabled-route policy and the JSON DELETE /idp/account endpoint
   // (which also 403s in single-user mode). Body is still HTML so a
-  // browser visitor sees the explanation.
+  // browser visitor sees the explanation. Every response sets
+  // anti-clickjacking + no-store headers — destructive-action page.
   fastify.get('/idp/account/delete', async (request, reply) => {
+    setNoCacheClickjackHeaders(reply);
     if (singleUser) {
       return reply.code(403).type('text/html').send(accountDeletePage({ singleUser: true }));
     }

--- a/src/idp/index.js
+++ b/src/idp/index.js
@@ -298,8 +298,15 @@ export async function idpPlugin(fastify, options) {
 
   // GET account-delete form (#392) - human-friendly UI for #352. Public
   // unauthenticated page; auth happens at form submission via password.
+  // Single-user mode returns 403 to stay consistent with /idp/register's
+  // disabled-route policy and the JSON DELETE /idp/account endpoint
+  // (which also 403s in single-user mode). Body is still HTML so a
+  // browser visitor sees the explanation.
   fastify.get('/idp/account/delete', async (request, reply) => {
-    return reply.type('text/html').send(accountDeletePage({ singleUser }));
+    if (singleUser) {
+      return reply.code(403).type('text/html').send(accountDeletePage({ singleUser: true }));
+    }
+    return reply.type('text/html').send(accountDeletePage({ singleUser: false }));
   });
 
   // POST account-delete form (#392) - processes the form submission.

--- a/src/idp/index.js
+++ b/src/idp/index.js
@@ -24,10 +24,11 @@ import {
   handleCredentialsInfo,
   handleChangePassword,
   handleDeleteAccount,
+  handleAccountDeleteForm,
 } from './credentials.js';
 import * as passkey from './passkey.js';
 import { addTrustedIssuer } from '../auth/solid-oidc.js';
-import { landingPage } from './views.js';
+import { landingPage, accountDeletePage } from './views.js';
 
 /**
  * IdP Fastify Plugin
@@ -293,6 +294,27 @@ export async function idpPlugin(fastify, options) {
     }
   }, async (request, reply) => {
     return handleDeleteAccount(request, reply, { singleUser });
+  });
+
+  // GET account-delete form (#392) - human-friendly UI for #352. Public
+  // unauthenticated page; auth happens at form submission via password.
+  fastify.get('/idp/account/delete', async (request, reply) => {
+    return reply.type('text/html').send(accountDeletePage({ singleUser }));
+  });
+
+  // POST account-delete form (#392) - processes the form submission.
+  // Same rate-limit as the JSON endpoint to keep the destructive-action
+  // surface consistent across both paths.
+  fastify.post('/idp/account/delete', {
+    config: {
+      rateLimit: {
+        max: 5,
+        timeWindow: '1 minute',
+        keyGenerator: (request) => request.ip
+      }
+    }
+  }, async (request, reply) => {
+    return handleAccountDeleteForm(request, reply, { singleUser });
   });
 
   // Interaction routes (our custom login/consent UI)

--- a/src/idp/views.js
+++ b/src/idp/views.js
@@ -669,11 +669,12 @@ export function accountDeletePage({ error = null, username = '', singleUser = fa
     <h1>Delete your account</h1>
 
     <div class="danger">
-      <strong>This is permanent.</strong> Your account record, credentials, and pod data
-      (every file you've stored — including your WebID profile document) will be removed.
-      Future sign-ins with this username will fail. Federated references (ActivityPub
-      follows, Nostr relays, type indexes) cannot be retracted from this server, so
-      external links to your WebID URI will become dangling.
+      <strong>This is permanent.</strong> Your account record and credentials will be
+      removed; future sign-ins with this username will fail. By default, your pod
+      data (every file you've stored, including your WebID profile document) is
+      also wiped — check the box below if you want to keep it. Federated references
+      (ActivityPub follows, Nostr relays, type indexes) cannot be retracted from
+      this server.
       <br><br>
       <span style="font-size: 12px; color: #7f1d1d;">
         Note: access tokens already issued may remain usable until they

--- a/src/idp/views.js
+++ b/src/idp/views.js
@@ -538,17 +538,25 @@ export function consentPage(uid, client, params, account) {
  *
  * Public unauthenticated page (matches the existing /idp landing and
  * /idp/register pattern). Auth happens at submission time: the user
- * supplies username + password, which the server validates and uses as
- * proof-of-possession for the delete. The "type your username to
- * confirm" field is the destructive-action UX guard.
+ * supplies an identifier (username or email) + password, which the
+ * server validates and uses as proof-of-possession for the delete.
+ * The "type your identifier to confirm" field is the destructive-action
+ * UX guard.
+ *
+ * On any failure (wrong password, mismatched confirmation, etc.) the
+ * handler re-renders this same form in place at status 200 with an
+ * error message and the identifier field pre-filled — no redirect.
  *
  * @param {object} opts
  * @param {string|null} opts.error - Error message (e.g. wrong password) to display
- * @param {string|null} opts.username - Pre-fill on redirect-back-with-error
+ * @param {string} opts.username - Pre-fill the identifier field on re-render after error
  * @param {boolean} opts.singleUser - When true, render a disabled message
  *   instead of the form. Deletion via HTTP is blocked in single-user mode
  *   (would brick the IdP until re-seed); operator path stays the CLI.
  * @param {boolean} opts.success - When true, render the post-delete confirmation
+ * @param {boolean} opts.purgeFailed - When true (only on success), include a
+ *   notice that the user requested a pod-data purge but it didn't complete.
+ *   Account deletion still succeeded.
  */
 export function accountDeletePage({ error = null, username = '', singleUser = false, success = false, purgeFailed = false } = {}) {
   if (singleUser) {
@@ -676,10 +684,10 @@ export function accountDeletePage({ error = null, username = '', singleUser = fa
     ${error ? `<div class="error">${escapeHtml(error)}</div>` : ''}
 
     <form method="POST" action="/idp/account/delete">
-      <label for="username">Username or email</label>
+      <label for="username">Username</label>
       <input type="text" id="username" name="username" required autofocus
              value="${escapeHtml(username || '')}"
-             placeholder="alice or alice@example.com">
+             placeholder="alice">
 
       <label for="currentPassword">Current password</label>
       <input type="password" id="currentPassword" name="currentPassword" required

--- a/src/idp/views.js
+++ b/src/idp/views.js
@@ -669,10 +669,11 @@ export function accountDeletePage({ error = null, username = '', singleUser = fa
     <h1>Delete your account</h1>
 
     <div class="danger">
-      <strong>This is permanent.</strong> Your account record and credentials will be
-      removed; future sign-ins with this username will fail. Anyone holding your
-      WebID URI will see it become a tombstone — federated references (ActivityPub,
-      Nostr, type indexes) cannot be retracted from this server.
+      <strong>This is permanent.</strong> Your account record, credentials, and pod data
+      (every file you've stored — including your WebID profile document) will be removed.
+      Future sign-ins with this username will fail. Federated references (ActivityPub
+      follows, Nostr relays, type indexes) cannot be retracted from this server, so
+      external links to your WebID URI will become dangling.
       <br><br>
       <span style="font-size: 12px; color: #7f1d1d;">
         Note: access tokens already issued may remain usable until they
@@ -697,11 +698,11 @@ export function accountDeletePage({ error = null, username = '', singleUser = fa
              placeholder="Must match the username above">
 
       <div class="checkbox-row">
-        <input type="checkbox" id="purgeData" name="purgeData" value="on">
-        <label for="purgeData">
-          <strong>Also delete all my pod data.</strong> Removes the pod folder
-          on disk — every file you've stored on this server is destroyed.
-          Off by default; your pod data is preserved if you leave this unchecked.
+        <input type="checkbox" id="keepData" name="keepData" value="on">
+        <label for="keepData">
+          <strong>Keep my pod data on this server.</strong> Check only if you want
+          to delete just your account record and leave your files in place. Default
+          (unchecked) wipes the pod folder along with the account.
         </label>
       </div>
 

--- a/src/idp/views.js
+++ b/src/idp/views.js
@@ -550,7 +550,7 @@ export function consentPage(uid, client, params, account) {
  *   (would brick the IdP until re-seed); operator path stays the CLI.
  * @param {boolean} opts.success - When true, render the post-delete confirmation
  */
-export function accountDeletePage({ error = null, username = '', singleUser = false, success = false } = {}) {
+export function accountDeletePage({ error = null, username = '', singleUser = false, success = false, purgeFailed = false } = {}) {
   if (singleUser) {
     return `
 <!DOCTYPE html>
@@ -591,8 +591,20 @@ export function accountDeletePage({ error = null, username = '', singleUser = fa
   <div class="container">
     <div class="logo">${solidLogo}</div>
     <h1>Account deleted</h1>
-    <p>Your account has been permanently removed. Any active sessions are now invalid.</p>
-    <a href="/idp" class="btn btn-primary" style="text-decoration: none;">Return to sign-in</a>
+    <p>Your account record has been removed from this server. Future sign-ins
+       with this username will fail.</p>
+    <p style="font-size: 13px; color: #64748b; margin-top: 8px;">
+      Note: any access tokens already issued may remain usable until they
+      expire — the server does not currently revoke them on account deletion.
+    </p>
+    ${purgeFailed ? `
+    <div class="error" style="margin-top: 16px;">
+      Your account was deleted, but the pod-data purge did not complete on
+      this server. Some files may still exist. Contact the operator to
+      finish the cleanup if needed.
+    </div>
+    ` : ''}
+    <a href="/idp" class="btn btn-primary" style="text-decoration: none; margin-top: 16px;">Return to sign-in</a>
   </div>
 </body>
 </html>
@@ -650,10 +662,15 @@ export function accountDeletePage({ error = null, username = '', singleUser = fa
     <h1>Delete your account</h1>
 
     <div class="danger">
-      <strong>This is permanent.</strong> Your account record, all credentials, and any active
-      sessions will be removed. Anyone holding your WebID URI will see it become a
-      tombstone — federated references (ActivityPub, Nostr, type indexes) cannot be
-      retracted from this server.
+      <strong>This is permanent.</strong> Your account record and credentials will be
+      removed; future sign-ins with this username will fail. Anyone holding your
+      WebID URI will see it become a tombstone — federated references (ActivityPub,
+      Nostr, type indexes) cannot be retracted from this server.
+      <br><br>
+      <span style="font-size: 12px; color: #7f1d1d;">
+        Note: access tokens already issued may remain usable until they
+        expire — the server does not currently revoke them on deletion.
+      </span>
     </div>
 
     ${error ? `<div class="error">${escapeHtml(error)}</div>` : ''}

--- a/src/idp/views.js
+++ b/src/idp/views.js
@@ -538,10 +538,9 @@ export function consentPage(uid, client, params, account) {
  *
  * Public unauthenticated page (matches the existing /idp landing and
  * /idp/register pattern). Auth happens at submission time: the user
- * supplies an identifier (username or email) + password, which the
- * server validates and uses as proof-of-possession for the delete.
- * The "type your identifier to confirm" field is the destructive-action
- * UX guard.
+ * supplies username + password, which the server validates and uses as
+ * proof-of-possession for the delete. The "type your username again to
+ * confirm" field is the destructive-action UX guard.
  *
  * On any failure (wrong password, mismatched confirmation, etc.) the
  * handler re-renders this same form in place at status 200 with an
@@ -700,10 +699,9 @@ export function accountDeletePage({ error = null, username = '', singleUser = fa
       <div class="checkbox-row">
         <input type="checkbox" id="purgeData" name="purgeData" value="on">
         <label for="purgeData">
-          <strong>Also delete all my pod data.</strong> Removes
-          <code>&lt;dataRoot&gt;/&lt;username&gt;/</code> from disk —
-          every file you've stored on this server is destroyed. Off by default;
-          your pod data is preserved if you leave this unchecked.
+          <strong>Also delete all my pod data.</strong> Removes the pod folder
+          on disk — every file you've stored on this server is destroyed.
+          Off by default; your pod data is preserved if you leave this unchecked.
         </label>
       </div>
 

--- a/src/idp/views.js
+++ b/src/idp/views.js
@@ -534,6 +534,169 @@ export function consentPage(uid, client, params, account) {
 }
 
 /**
+ * Account-deletion form HTML (#392).
+ *
+ * Public unauthenticated page (matches the existing /idp landing and
+ * /idp/register pattern). Auth happens at submission time: the user
+ * supplies username + password, which the server validates and uses as
+ * proof-of-possession for the delete. The "type your username to
+ * confirm" field is the destructive-action UX guard.
+ *
+ * @param {object} opts
+ * @param {string|null} opts.error - Error message (e.g. wrong password) to display
+ * @param {string|null} opts.username - Pre-fill on redirect-back-with-error
+ * @param {boolean} opts.singleUser - When true, render a disabled message
+ *   instead of the form. Deletion via HTTP is blocked in single-user mode
+ *   (would brick the IdP until re-seed); operator path stays the CLI.
+ * @param {boolean} opts.success - When true, render the post-delete confirmation
+ */
+export function accountDeletePage({ error = null, username = '', singleUser = false, success = false } = {}) {
+  if (singleUser) {
+    return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Account deletion disabled - Solid IdP</title>
+  <style>${styles}</style>
+</head>
+<body>
+  <div class="container">
+    <div class="logo">${solidLogo}</div>
+    <h1>Account deletion disabled</h1>
+    <p>This server runs in <strong>single-user mode</strong>. Deleting the single account
+       via HTTP would leave the server with no IdP account until re-seed,
+       so this endpoint is disabled.</p>
+    <p>The operator can still delete the account at the shell with:</p>
+    <pre style="background: #f1f5f9; padding: 12px; border-radius: 6px; font-size: 13px;">jss account delete &lt;username&gt;</pre>
+    <a href="/idp" class="btn btn-secondary" style="text-decoration: none;">Back</a>
+  </div>
+</body>
+</html>
+    `;
+  }
+
+  if (success) {
+    return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Account deleted - Solid IdP</title>
+  <style>${styles}</style>
+</head>
+<body>
+  <div class="container">
+    <div class="logo">${solidLogo}</div>
+    <h1>Account deleted</h1>
+    <p>Your account has been permanently removed. Any active sessions are now invalid.</p>
+    <a href="/idp" class="btn btn-primary" style="text-decoration: none;">Return to sign-in</a>
+  </div>
+</body>
+</html>
+    `;
+  }
+
+  return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Delete account - Solid IdP</title>
+  <style>${styles}
+  .danger {
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    color: #991b1b;
+    padding: 14px 16px;
+    border-radius: 8px;
+    margin: 16px 0 24px;
+    font-size: 13px;
+    line-height: 1.55;
+  }
+  .danger strong { color: #7f1d1d; }
+  .btn-danger {
+    background: #dc2626;
+    color: #fff;
+  }
+  .btn-danger:hover { background: #b91c1c; }
+  .checkbox-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    margin: 16px 0 8px;
+    padding: 10px 12px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+  }
+  .checkbox-row input[type="checkbox"] { margin-top: 3px; flex-shrink: 0; }
+  .checkbox-row label {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.5;
+    color: #334155;
+    cursor: pointer;
+  }
+  .checkbox-row label strong { color: #0f172a; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="logo">${solidLogo}</div>
+    <h1>Delete your account</h1>
+
+    <div class="danger">
+      <strong>This is permanent.</strong> Your account record, all credentials, and any active
+      sessions will be removed. Anyone holding your WebID URI will see it become a
+      tombstone — federated references (ActivityPub, Nostr, type indexes) cannot be
+      retracted from this server.
+    </div>
+
+    ${error ? `<div class="error">${escapeHtml(error)}</div>` : ''}
+
+    <form method="POST" action="/idp/account/delete">
+      <label for="username">Username or email</label>
+      <input type="text" id="username" name="username" required autofocus
+             value="${escapeHtml(username || '')}"
+             placeholder="alice or alice@example.com">
+
+      <label for="currentPassword">Current password</label>
+      <input type="password" id="currentPassword" name="currentPassword" required
+             placeholder="Re-enter your password">
+
+      <label for="confirmUsername">Type your username again to confirm</label>
+      <input type="text" id="confirmUsername" name="confirmUsername" required
+             placeholder="Must match the username above">
+
+      <div class="checkbox-row">
+        <input type="checkbox" id="purgeData" name="purgeData" value="on">
+        <label for="purgeData">
+          <strong>Also delete all my pod data.</strong> Removes
+          <code>&lt;dataRoot&gt;/&lt;username&gt;/</code> from disk —
+          every file you've stored on this server is destroyed. Off by default;
+          your pod data is preserved if you leave this unchecked.
+        </label>
+      </div>
+
+      <button type="submit" class="btn btn-danger" style="width: 100%; margin-top: 16px;">
+        Delete my account permanently
+      </button>
+    </form>
+
+    <p style="text-align: center; margin-top: 16px; font-size: 13px;">
+      <a href="/idp">Cancel and go back</a>
+    </p>
+  </div>
+</body>
+</html>
+  `;
+}
+
+/**
  * Error page HTML
  */
 export function errorPage(title, message) {

--- a/test/idp-delete-account.test.js
+++ b/test/idp-delete-account.test.js
@@ -314,6 +314,45 @@ describe('GET/POST /idp/account/delete — HTML form (#392)', () => {
     assert.match(html, /Delete my account permanently/);
   });
 
+  it('GET sets anti-clickjacking + no-store headers', async () => {
+    // Destructive-action page (form for account deletion) — must not
+    // be cacheable or embeddable in an iframe.
+    const res = await fetch(`${baseUrl}/idp/account/delete`);
+    assert.strictEqual(res.status, 200);
+    assert.match(res.headers.get('cache-control') || '', /no-store/i);
+    assert.strictEqual(res.headers.get('x-frame-options'), 'DENY');
+    assert.match(res.headers.get('content-security-policy') || '', /frame-ancestors 'none'/);
+  });
+
+  it('POST sets the same security headers on success and error responses', async () => {
+    // Error response: missing fields
+    const errRes = await fetch(`${baseUrl}/idp/account/delete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ username: 'x' }),
+    });
+    assert.match(errRes.headers.get('cache-control') || '', /no-store/i);
+    assert.strictEqual(errRes.headers.get('x-frame-options'), 'DENY');
+    assert.match(errRes.headers.get('content-security-policy') || '', /frame-ancestors 'none'/);
+
+    // Success response: full delete flow
+    const id = `lyle${Date.now()}`;
+    await createPod(baseUrl, id, `${id}@example.com`, 'password123');
+    const okRes = await fetch(`${baseUrl}/idp/account/delete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        username: id,
+        currentPassword: 'password123',
+        confirmUsername: id,
+      }),
+    });
+    assert.strictEqual(okRes.status, 200);
+    assert.match(okRes.headers.get('cache-control') || '', /no-store/i);
+    assert.strictEqual(okRes.headers.get('x-frame-options'), 'DENY');
+    assert.match(okRes.headers.get('content-security-policy') || '', /frame-ancestors 'none'/);
+  });
+
   it('POST happy path: deletes account AND wipes pod data by default; login fails after', async () => {
     // Form's default is purge-on (the user is leaving — wipe everything).
     // The JSON DELETE endpoint keeps purge-off as default (matches CLI for

--- a/test/idp-delete-account.test.js
+++ b/test/idp-delete-account.test.js
@@ -308,18 +308,28 @@ describe('GET/POST /idp/account/delete — HTML form (#392)', () => {
     assert.match(html, /name="username"/);
     assert.match(html, /name="currentPassword"/);
     assert.match(html, /name="confirmUsername"/);
-    assert.match(html, /name="purgeData"/);
+    // Form's checkbox is `keepData` (inverse of the JSON endpoint's
+    // purgeData) so the form's default is purge-on for the leaving-user UX.
+    assert.match(html, /name="keepData"/);
     assert.match(html, /Delete my account permanently/);
   });
 
-  it('POST happy path: deletes account, returns success HTML, login fails after', async () => {
+  it('POST happy path: deletes account AND wipes pod data by default; login fails after', async () => {
+    // Form's default is purge-on (the user is leaving — wipe everything).
+    // The JSON DELETE endpoint keeps purge-off as default (matches CLI for
+    // programmatic / operator use); the form diverges deliberately for the
+    // leaving-user UX.
     const id = `harry${Date.now()}`;
     await createPod(baseUrl, id, `${id}@example.com`, 'password123');
+    const podPath = path.join(DATA_DIR, id);
+    assert.strictEqual(await fs.pathExists(podPath), true,
+      'pod tree should exist before deletion');
 
     const formBody = new URLSearchParams({
       username: id,
       currentPassword: 'password123',
       confirmUsername: id,
+      // No keepData — defaults to purge-on
     });
     const res = await fetch(`${baseUrl}/idp/account/delete`, {
       method: 'POST',
@@ -337,9 +347,13 @@ describe('GET/POST /idp/account/delete — HTML form (#392)', () => {
       body: JSON.stringify({ email: `${id}@example.com`, password: 'password123' }),
     });
     assert.strictEqual(reLogin.status, 401);
+
+    // Pod data also wiped (default behavior on the form)
+    assert.strictEqual(await fs.pathExists(podPath), false,
+      'pod data should be wiped by default on the form path');
   });
 
-  it('POST with purgeData=on also wipes the pod tree', async () => {
+  it('POST with keepData=on opts out of the purge, account still deleted', async () => {
     const id = `iris${Date.now()}`;
     await createPod(baseUrl, id, `${id}@example.com`, 'password123');
     const podPath = path.join(DATA_DIR, id);
@@ -349,7 +363,7 @@ describe('GET/POST /idp/account/delete — HTML form (#392)', () => {
       username: id,
       currentPassword: 'password123',
       confirmUsername: id,
-      purgeData: 'on',
+      keepData: 'on',
     });
     const res = await fetch(`${baseUrl}/idp/account/delete`, {
       method: 'POST',
@@ -357,7 +371,18 @@ describe('GET/POST /idp/account/delete — HTML form (#392)', () => {
       body: formBody,
     });
     assert.strictEqual(res.status, 200);
-    assert.strictEqual(await fs.pathExists(podPath), false);
+
+    // Account gone
+    const reLogin = await fetch(`${baseUrl}/idp/credentials`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: `${id}@example.com`, password: 'password123' }),
+    });
+    assert.strictEqual(reLogin.status, 401);
+
+    // Pod data preserved (the user opted to keep it)
+    assert.strictEqual(await fs.pathExists(podPath), true,
+      'keepData=on should preserve pod data even though account is deleted');
   });
 
   it('POST with mismatched confirmUsername renders form with error, account untouched', async () => {
@@ -469,9 +494,11 @@ describe('GET/POST /idp/account/delete — single-user mode renders disabled mes
     else process.env.JSS_SINGLE_USER_PASSWORD = originalPassword;
   });
 
-  it('GET renders the disabled message instead of the form', async () => {
+  it('GET returns 403 with the disabled-message HTML', async () => {
+    // 403 keeps single-user disabled routes consistent: /idp/register,
+    // the JSON DELETE /idp/account, and this GET all 403 in single-user.
     const res = await fetch(`${baseUrl}/idp/account/delete`);
-    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.status, 403);
     const html = await res.text();
     assert.match(html, /single-user mode/i);
     assert.match(html, /jss account delete/);
@@ -479,7 +506,7 @@ describe('GET/POST /idp/account/delete — single-user mode renders disabled mes
     assert.doesNotMatch(html, /<form\s[^>]*action="\/idp\/account\/delete"/);
   });
 
-  it('POST also returns the disabled message — does not delete', async () => {
+  it('POST returns 403 with disabled-message HTML — does not delete', async () => {
     const formBody = new URLSearchParams({
       username: 'me',
       currentPassword: 'singletest',
@@ -490,7 +517,7 @@ describe('GET/POST /idp/account/delete — single-user mode renders disabled mes
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: formBody,
     });
-    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.status, 403);
     const html = await res.text();
     assert.match(html, /single-user mode/i);
 

--- a/test/idp-delete-account.test.js
+++ b/test/idp-delete-account.test.js
@@ -269,6 +269,241 @@ describe('DELETE /idp/account — self-delete', () => {
   });
 });
 
+describe('GET/POST /idp/account/delete — HTML form (#392)', () => {
+  let server;
+  let baseUrl;
+  let originalDataRoot;
+  const DATA_DIR = './test-data-delete-form';
+
+  before(async () => {
+    originalDataRoot = process.env.DATA_ROOT;
+    await fs.remove(DATA_DIR);
+    await fs.ensureDir(DATA_DIR);
+    const port = await getAvailablePort();
+    baseUrl = `http://${TEST_HOST}:${port}`;
+    server = createServer({
+      logger: false,
+      root: DATA_DIR,
+      idp: true,
+      idpIssuer: baseUrl,
+      forceCloseConnections: true,
+    });
+    await server.listen({ port, host: TEST_HOST });
+  });
+
+  after(async () => {
+    await server.close();
+    await fs.remove(DATA_DIR);
+    if (originalDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = originalDataRoot;
+  });
+
+  it('GET renders the form HTML', async () => {
+    const res = await fetch(`${baseUrl}/idp/account/delete`);
+    assert.strictEqual(res.status, 200);
+    const ct = res.headers.get('content-type') || '';
+    assert.match(ct, /text\/html/);
+    const html = await res.text();
+    assert.match(html, /<form\s[^>]*action="\/idp\/account\/delete"/);
+    assert.match(html, /name="username"/);
+    assert.match(html, /name="currentPassword"/);
+    assert.match(html, /name="confirmUsername"/);
+    assert.match(html, /name="purgeData"/);
+    assert.match(html, /Delete my account permanently/);
+  });
+
+  it('POST happy path: deletes account, returns success HTML, login fails after', async () => {
+    const id = `harry${Date.now()}`;
+    await createPod(baseUrl, id, `${id}@example.com`, 'password123');
+
+    const formBody = new URLSearchParams({
+      username: id,
+      currentPassword: 'password123',
+      confirmUsername: id,
+    });
+    const res = await fetch(`${baseUrl}/idp/account/delete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: formBody,
+    });
+    assert.strictEqual(res.status, 200);
+    const html = await res.text();
+    assert.match(html, /Account deleted/);
+
+    // Login now fails
+    const reLogin = await fetch(`${baseUrl}/idp/credentials`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: `${id}@example.com`, password: 'password123' }),
+    });
+    assert.strictEqual(reLogin.status, 401);
+  });
+
+  it('POST with purgeData=on also wipes the pod tree', async () => {
+    const id = `iris${Date.now()}`;
+    await createPod(baseUrl, id, `${id}@example.com`, 'password123');
+    const podPath = path.join(DATA_DIR, id);
+    assert.strictEqual(await fs.pathExists(podPath), true);
+
+    const formBody = new URLSearchParams({
+      username: id,
+      currentPassword: 'password123',
+      confirmUsername: id,
+      purgeData: 'on',
+    });
+    const res = await fetch(`${baseUrl}/idp/account/delete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: formBody,
+    });
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(await fs.pathExists(podPath), false);
+  });
+
+  it('POST with mismatched confirmUsername renders form with error, account untouched', async () => {
+    const id = `jack${Date.now()}`;
+    await createPod(baseUrl, id, `${id}@example.com`, 'password123');
+
+    const formBody = new URLSearchParams({
+      username: id,
+      currentPassword: 'password123',
+      confirmUsername: 'totally-different',
+    });
+    const res = await fetch(`${baseUrl}/idp/account/delete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: formBody,
+    });
+    assert.strictEqual(res.status, 200);
+    const html = await res.text();
+    assert.match(html, /Confirmation does not match/);
+    // Username pre-filled in the form for retry
+    assert.match(html, new RegExp(`value="${id}"`));
+
+    // Account intact
+    const login = await fetch(`${baseUrl}/idp/credentials`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: `${id}@example.com`, password: 'password123' }),
+    });
+    assert.strictEqual(login.status, 200);
+  });
+
+  it('POST with wrong password renders form with error, account untouched', async () => {
+    const id = `kelly${Date.now()}`;
+    await createPod(baseUrl, id, `${id}@example.com`, 'password123');
+
+    const formBody = new URLSearchParams({
+      username: id,
+      currentPassword: 'wrong',
+      confirmUsername: id,
+    });
+    const res = await fetch(`${baseUrl}/idp/account/delete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: formBody,
+    });
+    assert.strictEqual(res.status, 200);
+    const html = await res.text();
+    assert.match(html, /incorrect/i);
+
+    // Account intact
+    const login = await fetch(`${baseUrl}/idp/credentials`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: `${id}@example.com`, password: 'password123' }),
+    });
+    assert.strictEqual(login.status, 200);
+  });
+
+  it('POST with missing fields renders form with error', async () => {
+    const formBody = new URLSearchParams({
+      username: 'someone',
+      // currentPassword and confirmUsername omitted
+    });
+    const res = await fetch(`${baseUrl}/idp/account/delete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: formBody,
+    });
+    assert.strictEqual(res.status, 200);
+    const html = await res.text();
+    assert.match(html, /required/i);
+  });
+});
+
+describe('GET/POST /idp/account/delete — single-user mode renders disabled message', () => {
+  let server;
+  let baseUrl;
+  let originalDataRoot;
+  let originalPassword;
+  const DATA_DIR = './test-data-delete-form-single';
+
+  before(async () => {
+    originalDataRoot = process.env.DATA_ROOT;
+    originalPassword = process.env.JSS_SINGLE_USER_PASSWORD;
+    process.env.JSS_SINGLE_USER_PASSWORD = 'singletest';
+    await fs.remove(DATA_DIR);
+    await fs.ensureDir(DATA_DIR);
+    const port = await getAvailablePort();
+    baseUrl = `http://${TEST_HOST}:${port}`;
+    server = createServer({
+      logger: false,
+      root: DATA_DIR,
+      idp: true,
+      idpIssuer: baseUrl,
+      singleUser: true,
+      singleUserName: 'me',
+      singleUserPassword: 'singletest',
+      forceCloseConnections: true,
+    });
+    await server.listen({ port, host: TEST_HOST });
+  });
+
+  after(async () => {
+    await server.close();
+    await fs.remove(DATA_DIR);
+    if (originalDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = originalDataRoot;
+    if (originalPassword === undefined) delete process.env.JSS_SINGLE_USER_PASSWORD;
+    else process.env.JSS_SINGLE_USER_PASSWORD = originalPassword;
+  });
+
+  it('GET renders the disabled message instead of the form', async () => {
+    const res = await fetch(`${baseUrl}/idp/account/delete`);
+    assert.strictEqual(res.status, 200);
+    const html = await res.text();
+    assert.match(html, /single-user mode/i);
+    assert.match(html, /jss account delete/);
+    // No form
+    assert.doesNotMatch(html, /<form\s[^>]*action="\/idp\/account\/delete"/);
+  });
+
+  it('POST also returns the disabled message — does not delete', async () => {
+    const formBody = new URLSearchParams({
+      username: 'me',
+      currentPassword: 'singletest',
+      confirmUsername: 'me',
+    });
+    const res = await fetch(`${baseUrl}/idp/account/delete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: formBody,
+    });
+    assert.strictEqual(res.status, 200);
+    const html = await res.text();
+    assert.match(html, /single-user mode/i);
+
+    // Account still works
+    const login = await fetch(`${baseUrl}/idp/credentials`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'me', password: 'singletest' }),
+    });
+    assert.strictEqual(login.status, 200);
+  });
+});
+
 describe('DELETE /idp/account — single-user mode', () => {
   let server;
   let baseUrl;


### PR DESCRIPTION
Closes #392. Builds on #391 (JSON endpoint).

## Summary
- Public unauthenticated form at `/idp/account/delete` — matches the existing `/idp` and `/idp/register` pattern.
- Auth at submission time: form posts username + password, server validates credentials and uses them as proof-of-possession for the delete (side-effect-free via `findByUsername` + `verifyPassword` per pass 5).
- No JavaScript required. Form-encoded POST works in any browser.
- Single-user mode returns 403 with HTML disabled-message body (consistent with `/idp/register` and the JSON DELETE endpoint's 403).

## Form
- Username (no email — JSS doesn't actually do email anywhere user-facing; data layer is the only place email exists, auto-generated as `<username>@jss`)
- Current password (re-entry as proof)
- Type your username again to confirm (destructive-action UX guard)
- **☐ Keep my pod data on this server** — opt-out checkbox; the form's default is **purge-on** (the user is leaving the server, so wiping their pod data with the account is the expected shape). Checking this box opts out of the purge but the account is still deleted.

## Form vs JSON endpoint defaults — deliberately different

| Surface | Default | Field | Rationale |
|---|---|---|---|
| `POST /idp/account/delete` (form) | **purge ON** | `keepData` (opt-out) | User is leaving — total cleanup is the natural expectation |
| `DELETE /idp/account` (JSON) | purge off | `purgeData` (opt-in) | Programmatic / CLI parity — operator scripts shouldn't accidentally wipe data |
| `jss account delete` (CLI) | purge off | `--purge` flag | Operator path; same shape as JSON |

## Routes
| | |
|---|---|
| `GET /idp/account/delete` | Render the form (or single-user disabled page with 403) |
| `POST /idp/account/delete` | Process the submission. 5/min/IP rate-limit (same as JSON endpoint) |

## Internal refactor
Factored "delete + optional purge" into `deleteAccountAndOptionallyPurge(request, account, purgeData)` shared between the JSON endpoint and the form endpoint — same code path, same case-sensitivity fix (#391 pass 2: uses `account.podName`), same path-relative safety check (#391 pass 3).

## Tests added (9)

| | |
|---|---|
| GET renders form HTML | ✓ all required fields present, including `name="keepData"` |
| POST happy path | ✓ default purges pod data + success page + login fails 401 |
| POST with `keepData=on` | ✓ account deleted but pod data preserved |
| POST mismatched confirmUsername | ✓ form re-rendered with error, account untouched |
| POST wrong password | ✓ form re-rendered with error, account untouched |
| POST missing fields | ✓ form re-rendered with error |
| Single-user GET | ✓ **403** with disabled message |
| Single-user POST | ✓ **403** + account still functional |
| Existing 9 DELETE-endpoint tests | ✓ unchanged |

17/17 delete-account tests pass; 636/636 full suite passes.

## Files
- `src/idp/credentials.js` — `handleAccountDeleteForm` + shared `deleteAccountAndOptionallyPurge` helper, ~120 LOC
- `src/idp/views.js` — `accountDeletePage` template (form + single-user disabled variant + success variant), ~165 LOC
- `src/idp/index.js` — two routes (GET + POST) with 403 handling for single-user mode, ~24 LOC
- `test/idp-delete-account.test.js` — 9 new tests, ~270 LOC

## Test plan
- [ ] CI green
- [ ] Manual: open `https://test-pod.example/idp/account/delete` in a browser → form renders
- [ ] Manual: submit with valid credentials and **leave the keep-data box unchecked** (default) → success page, account gone, pod data gone
- [ ] Manual: submit with the keep-data box checked → success page, account gone, pod data preserved
- [ ] Manual: visit on a single-user pod → 403 with disabled message instead of form

## Refs
- #392 — this feature
- #391 — JSON DELETE endpoint
- #352 — original feature request