### PR TITLE
auth: LWS10-CID JWT verifier with ES256K (#397)

### DIFF
--- a/src/auth/lws-cid.js
+++ b/src/auth/lws-cid.js
@@ -208,14 +208,21 @@ export async function verifyLwsCidAuth(request) {
   if (audList.length === 0) {
     return { webId: null, error: 'JWT aud claim is required' };
   }
-  if (reqOrigin) {
-    const audMatch = audList.some((a) => normalizeOrigin(a) === reqOrigin);
-    if (!audMatch) {
-      return {
-        webId: null,
-        error: `aud does not include this server's origin (${reqOrigin})`,
-      };
-    }
+  if (!reqOrigin) {
+    // We can't determine our own origin, so we can't verify aud. Per
+    // FPWD, aud MUST include the target server — failing closed is
+    // safer than silently accepting any aud value.
+    return {
+      webId: null,
+      error: 'cannot determine server origin to verify aud',
+    };
+  }
+  const audMatch = audList.some((a) => normalizeOrigin(a) === reqOrigin);
+  if (!audMatch) {
+    return {
+      webId: null,
+      error: `aud does not include this server's origin (${reqOrigin})`,
+    };
   }
 
   // Fetch the CID document (= WebID profile) and locate the VM by kid.
@@ -390,7 +397,10 @@ async function fetchProfileNoCache(docUrl) {
     let res;
     try {
       res = await fetch(currentUrl, {
-        headers: { Accept: 'application/ld+json' },
+        // Prefer JSON-LD but accept plain JSON too — some WebID hosts
+        // serve `application/json` for `card.jsonld`. The body is JSON
+        // either way; we don't perform JSON-LD-specific processing here.
+        headers: { Accept: 'application/ld+json, application/json;q=0.9' },
         redirect: 'manual',
         signal: controller.signal,
       });
@@ -483,7 +493,7 @@ function absolutize(u, base) {
  */
 async function verifyEs256kJwt(token, jwk) {
   if (jwk.kty !== 'EC' || (jwk.crv !== 'secp256k1' && jwk.crv !== 'P-256K')) {
-    throw new Error(`ES256K requires kty:EC crv:secp256k1, got kty:${jwk.kty} crv:${jwk.crv}`);
+    throw new Error(`ES256K requires kty:EC and crv:secp256k1 (or legacy crv:P-256K), got kty:${jwk.kty} crv:${jwk.crv}`);
   }
   if (typeof jwk.x !== 'string' || typeof jwk.y !== 'string') {
     throw new Error('JWK missing x/y coordinates');

--- a/src/auth/lws-cid.js
+++ b/src/auth/lws-cid.js
@@ -80,11 +80,17 @@ export function _clearProfileCacheForTests() {
 /**
  * Cheap detector — does this request carry an LWS-CID JWT?
  *
- * True when:
+ * Routes a Bearer JWT to verifyLwsCidAuth only when it shows the
+ * specific LWS-CID shape:
  *   - Authorization: Bearer <token>
  *   - token is a 3-part JWT
- *   - header.kid is a URL with a fragment (which is what an LWS-CID
- *     verificationMethod id always looks like)
+ *   - header.alg is one of our accepted JWS algorithms
+ *   - header.kid is an http(s) URL with a fragment (which is what an
+ *     LWS-CID verificationMethod id always looks like)
+ *
+ * Other JWS algs / non-URL kids fall through to the existing
+ * IdP / simple-token paths in token.js — so this detector is
+ * conservative on purpose.
  *
  * @param {object} request
  * @returns {boolean}
@@ -97,8 +103,11 @@ export function hasLwsCidAuth(request) {
   if (parts.length !== 3) return false;
   try {
     const header = JSON.parse(b64uDecode(parts[0]).toString('utf8'));
-    if (!header || typeof header.kid !== 'string') return false;
+    if (!header) return false;
+    if (typeof header.alg !== 'string' || !ACCEPTED_ALGS.has(header.alg)) return false;
+    if (typeof header.kid !== 'string') return false;
     const u = new URL(header.kid);
+    if (u.protocol !== 'https:' && u.protocol !== 'http:') return false;
     return Boolean(u.hash); // LWS-CID kid is always a fragment URI
   } catch {
     return false;
@@ -241,6 +250,26 @@ export async function verifyLwsCidAuth(request) {
   }
   if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
     return { webId: null, error: 'CID document is not a JSON object' };
+  }
+
+  // Subject-identity check. The CID document we just fetched MUST
+  // actually identify itself as the JWT's `sub`. Without this, a doc
+  // hosted at the same URL could declare itself to be a different
+  // WebID fragment, but reuse a verificationMethod controlled by
+  // another node — and we'd authenticate as `sub` based on the wrong
+  // VM's signature.
+  const profileSubject = absolutize(profile['@id'] ?? profile.id, webIdDoc);
+  if (!profileSubject) {
+    return {
+      webId: null,
+      error: 'CID document declares no subject (@id / id)',
+    };
+  }
+  if (profileSubject !== webId) {
+    return {
+      webId: null,
+      error: `CID document subject (${profileSubject}) does not match JWT sub (${webId})`,
+    };
   }
 
   const vm = findVerificationMethod(profile, header.kid, webIdDoc);

--- a/src/auth/lws-cid.js
+++ b/src/auth/lws-cid.js
@@ -337,11 +337,14 @@ function getRequestOrigin(request) {
   // Multi-proxy chains may produce comma-separated lists (e.g.
   // `x-forwarded-host: a.example, b.internal`); the leftmost value is
   // the original client-facing front-end, which is what we want.
+  //
+  // The result is run through normalizeOrigin so default ports and
+  // case folding match the audList comparison side.
   const headers = request.headers || {};
   const proto = firstHeaderValue(headers['x-forwarded-proto']) || request.protocol || 'https';
   const host  = firstHeaderValue(headers['x-forwarded-host']) || headers.host || request.hostname;
   if (!host) return null;
-  return `${proto}://${host}`;
+  return normalizeOrigin(`${proto}://${host}`);
 }
 
 function firstHeaderValue(v) {

--- a/src/auth/lws-cid.js
+++ b/src/auth/lws-cid.js
@@ -35,6 +35,7 @@
 import * as jose from 'jose';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
+import { validateExternalUrl } from '../utils/ssrf.js';
 
 // JWS algorithms we accept. ES256K (RFC8812) is the primary target —
 // secp256k1, the same curve as Nostr — but we support the common JWS
@@ -48,6 +49,21 @@ const MAX_IAT_AGE = 600; // 10 minutes
 
 // Clock skew tolerance for exp/nbf checks (seconds).
 const CLOCK_SKEW = 60;
+
+// Profile fetch cache. Auth is on the hot path; refetching the CID
+// document on every request is unacceptable for both latency and
+// reliability. Mirrors the pattern in did-nostr.js.
+const profileCache = new Map(); // url -> { profile, timestamp, failureTtl?: true }
+const PROFILE_CACHE_TTL = 5 * 60 * 1000; // 5 minutes for hits
+const PROFILE_FAILURE_TTL = 60 * 1000;   // 1 minute for misses
+
+// Manual-redirect cap so a chain can't loop or grind.
+const MAX_REDIRECTS = 5;
+
+/** @internal — exposed for tests */
+export function _clearProfileCacheForTests() {
+  profileCache.clear();
+}
 
 /**
  * Cheap detector — does this request carry an LWS-CID JWT?
@@ -119,7 +135,7 @@ export async function verifyLwsCidAuth(request) {
   }
 
   // FPWD §4: sub === iss === client_id, all the same WebID URI.
-  const { sub, iss, client_id, aud, exp, iat } = payload;
+  const { sub, iss, client_id, aud, exp, iat, nbf } = payload;
   if (!sub || !iss || !client_id) {
     return { webId: null, error: 'JWT missing sub/iss/client_id' };
   }
@@ -139,24 +155,50 @@ export async function verifyLwsCidAuth(request) {
     };
   }
 
-  // Time checks.
-  const now = Math.floor(Date.now() / 1000);
-  if (typeof exp === 'number' && now > exp + CLOCK_SKEW) {
-    return { webId: null, error: 'JWT expired' };
+  // Time-claim validation. The ES256K branch below skips jose.jwtVerify
+  // and relies on these checks alone, so each claim's TYPE matters as
+  // much as its value — `exp: "9999999999"` (string) must NOT be silently
+  // accepted as a number. Per FPWD §4, exp and iat are both required;
+  // nbf is optional but enforced when present.
+  if (exp !== undefined && typeof exp !== 'number') {
+    return { webId: null, error: 'JWT exp claim must be a number' };
   }
-  if (typeof iat === 'number' && now - iat > MAX_IAT_AGE + CLOCK_SKEW) {
-    return { webId: null, error: 'JWT iat too old' };
+  if (iat !== undefined && typeof iat !== 'number') {
+    return { webId: null, error: 'JWT iat claim must be a number' };
+  }
+  if (nbf !== undefined && typeof nbf !== 'number') {
+    return { webId: null, error: 'JWT nbf claim must be a number' };
   }
   if (typeof iat !== 'number' && typeof exp !== 'number') {
     return { webId: null, error: 'JWT missing both iat and exp' };
   }
+  const now = Math.floor(Date.now() / 1000);
+  if (typeof exp === 'number' && now > exp + CLOCK_SKEW) {
+    return { webId: null, error: 'JWT expired' };
+  }
+  if (typeof nbf === 'number' && now + CLOCK_SKEW < nbf) {
+    return { webId: null, error: 'JWT not yet valid (nbf in the future)' };
+  }
+  if (typeof iat === 'number') {
+    if (now - iat > MAX_IAT_AGE + CLOCK_SKEW) {
+      return { webId: null, error: 'JWT iat too old' };
+    }
+    if (iat - now > CLOCK_SKEW) {
+      return { webId: null, error: 'JWT iat is in the future' };
+    }
+  }
 
-  // Audience check — the request's origin must be in aud.
+  // Audience check — `aud` is required (FPWD §4: "the aud claim MUST
+  // include the target authorization server"), and the request's
+  // origin must appear in it.
   const reqOrigin = getRequestOrigin(request);
+  const audList = aud === undefined ? [] : Array.isArray(aud) ? aud : [aud];
+  if (audList.length === 0) {
+    return { webId: null, error: 'JWT aud claim is required' };
+  }
   if (reqOrigin) {
-    const audList = aud === undefined ? [] : Array.isArray(aud) ? aud : [aud];
     const audMatch = audList.some((a) => normalizeOrigin(a) === reqOrigin);
-    if (audList.length > 0 && !audMatch) {
+    if (!audMatch) {
       return {
         webId: null,
         error: `aud does not include this server's origin (${reqOrigin})`,
@@ -255,9 +297,14 @@ function stripHash(u) {
 }
 
 function getRequestOrigin(request) {
-  const host = request.headers?.host;
+  // Behind a reverse proxy, the front-end forwarded headers are the
+  // authoritative source. Match the convention used in src/ap/* and
+  // similar code: x-forwarded-* take precedence, fall back to fastify's
+  // protocol/hostname.
+  const headers = request.headers || {};
+  const proto = headers['x-forwarded-proto'] || request.protocol || 'https';
+  const host = headers['x-forwarded-host'] || headers.host || request.hostname;
   if (!host) return null;
-  const proto = request.protocol || (request.headers?.['x-forwarded-proto']) || 'https';
   return `${proto}://${host}`;
 }
 
@@ -272,22 +319,85 @@ function normalizeOrigin(s) {
 }
 
 async function fetchProfile(docUrl) {
-  // 5s timeout — profiles are small static documents.
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 5000);
+  // Cache hit (or recent failure) — return immediately.
+  const cached = profileCache.get(docUrl);
+  if (cached) {
+    const ttl = cached.failureTtl ? PROFILE_FAILURE_TTL : PROFILE_CACHE_TTL;
+    if (Date.now() - cached.timestamp < ttl) {
+      if (cached.failureTtl) throw new Error(cached.error);
+      return cached.profile;
+    }
+    profileCache.delete(docUrl);
+  }
+
   try {
-    const res = await fetch(docUrl, {
-      headers: { Accept: 'application/ld+json' },
-      signal: controller.signal,
+    const profile = await fetchProfileNoCache(docUrl);
+    profileCache.set(docUrl, { profile, timestamp: Date.now() });
+    return profile;
+  } catch (err) {
+    profileCache.set(docUrl, {
+      timestamp: Date.now(),
+      failureTtl: true,
+      error: err.message,
     });
+    throw err;
+  }
+}
+
+/**
+ * Fetch the CID document with SSRF protection.
+ *
+ * docUrl comes from JWT claims (sub, kid) BEFORE the signature is
+ * verified, so it's untrusted. We:
+ *   1. Validate it through the existing SSRF guard (blocks loopback,
+ *      private IPs, http (in production), DNS that resolves to private
+ *      addresses).
+ *   2. Disable automatic redirects and re-validate every Location to
+ *      defeat redirect-based bypasses (mirrors the cors-proxy pattern).
+ *   3. Cap redirects so a chain can't loop.
+ *   4. Always send a fresh Accept and a small read-side timeout.
+ */
+async function fetchProfileNoCache(docUrl) {
+  let currentUrl = docUrl;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    const validation = await validateExternalUrl(currentUrl, {
+      // Allow http on dev only — production deploys should always be https.
+      requireHttps: process.env.NODE_ENV === 'production',
+      blockPrivateIPs: true,
+      resolveDNS: true,
+    });
+    if (!validation.valid) {
+      throw new Error(`SSRF protection: ${validation.error}`);
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5000);
+    let res;
+    try {
+      res = await fetch(currentUrl, {
+        headers: { Accept: 'application/ld+json' },
+        redirect: 'manual',
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    // Manual redirect handling — re-validate every Location.
+    if (res.status >= 300 && res.status < 400) {
+      const loc = res.headers.get('location');
+      if (!loc) throw new Error(`redirect ${res.status} without Location`);
+      currentUrl = new URL(loc, currentUrl).toString();
+      continue;
+    }
+
     if (!res.ok) {
       throw new Error(`HTTP ${res.status}`);
     }
     const text = await res.text();
     return JSON.parse(text);
-  } finally {
-    clearTimeout(timer);
   }
+  throw new Error(`too many redirects (>${MAX_REDIRECTS})`);
 }
 
 function findVerificationMethod(profile, kid, baseUrl) {

--- a/src/auth/lws-cid.js
+++ b/src/auth/lws-cid.js
@@ -157,6 +157,13 @@ export async function verifyLwsCidAuth(request) {
   if (!kidUrl.hash) {
     return { webId: null, error: 'kid must be a fragment URI within a CID document' };
   }
+  // Normalize kid via the URL parser's canonicalization (case-folded
+  // scheme/host, default-port stripped, percent-encoded path) so all
+  // downstream comparisons against absolutized VM ids and proof-purpose
+  // refs operate on canonical strings. Otherwise a semantically
+  // equivalent but non-canonical kid in the JWT header would fail to
+  // match the profile's id values.
+  const kid = kidUrl.toString();
 
   // FPWD §4: sub === iss === client_id, all the same WebID URI.
   const { sub, iss, client_id, aud, exp, iat, nbf } = payload;
@@ -170,12 +177,12 @@ export async function verifyLwsCidAuth(request) {
 
   // The kid's document URL must match the WebID's document URL — the VM
   // lives inside the subject's CID document.
-  const kidDoc = stripHash(header.kid);
+  const kidDoc = stripHash(kid);
   const webIdDoc = stripHash(webId);
   if (kidDoc !== webIdDoc) {
     return {
       webId: null,
-      error: `kid (${header.kid}) is not in the subject's CID document (${webIdDoc})`,
+      error: `kid (${kid}) is not in the subject's CID document (${webIdDoc})`,
     };
   }
 
@@ -275,20 +282,20 @@ export async function verifyLwsCidAuth(request) {
     };
   }
 
-  const vm = findVerificationMethod(profile, header.kid, webIdDoc);
+  const vm = findVerificationMethod(profile, kid, webIdDoc);
   if (!vm) {
     return {
       webId: null,
-      error: `no verificationMethod with id ${header.kid} in CID document`,
+      error: `no verificationMethod with id ${kid} in CID document`,
     };
   }
 
   // VM must be referenced by `authentication` to be usable as an auth
   // credential. (CID 1.0 §3.3)
-  if (!isInProofPurpose(profile, 'authentication', header.kid, webIdDoc)) {
+  if (!isInProofPurpose(profile, 'authentication', kid, webIdDoc)) {
     return {
       webId: null,
-      error: `verificationMethod ${header.kid} is not listed in authentication`,
+      error: `verificationMethod ${kid} is not listed in authentication`,
     };
   }
 

--- a/src/auth/lws-cid.js
+++ b/src/auth/lws-cid.js
@@ -165,15 +165,37 @@ export async function verifyLwsCidAuth(request) {
   // match the profile's id values.
   const kid = kidUrl.toString();
 
+  // Auth credentials over plaintext HTTP are a non-starter — fail loud
+  // and early with a clear error rather than letting the request limp
+  // along to a generic "could not fetch / SSRF protection" failure
+  // downstream. (The SSRF guard still has its own production check as
+  // defense-in-depth.)
+  if (kidUrl.protocol !== 'https:') {
+    return { webId: null, error: 'kid must use https' };
+  }
+
   // FPWD §4: sub === iss === client_id, all the same WebID URI.
+  // Compare canonicalized forms so semantically equal but textually
+  // different URIs (different case, default ports written out, etc.)
+  // pass equality. The canonical form is also what we hand back to
+  // callers — WAC and other downstream consumers do string equality on
+  // the WebID, so handing them a non-canonical form would fail to
+  // match ACL agent entries.
   const { sub, iss, client_id, aud, exp, iat, nbf } = payload;
   if (!sub || !iss || !client_id) {
     return { webId: null, error: 'JWT missing sub/iss/client_id' };
   }
-  if (sub !== iss || sub !== client_id) {
+  let webId, canonicalIss, canonicalClientId;
+  try {
+    webId = new URL(sub).toString();
+    canonicalIss = new URL(iss).toString();
+    canonicalClientId = new URL(client_id).toString();
+  } catch (err) {
+    return { webId: null, error: `invalid sub/iss/client_id URI: ${err.message}` };
+  }
+  if (webId !== canonicalIss || webId !== canonicalClientId) {
     return { webId: null, error: 'sub, iss, and client_id MUST all use the same URI value' };
   }
-  const webId = sub;
 
   // The kid's document URL must match the WebID's document URL — the VM
   // lives inside the subject's CID document.

--- a/src/auth/lws-cid.js
+++ b/src/auth/lws-cid.js
@@ -136,7 +136,10 @@ export async function verifyLwsCidAuth(request) {
     return { webId: null, error: `malformed JWT: ${err.message}` };
   }
 
-  if (!header.alg || header.alg === 'none') {
+  if (typeof header.alg !== 'string' || header.alg.length === 0) {
+    return { webId: null, error: 'JWT header missing alg' };
+  }
+  if (header.alg === 'none') {
     return { webId: null, error: 'JWT MUST NOT use "none" as the signing algorithm' };
   }
   if (!ACCEPTED_ALGS.has(header.alg)) {

--- a/src/auth/lws-cid.js
+++ b/src/auth/lws-cid.js
@@ -57,13 +57,20 @@ const CLOCK_SKEW = 60;
 
 // Profile fetch cache. Auth is on the hot path; refetching the CID
 // document on every request is unacceptable for both latency and
-// reliability. Mirrors the pattern in did-nostr.js.
-const profileCache = new Map(); // url -> { profile, timestamp, failureTtl?: true }
+// reliability. Mirrors the pattern in did-nostr.js, but bounded — an
+// attacker can otherwise grow the cache without limit by sending tokens
+// with many distinct `sub` URLs.
+const profileCache = new Map(); // url -> { profile, timestamp, failureTtl?, error? }
 const PROFILE_CACHE_TTL = 5 * 60 * 1000; // 5 minutes for hits
 const PROFILE_FAILURE_TTL = 60 * 1000;   // 1 minute for misses
+const PROFILE_CACHE_MAX = 1000;          // simple LRU bound
 
 // Manual-redirect cap so a chain can't loop or grind.
 const MAX_REDIRECTS = 5;
+
+// Max profile body size — guards against DoS via giant JSON bodies on
+// untrusted URLs. CID documents are tiny in practice (~1-5 KB).
+const MAX_PROFILE_BYTES = 256 * 1024; // 256 KB
 
 /** @internal — exposed for tests */
 export function _clearProfileCacheForTests() {
@@ -253,18 +260,24 @@ export async function verifyLwsCidAuth(request) {
     };
   }
 
-  // Confirm the VM's controller agrees with the profile's controller (or
-  // with @id on fallback). Self-controlled is the common case.
+  // Confirm the VM's controller agrees with the profile's controller
+  // (or with @id on fallback). Self-controlled is the common case. A
+  // profile with no controller / @id / id at all is malformed — fail
+  // closed rather than letting the VM controller check pass vacuously.
   const expectedCtrls = normalizeControllers(profile.controller ?? profile['@id'] ?? profile.id, webIdDoc);
+  if (expectedCtrls.length === 0) {
+    return {
+      webId: null,
+      error: 'CID document has no controller or @id — controller check cannot proceed',
+    };
+  }
   const vmCtrls = normalizeControllers(vm.controller, webIdDoc);
-  if (expectedCtrls.length > 0) {
-    const matched = vmCtrls.some((c) => expectedCtrls.includes(c));
-    if (!matched) {
-      return {
-        webId: null,
-        error: `verificationMethod controller does not match profile controller`,
-      };
-    }
+  const matched = vmCtrls.some((c) => expectedCtrls.includes(c));
+  if (!matched) {
+    return {
+      webId: null,
+      error: 'verificationMethod controller does not match profile controller',
+    };
   }
 
   // Decode the JWK and verify the signature.
@@ -320,11 +333,24 @@ function getRequestOrigin(request) {
   // authoritative source. Match the convention used in src/ap/* and
   // similar code: x-forwarded-* take precedence, fall back to fastify's
   // protocol/hostname.
+  //
+  // Multi-proxy chains may produce comma-separated lists (e.g.
+  // `x-forwarded-host: a.example, b.internal`); the leftmost value is
+  // the original client-facing front-end, which is what we want.
   const headers = request.headers || {};
-  const proto = headers['x-forwarded-proto'] || request.protocol || 'https';
-  const host = headers['x-forwarded-host'] || headers.host || request.hostname;
+  const proto = firstHeaderValue(headers['x-forwarded-proto']) || request.protocol || 'https';
+  const host  = firstHeaderValue(headers['x-forwarded-host']) || headers.host || request.hostname;
   if (!host) return null;
   return `${proto}://${host}`;
+}
+
+function firstHeaderValue(v) {
+  if (!v) return null;
+  // Fastify can yield a string, an array, or undefined.
+  const s = Array.isArray(v) ? v[0] : v;
+  if (typeof s !== 'string') return null;
+  const first = s.split(',')[0].trim();
+  return first || null;
 }
 
 function normalizeOrigin(s) {
@@ -338,11 +364,15 @@ function normalizeOrigin(s) {
 }
 
 async function fetchProfile(docUrl) {
-  // Cache hit (or recent failure) — return immediately.
+  // Cache hit (or recent failure) — return immediately. On hit we
+  // delete-then-reset so this entry moves to the tail of the Map's
+  // insertion order, giving us LRU eviction without an extra structure.
   const cached = profileCache.get(docUrl);
   if (cached) {
     const ttl = cached.failureTtl ? PROFILE_FAILURE_TTL : PROFILE_CACHE_TTL;
     if (Date.now() - cached.timestamp < ttl) {
+      profileCache.delete(docUrl);
+      profileCache.set(docUrl, cached);
       if (cached.failureTtl) throw new Error(cached.error);
       return cached.profile;
     }
@@ -351,15 +381,26 @@ async function fetchProfile(docUrl) {
 
   try {
     const profile = await fetchProfileNoCache(docUrl);
-    profileCache.set(docUrl, { profile, timestamp: Date.now() });
+    setCached(docUrl, { profile, timestamp: Date.now() });
     return profile;
   } catch (err) {
-    profileCache.set(docUrl, {
+    setCached(docUrl, {
       timestamp: Date.now(),
       failureTtl: true,
       error: err.message,
     });
     throw err;
+  }
+}
+
+/** Insert into the bounded LRU; evict the oldest entry past the cap. */
+function setCached(url, entry) {
+  profileCache.set(url, entry);
+  while (profileCache.size > PROFILE_CACHE_MAX) {
+    // Map iterates in insertion order; first key is the oldest.
+    const oldest = profileCache.keys().next().value;
+    if (oldest === undefined) break;
+    profileCache.delete(oldest);
   }
 }
 
@@ -373,11 +414,17 @@ async function fetchProfile(docUrl) {
  *      addresses).
  *   2. Disable automatic redirects and re-validate every Location to
  *      defeat redirect-based bypasses (mirrors the cors-proxy pattern).
+ *      Cross-origin redirects are refused — otherwise a target
+ *      attacker-controlled host could serve a substitute CID document
+ *      for the WebID's origin.
  *   3. Cap redirects so a chain can't loop.
- *   4. Always send a fresh Accept and a small read-side timeout.
+ *   4. Cap response body size so a giant payload can't OOM us.
+ *   5. Always send a fresh Accept and a small read-side timeout.
  */
 async function fetchProfileNoCache(docUrl) {
+  const originalOrigin = new URL(docUrl).origin;
   let currentUrl = docUrl;
+
   // Hop 0 is the original request; up to MAX_REDIRECTS subsequent
   // redirects are followed, after which we throw.
   for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
@@ -408,25 +455,73 @@ async function fetchProfileNoCache(docUrl) {
       clearTimeout(timer);
     }
 
-    // Manual redirect handling — re-validate every Location.
+    // Manual redirect handling — re-validate every Location and require
+    // same-origin so a redirect can't substitute an attacker-controlled
+    // CID document for the WebID's origin.
     if (res.status >= 300 && res.status < 400) {
       if (isLastAllowedHop) {
         throw new Error(`too many redirects (>${MAX_REDIRECTS})`);
       }
       const loc = res.headers.get('location');
       if (!loc) throw new Error(`redirect ${res.status} without Location`);
-      currentUrl = new URL(loc, currentUrl).toString();
+      const nextUrl = new URL(loc, currentUrl).toString();
+      const nextOrigin = new URL(nextUrl).origin;
+      if (nextOrigin !== originalOrigin) {
+        throw new Error(
+          `cross-origin redirect refused: ${originalOrigin} → ${nextOrigin}`,
+        );
+      }
+      currentUrl = nextUrl;
       continue;
     }
 
     if (!res.ok) {
       throw new Error(`HTTP ${res.status}`);
     }
-    const text = await res.text();
+
+    // Size guard. Two layers: trust Content-Length when present, then
+    // also enforce as we read so a streaming response can't lie.
+    const declared = Number(res.headers.get('content-length'));
+    if (Number.isFinite(declared) && declared > MAX_PROFILE_BYTES) {
+      throw new Error(
+        `CID document too large (Content-Length=${declared} > ${MAX_PROFILE_BYTES})`,
+      );
+    }
+    const text = await readBodyWithCap(res, MAX_PROFILE_BYTES);
     return JSON.parse(text);
   }
   // Loop exited without returning or redirecting — defensive fallback.
   throw new Error('profile fetch loop exited unexpectedly');
+}
+
+/**
+ * Read response body with a hard byte cap. Aborts the stream as soon as
+ * the cap is exceeded so we don't buffer the entire untrusted payload.
+ */
+async function readBodyWithCap(res, maxBytes) {
+  const reader = res.body?.getReader?.();
+  if (!reader) {
+    // No streaming reader (older runtimes / mocked responses) — fall
+    // back to .text() but enforce the cap after the fact.
+    const text = await res.text();
+    if (Buffer.byteLength(text, 'utf8') > maxBytes) {
+      throw new Error(`CID document too large (>${maxBytes} bytes)`);
+    }
+    return text;
+  }
+  const chunks = [];
+  let total = 0;
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      try { await reader.cancel(); } catch { /* noop */ }
+      throw new Error(`CID document too large (>${maxBytes} bytes)`);
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks.map((c) => Buffer.from(c.buffer, c.byteOffset, c.byteLength))).toString('utf8');
 }
 
 function findVerificationMethod(profile, kid, baseUrl) {

--- a/src/auth/lws-cid.js
+++ b/src/auth/lws-cid.js
@@ -1,0 +1,381 @@
+/**
+ * LWS 1.0 Authentication Suite — Self-Signed Identity using Controlled Identifiers
+ *
+ * Implements the verifier side of the LWS10-CID FPWD (2026-04-23):
+ *   https://www.w3.org/TR/2026/WD-lws10-authn-ssi-cid-20260423/
+ *
+ * The credential is a JWT (RFC7515 / RFC7519) signed with a JWS algorithm.
+ * The verifier:
+ *
+ *   1. Reads `kid` from the JWT header. Per LWS10-CID, `kid` references a
+ *      verificationMethod inside the subject's controlled identifier
+ *      document — for a Solid pod, that document IS the WebID profile.
+ *   2. Validates the FPWD §4 constraints: `sub === iss === client_id`
+ *      (all the same WebID URI), `aud` includes the target server, `exp`
+ *      not past, `iat` recent.
+ *   3. Fetches the WebID profile, locates the verificationMethod by `kid`.
+ *   4. Decodes its `publicKeyJwk`.
+ *   5. Verifies the JWT signature per RFC7515 §5.2.
+ *   6. Confirms the VM's `controller` matches the profile's declared
+ *      controller (with fallback to @id) — same self-control rule the
+ *      doctor's lws-cid validator uses on the client side.
+ *   7. Returns the WebID as the authenticated identity.
+ *
+ * Design choices:
+ *
+ * - Detection is unambiguous: LWS-CID JWTs have a `kid` whose value is a
+ *   URL with a fragment (the VM's `id`). IDP-issued JWTs (the existing
+ *   `verifyJwtFromIdp` path) use opaque fingerprints. We route on shape.
+ *
+ * - secp256k1 / ES256K is the focus algorithm — same key Nostr users
+ *   already have, signed as ECDSA for spec conformance. ES256 / EdDSA /
+ *   RS256 also accepted; jose handles those natively.
+ */
+
+import * as jose from 'jose';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { sha256 } from '@noble/hashes/sha256';
+
+// JWS algorithms we accept. ES256K (RFC8812) is the primary target —
+// secp256k1, the same curve as Nostr — but we support the common JWS
+// algorithms too so other CID-document key shapes work out of the box.
+const ACCEPTED_ALGS = new Set(['ES256K', 'ES256', 'ES384', 'EdDSA', 'RS256']);
+
+// Maximum age for the iat (issued-at) claim, in seconds. JWT-as-HTTP-auth
+// tokens are expected to be freshly minted; rejecting stale ones limits
+// replay if an exp claim is sloppy or absent.
+const MAX_IAT_AGE = 600; // 10 minutes
+
+// Clock skew tolerance for exp/nbf checks (seconds).
+const CLOCK_SKEW = 60;
+
+/**
+ * Cheap detector — does this request carry an LWS-CID JWT?
+ *
+ * True when:
+ *   - Authorization: Bearer <token>
+ *   - token is a 3-part JWT
+ *   - header.kid is a URL with a fragment (which is what an LWS-CID
+ *     verificationMethod id always looks like)
+ *
+ * @param {object} request
+ * @returns {boolean}
+ */
+export function hasLwsCidAuth(request) {
+  const auth = request.headers?.authorization;
+  if (!auth || typeof auth !== 'string' || !auth.startsWith('Bearer ')) return false;
+  const token = auth.slice(7).trim();
+  const parts = token.split('.');
+  if (parts.length !== 3) return false;
+  try {
+    const header = JSON.parse(b64uDecode(parts[0]).toString('utf8'));
+    if (!header || typeof header.kid !== 'string') return false;
+    const u = new URL(header.kid);
+    return Boolean(u.hash); // LWS-CID kid is always a fragment URI
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verify an LWS-CID JWT and return the authenticated WebID.
+ *
+ * @param {object} request
+ * @returns {Promise<{webId: string|null, error: string|null}>}
+ */
+export async function verifyLwsCidAuth(request) {
+  const auth = request.headers?.authorization;
+  if (!auth || !auth.startsWith('Bearer ')) {
+    return { webId: null, error: 'missing Bearer token' };
+  }
+  const token = auth.slice(7).trim();
+
+  // Decode header + payload without verifying so we can pick the key.
+  let header, payload;
+  try {
+    header = jose.decodeProtectedHeader(token);
+    payload = jose.decodeJwt(token);
+  } catch (err) {
+    return { webId: null, error: `malformed JWT: ${err.message}` };
+  }
+
+  if (!header.alg || header.alg === 'none') {
+    return { webId: null, error: 'JWT MUST NOT use "none" as the signing algorithm' };
+  }
+  if (!ACCEPTED_ALGS.has(header.alg)) {
+    return { webId: null, error: `unsupported alg: ${header.alg}` };
+  }
+  if (typeof header.kid !== 'string' || !header.kid) {
+    return { webId: null, error: 'missing kid' };
+  }
+  let kidUrl;
+  try {
+    kidUrl = new URL(header.kid);
+  } catch {
+    return { webId: null, error: 'kid is not a URL' };
+  }
+  if (!kidUrl.hash) {
+    return { webId: null, error: 'kid must be a fragment URI within a CID document' };
+  }
+
+  // FPWD §4: sub === iss === client_id, all the same WebID URI.
+  const { sub, iss, client_id, aud, exp, iat } = payload;
+  if (!sub || !iss || !client_id) {
+    return { webId: null, error: 'JWT missing sub/iss/client_id' };
+  }
+  if (sub !== iss || sub !== client_id) {
+    return { webId: null, error: 'sub, iss, and client_id MUST all use the same URI value' };
+  }
+  const webId = sub;
+
+  // The kid's document URL must match the WebID's document URL — the VM
+  // lives inside the subject's CID document.
+  const kidDoc = stripHash(header.kid);
+  const webIdDoc = stripHash(webId);
+  if (kidDoc !== webIdDoc) {
+    return {
+      webId: null,
+      error: `kid (${header.kid}) is not in the subject's CID document (${webIdDoc})`,
+    };
+  }
+
+  // Time checks.
+  const now = Math.floor(Date.now() / 1000);
+  if (typeof exp === 'number' && now > exp + CLOCK_SKEW) {
+    return { webId: null, error: 'JWT expired' };
+  }
+  if (typeof iat === 'number' && now - iat > MAX_IAT_AGE + CLOCK_SKEW) {
+    return { webId: null, error: 'JWT iat too old' };
+  }
+  if (typeof iat !== 'number' && typeof exp !== 'number') {
+    return { webId: null, error: 'JWT missing both iat and exp' };
+  }
+
+  // Audience check — the request's origin must be in aud.
+  const reqOrigin = getRequestOrigin(request);
+  if (reqOrigin) {
+    const audList = aud === undefined ? [] : Array.isArray(aud) ? aud : [aud];
+    const audMatch = audList.some((a) => normalizeOrigin(a) === reqOrigin);
+    if (audList.length > 0 && !audMatch) {
+      return {
+        webId: null,
+        error: `aud does not include this server's origin (${reqOrigin})`,
+      };
+    }
+  }
+
+  // Fetch the CID document (= WebID profile) and locate the VM by kid.
+  let profile;
+  try {
+    profile = await fetchProfile(webIdDoc);
+  } catch (err) {
+    return { webId: null, error: `could not fetch CID document: ${err.message}` };
+  }
+  if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+    return { webId: null, error: 'CID document is not a JSON object' };
+  }
+
+  const vm = findVerificationMethod(profile, header.kid, webIdDoc);
+  if (!vm) {
+    return {
+      webId: null,
+      error: `no verificationMethod with id ${header.kid} in CID document`,
+    };
+  }
+
+  // VM must be referenced by `authentication` to be usable as an auth
+  // credential. (CID 1.0 §3.3)
+  if (!isInProofPurpose(profile, 'authentication', vm, header.kid, webIdDoc)) {
+    return {
+      webId: null,
+      error: `verificationMethod ${header.kid} is not listed in authentication`,
+    };
+  }
+
+  // Confirm the VM's controller agrees with the profile's controller (or
+  // with @id on fallback). Self-controlled is the common case.
+  const expectedCtrls = normalizeControllers(profile.controller ?? profile['@id'] ?? profile.id, webIdDoc);
+  const vmCtrls = normalizeControllers(vm.controller, webIdDoc);
+  if (expectedCtrls.length > 0) {
+    const matched = vmCtrls.some((c) => expectedCtrls.includes(c));
+    if (!matched) {
+      return {
+        webId: null,
+        error: `verificationMethod controller does not match profile controller`,
+      };
+    }
+  }
+
+  // Decode the JWK and verify the signature.
+  if (!vm.publicKeyJwk || typeof vm.publicKeyJwk !== 'object') {
+    return {
+      webId: null,
+      error: 'verificationMethod has no publicKeyJwk (Multikey-only VMs not yet handled here)',
+    };
+  }
+  const jwk = vm.publicKeyJwk;
+
+  try {
+    if (header.alg === 'ES256K') {
+      // jose's Web Crypto path doesn't support secp256k1 in all
+      // environments. Verify with @noble/curves directly — same primitive
+      // we already use for Schnorr in the Nostr path.
+      await verifyEs256kJwt(token, jwk);
+    } else {
+      const key = await jose.importJWK(jwk, header.alg);
+      await jose.jwtVerify(token, key, {
+        algorithms: [header.alg],
+        clockTolerance: CLOCK_SKEW,
+      });
+    }
+  } catch (err) {
+    return { webId: null, error: `signature verification failed: ${err.message}` };
+  }
+
+  return { webId, error: null };
+}
+
+// ---------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------
+
+function b64uDecode(s) {
+  return Buffer.from(s.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
+}
+
+function stripHash(u) {
+  if (typeof u !== 'string') return u;
+  try {
+    const url = new URL(u);
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return u.split('#')[0];
+  }
+}
+
+function getRequestOrigin(request) {
+  const host = request.headers?.host;
+  if (!host) return null;
+  const proto = request.protocol || (request.headers?.['x-forwarded-proto']) || 'https';
+  return `${proto}://${host}`;
+}
+
+function normalizeOrigin(s) {
+  if (typeof s !== 'string') return null;
+  try {
+    const u = new URL(s);
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return s;
+  }
+}
+
+async function fetchProfile(docUrl) {
+  // 5s timeout — profiles are small static documents.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
+  try {
+    const res = await fetch(docUrl, {
+      headers: { Accept: 'application/ld+json' },
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    const text = await res.text();
+    return JSON.parse(text);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function findVerificationMethod(profile, kid, baseUrl) {
+  const vms = asArray(profile.verificationMethod);
+  for (const vm of vms) {
+    if (!vm || typeof vm !== 'object') continue;
+    const vmId = vm.id || vm['@id'];
+    if (!vmId) continue;
+    if (absolutize(vmId, baseUrl) === kid) return vm;
+  }
+  return null;
+}
+
+function isInProofPurpose(profile, predicate, vm, kid, baseUrl) {
+  const entries = asArray(profile[predicate]);
+  if (entries.length === 0) return false;
+  for (const ent of entries) {
+    if (typeof ent === 'string') {
+      if (absolutize(ent, baseUrl) === kid) return true;
+    } else if (ent && typeof ent === 'object') {
+      const id = ent['@id'] ?? ent.id;
+      if (id && absolutize(id, baseUrl) === kid) return true;
+    }
+  }
+  return false;
+}
+
+function normalizeControllers(value, baseUrl) {
+  if (value === undefined || value === null) return [];
+  const list = Array.isArray(value) ? value : [value];
+  const out = [];
+  for (const v of list) {
+    let iri;
+    if (typeof v === 'string') iri = v;
+    else if (v && typeof v === 'object') iri = v['@id'] ?? v.id;
+    if (typeof iri !== 'string' || iri.length === 0) continue;
+    out.push(absolutize(iri, baseUrl));
+  }
+  return out;
+}
+
+function asArray(v) {
+  if (v === undefined || v === null) return [];
+  return Array.isArray(v) ? v : [v];
+}
+
+function absolutize(u, base) {
+  if (!u) return u;
+  try {
+    return new URL(u, base).toString();
+  } catch {
+    return u;
+  }
+}
+
+/**
+ * Verify a JWT signed with ES256K (ECDSA over secp256k1) using
+ * @noble/curves. Returns on success, throws on failure.
+ *
+ * Web Crypto / jose lack uniform secp256k1 support across Node versions,
+ * and this primitive is already in tree (used by NIP-98 / Nostr). The
+ * curve (secp256k1) is the same one Nostr keys live on, so a Nostr
+ * private key can sign here without any new key material.
+ */
+async function verifyEs256kJwt(token, jwk) {
+  if (jwk.kty !== 'EC' || (jwk.crv !== 'secp256k1' && jwk.crv !== 'P-256K')) {
+    throw new Error(`ES256K requires kty:EC crv:secp256k1, got kty:${jwk.kty} crv:${jwk.crv}`);
+  }
+  if (typeof jwk.x !== 'string' || typeof jwk.y !== 'string') {
+    throw new Error('JWK missing x/y coordinates');
+  }
+  // Build the uncompressed SEC1 public point: 0x04 || x || y
+  const x = b64uDecode(jwk.x);
+  const y = b64uDecode(jwk.y);
+  if (x.length !== 32 || y.length !== 32) {
+    throw new Error(`secp256k1 coordinates must be 32 bytes; got x=${x.length} y=${y.length}`);
+  }
+  const pub = Buffer.concat([Buffer.from([0x04]), x, y]);
+
+  const [headerB64, payloadB64, sigB64] = token.split('.');
+  const signingInput = Buffer.from(`${headerB64}.${payloadB64}`, 'utf8');
+  const sigRaw = b64uDecode(sigB64);
+  if (sigRaw.length !== 64) {
+    throw new Error(`ES256K signature must be 64 bytes (r||s); got ${sigRaw.length}`);
+  }
+
+  const msgHash = sha256(signingInput);
+  const sig = secp256k1.Signature.fromCompact(sigRaw);
+  const ok = secp256k1.verify(sig, msgHash, pub);
+  if (!ok) throw new Error('signature is not valid');
+}

--- a/src/auth/lws-cid.js
+++ b/src/auth/lws-cid.js
@@ -44,8 +44,13 @@ const ACCEPTED_ALGS = new Set(['ES256K', 'ES256', 'ES384', 'EdDSA', 'RS256']);
 
 // Maximum age for the iat (issued-at) claim, in seconds. JWT-as-HTTP-auth
 // tokens are expected to be freshly minted; rejecting stale ones limits
-// replay if an exp claim is sloppy or absent.
+// replay damage.
 const MAX_IAT_AGE = 600; // 10 minutes
+
+// Maximum allowed token lifetime (exp − iat). Auth tokens are short-lived
+// by design; arbitrarily long-lived JWTs widen the replay window if a
+// signed token leaks.
+const MAX_LIFETIME = 3600; // 1 hour
 
 // Clock skew tolerance for exp/nbf checks (seconds).
 const CLOCK_SKEW = 60;
@@ -157,35 +162,42 @@ export async function verifyLwsCidAuth(request) {
 
   // Time-claim validation. The ES256K branch below skips jose.jwtVerify
   // and relies on these checks alone, so each claim's TYPE matters as
-  // much as its value — `exp: "9999999999"` (string) must NOT be silently
-  // accepted as a number. Per FPWD §4, exp and iat are both required;
-  // nbf is optional but enforced when present.
-  if (exp !== undefined && typeof exp !== 'number') {
-    return { webId: null, error: 'JWT exp claim must be a number' };
+  // much as its value — `exp: "9999999999"` (string) must NOT be
+  // silently accepted as a number.
+  //
+  // Per FPWD §4, both iat and exp are MUST; nbf is optional but enforced
+  // when present. We additionally cap the lifetime (exp − iat) to bound
+  // the replay window if a signed token leaks.
+  if (typeof exp !== 'number') {
+    return { webId: null, error: 'JWT exp claim is required and must be a number' };
   }
-  if (iat !== undefined && typeof iat !== 'number') {
-    return { webId: null, error: 'JWT iat claim must be a number' };
+  if (typeof iat !== 'number') {
+    return { webId: null, error: 'JWT iat claim is required and must be a number' };
   }
   if (nbf !== undefined && typeof nbf !== 'number') {
     return { webId: null, error: 'JWT nbf claim must be a number' };
   }
-  if (typeof iat !== 'number' && typeof exp !== 'number') {
-    return { webId: null, error: 'JWT missing both iat and exp' };
-  }
   const now = Math.floor(Date.now() / 1000);
-  if (typeof exp === 'number' && now > exp + CLOCK_SKEW) {
+  if (now > exp + CLOCK_SKEW) {
     return { webId: null, error: 'JWT expired' };
   }
   if (typeof nbf === 'number' && now + CLOCK_SKEW < nbf) {
     return { webId: null, error: 'JWT not yet valid (nbf in the future)' };
   }
-  if (typeof iat === 'number') {
-    if (now - iat > MAX_IAT_AGE + CLOCK_SKEW) {
-      return { webId: null, error: 'JWT iat too old' };
-    }
-    if (iat - now > CLOCK_SKEW) {
-      return { webId: null, error: 'JWT iat is in the future' };
-    }
+  if (now - iat > MAX_IAT_AGE + CLOCK_SKEW) {
+    return { webId: null, error: 'JWT iat too old' };
+  }
+  if (iat - now > CLOCK_SKEW) {
+    return { webId: null, error: 'JWT iat is in the future' };
+  }
+  if (exp - iat > MAX_LIFETIME) {
+    return {
+      webId: null,
+      error: `JWT lifetime exceeds maximum (${exp - iat}s > ${MAX_LIFETIME}s)`,
+    };
+  }
+  if (exp <= iat) {
+    return { webId: null, error: 'JWT exp must be after iat' };
   }
 
   // Audience check — `aud` is required (FPWD §4: "the aud claim MUST
@@ -227,7 +239,7 @@ export async function verifyLwsCidAuth(request) {
 
   // VM must be referenced by `authentication` to be usable as an auth
   // credential. (CID 1.0 §3.3)
-  if (!isInProofPurpose(profile, 'authentication', vm, header.kid, webIdDoc)) {
+  if (!isInProofPurpose(profile, 'authentication', header.kid, webIdDoc)) {
     return {
       webId: null,
       error: `verificationMethod ${header.kid} is not listed in authentication`,
@@ -359,7 +371,10 @@ async function fetchProfile(docUrl) {
  */
 async function fetchProfileNoCache(docUrl) {
   let currentUrl = docUrl;
+  // Hop 0 is the original request; up to MAX_REDIRECTS subsequent
+  // redirects are followed, after which we throw.
   for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    const isLastAllowedHop = hop === MAX_REDIRECTS;
     const validation = await validateExternalUrl(currentUrl, {
       // Allow http on dev only — production deploys should always be https.
       requireHttps: process.env.NODE_ENV === 'production',
@@ -385,6 +400,9 @@ async function fetchProfileNoCache(docUrl) {
 
     // Manual redirect handling — re-validate every Location.
     if (res.status >= 300 && res.status < 400) {
+      if (isLastAllowedHop) {
+        throw new Error(`too many redirects (>${MAX_REDIRECTS})`);
+      }
       const loc = res.headers.get('location');
       if (!loc) throw new Error(`redirect ${res.status} without Location`);
       currentUrl = new URL(loc, currentUrl).toString();
@@ -397,7 +415,8 @@ async function fetchProfileNoCache(docUrl) {
     const text = await res.text();
     return JSON.parse(text);
   }
-  throw new Error(`too many redirects (>${MAX_REDIRECTS})`);
+  // Loop exited without returning or redirecting — defensive fallback.
+  throw new Error('profile fetch loop exited unexpectedly');
 }
 
 function findVerificationMethod(profile, kid, baseUrl) {
@@ -411,7 +430,7 @@ function findVerificationMethod(profile, kid, baseUrl) {
   return null;
 }
 
-function isInProofPurpose(profile, predicate, vm, kid, baseUrl) {
+function isInProofPurpose(profile, predicate, kid, baseUrl) {
   const entries = asArray(profile[predicate]);
   if (entries.length === 0) return false;
   for (const ent of entries) {

--- a/src/auth/token.js
+++ b/src/auth/token.js
@@ -4,11 +4,14 @@
  * Supports multiple modes:
  * 1. Simple tokens (for local/dev use): base64(JSON({webId, iat, exp})) + HMAC signature
  * 2. Solid-OIDC DPoP tokens (for federation): verified via external IdP JWKS
- * 3. Nostr NIP-98 tokens: Schnorr signatures, returns did:nostr identity
+ * 3. LWS10-CID JWTs (FPWD 2026-04-23): kid points at a verificationMethod
+ *    in the subject's WebID profile; signed with a JWS alg (ES256K, ES256, …)
+ * 4. Nostr NIP-98 tokens: Schnorr signatures, returns did:nostr identity
  */
 
 import crypto from 'crypto';
 import { verifySolidOidc, hasSolidOidcAuth } from './solid-oidc.js';
+import { verifyLwsCidAuth, hasLwsCidAuth } from './lws-cid.js';
 import { verifyNostrAuth, hasNostrAuth } from './nostr.js';
 import { webIdTlsAuth, hasClientCertificate } from './webid-tls.js';
 import { resolveTokenSecret } from './token-secret.js';
@@ -203,6 +206,14 @@ export async function getWebIdFromRequestAsync(request) {
     // Try Solid-OIDC first (DPoP tokens)
     if (hasSolidOidcAuth(request)) {
       return verifySolidOidc(request);
+    }
+
+    // Try LWS10-CID (Bearer JWT whose kid is a fragment URL into a CID
+    // document). Detected by header shape, so it doesn't conflict with
+    // the IDP-issued JWTs handled in the Bearer fallback below — those
+    // use opaque fingerprint kids, not URLs.
+    if (hasLwsCidAuth(request)) {
+      return verifyLwsCidAuth(request);
     }
 
     // Try Nostr NIP-98 (Schnorr signatures)

--- a/test/lws-cid.test.js
+++ b/test/lws-cid.test.js
@@ -212,6 +212,19 @@ describe('verifyLwsCidAuth', () => {
     assert.match(r.error, /none/);
   });
 
+  it('rejects missing alg with a distinct error (not the "none" message)', async () => {
+    // Built without an alg header. The detector would normally screen
+    // these out, but the verifier should still produce a clear error
+    // if called directly (defense-in-depth).
+    const h64 = b64u(Buffer.from(JSON.stringify({ kid: VM_ID, typ: 'JWT' })));
+    const p64 = b64u(Buffer.from(JSON.stringify(claims())));
+    const sig = b64u(Buffer.from('not-a-real-signature'));
+    const token = `${h64}.${p64}.${sig}`;
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /missing alg/);
+    assert.doesNotMatch(r.error, /"none"/);
+  });
+
   it('rejects when sub != iss', async () => {
     const token = makeJwt({
       privKey: priv,

--- a/test/lws-cid.test.js
+++ b/test/lws-cid.test.js
@@ -258,7 +258,7 @@ describe('verifyLwsCidAuth', () => {
       payload: claims(now, { exp: '9999999999' }),
     });
     const r = await verifyLwsCidAuth(makeRequest(token));
-    assert.match(r.error, /exp claim must be a number/);
+    assert.match(r.error, /exp claim/);
   });
 
   it('rejects non-numeric iat', async () => {
@@ -269,7 +269,51 @@ describe('verifyLwsCidAuth', () => {
       payload: claims(now, { iat: 'right-now' }),
     });
     const r = await verifyLwsCidAuth(makeRequest(token));
-    assert.match(r.error, /iat claim must be a number/);
+    assert.match(r.error, /iat claim/);
+  });
+
+  it('rejects missing exp', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: claims(now, { exp: undefined }),
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /exp claim is required/);
+  });
+
+  it('rejects missing iat', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: claims(now, { iat: undefined }),
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /iat claim is required/);
+  });
+
+  it('rejects lifetime > 1 hour (replay window cap)', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: claims(now, { iat: now, exp: now + 7200 }),
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /lifetime exceeds maximum/);
+  });
+
+  it('rejects exp <= iat', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: claims(now, { iat: now, exp: now }),
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /exp must be after iat/);
   });
 
   it('rejects missing aud', async () => {

--- a/test/lws-cid.test.js
+++ b/test/lws-cid.test.js
@@ -531,6 +531,38 @@ describe('verifyLwsCidAuth', () => {
     assert.strictEqual(r.webId, WEBID);
   });
 
+  it('rejects http: kid early with a clear message (not a generic SSRF failure)', async () => {
+    const httpKid = 'http://example.com/profile/card.jsonld#k1';
+    const httpSub = 'http://example.com/profile/card.jsonld#me';
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: httpKid },
+      payload: claims(undefined, { sub: httpSub, iss: httpSub, client_id: httpSub }),
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /kid must use https/);
+  });
+
+  it('canonicalizes sub (case/default-port) before subject-identity check', async () => {
+    // JWT carries non-canonical sub/iss/client_id (uppercase scheme,
+    // explicit default port). Profile @id is canonical. After
+    // canonicalization, both should match and the returned webId is
+    // canonical (so downstream WAC ACL string matching works).
+    const noncanonical = 'HTTPS://Example.COM:443/profile/card.jsonld#me';
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: claims(undefined, {
+        sub: noncanonical,
+        iss: noncanonical,
+        client_id: noncanonical,
+      }),
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.strictEqual(r.error, null);
+    assert.strictEqual(r.webId, WEBID); // canonical form returned
+  });
+
   it('canonicalizes kid (case/default-port) before matching VM ids', async () => {
     // JWT carries a non-canonical kid (uppercase scheme + host,
     // explicit default port); the profile's VM id is canonical.

--- a/test/lws-cid.test.js
+++ b/test/lws-cid.test.js
@@ -10,7 +10,8 @@ import { describe, it, before, beforeEach, after } from 'node:test';
 import assert from 'node:assert';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
-import { hasLwsCidAuth, verifyLwsCidAuth } from '../src/auth/lws-cid.js';
+import * as jose from 'jose';
+import { hasLwsCidAuth, verifyLwsCidAuth, _clearProfileCacheForTests } from '../src/auth/lws-cid.js';
 
 // --- helpers ---------------------------------------------------------
 
@@ -40,7 +41,7 @@ function makeJwt({ privKey, header, payload }) {
   return `${h64}.${p64}.${b64u(sig.toCompactRawBytes())}`;
 }
 
-function makeRequest(token, { host = 'pod.example', proto = 'https' } = {}) {
+function makeRequest(token, { host = 'example.com', proto = 'https' } = {}) {
   return {
     headers: {
       authorization: `Bearer ${token}`,
@@ -50,10 +51,10 @@ function makeRequest(token, { host = 'pod.example', proto = 'https' } = {}) {
   };
 }
 
-const WEBID = 'https://pod.example/profile/card.jsonld#me';
-const DOC_URL = 'https://pod.example/profile/card.jsonld';
+const WEBID = 'https://example.com/profile/card.jsonld#me';
+const DOC_URL = 'https://example.com/profile/card.jsonld';
 const VM_ID = `${DOC_URL}#nostr-key-1`;
-const POD_ORIGIN = 'https://pod.example';
+const POD_ORIGIN = 'https://example.com';
 
 // Minimal CID-shaped profile.
 function buildProfile(jwk, { withAuthRef = true, controller = WEBID } = {}) {
@@ -139,6 +140,10 @@ describe('hasLwsCidAuth', () => {
 describe('verifyLwsCidAuth', () => {
   let priv;
   let jwk;
+  // Default valid claims — tests can override per-case.
+  function claims(now = Math.floor(Date.now() / 1000), extra = {}) {
+    return { sub: WEBID, iss: WEBID, client_id: WEBID, aud: [POD_ORIGIN], iat: now, exp: now + 60, ...extra };
+  }
 
   before(() => {
     installFetchStub();
@@ -153,17 +158,16 @@ describe('verifyLwsCidAuth', () => {
     jwk = jwkFromSecp256k1(priv);
     nextStatus = 200;
     nextProfile = buildProfile(jwk);
+    // Cache must not survive between tests; otherwise nextProfile
+    // changes are masked by a stale hit on DOC_URL.
+    _clearProfileCacheForTests();
   });
 
   it('verifies a valid ES256K JWT against a CID-shaped profile', async () => {
-    const now = Math.floor(Date.now() / 1000);
     const token = makeJwt({
       privKey: priv,
       header: { alg: 'ES256K', kid: VM_ID, typ: 'JWT' },
-      payload: {
-        sub: WEBID, iss: WEBID, client_id: WEBID,
-        aud: [POD_ORIGIN], iat: now, exp: now + 60,
-      },
+      payload: claims(),
     });
     const result = await verifyLwsCidAuth(makeRequest(token));
     assert.strictEqual(result.error, null);
@@ -174,7 +178,7 @@ describe('verifyLwsCidAuth', () => {
     const token = makeJwt({
       privKey: priv,
       header: { alg: 'none', kid: VM_ID, typ: 'JWT' },
-      payload: { sub: WEBID, iss: WEBID, client_id: WEBID, iat: Math.floor(Date.now()/1000) },
+      payload: claims(),
     });
     const r = await verifyLwsCidAuth(makeRequest(token));
     assert.strictEqual(r.webId, null);
@@ -185,10 +189,7 @@ describe('verifyLwsCidAuth', () => {
     const token = makeJwt({
       privKey: priv,
       header: { alg: 'ES256K', kid: VM_ID },
-      payload: {
-        sub: WEBID, iss: 'https://other/#me', client_id: WEBID,
-        iat: Math.floor(Date.now()/1000),
-      },
+      payload: claims(undefined, { iss: 'https://other.example/profile#me' }),
     });
     const r = await verifyLwsCidAuth(makeRequest(token));
     assert.match(r.error, /sub.*iss.*client_id/);
@@ -199,7 +200,7 @@ describe('verifyLwsCidAuth', () => {
     const token = makeJwt({
       privKey: priv,
       header: { alg: 'ES256K', kid: otherKid },
-      payload: { sub: WEBID, iss: WEBID, client_id: WEBID, iat: Math.floor(Date.now()/1000) },
+      payload: claims(),
     });
     const r = await verifyLwsCidAuth(makeRequest(token));
     assert.match(r.error, /not in the subject/);
@@ -210,13 +211,76 @@ describe('verifyLwsCidAuth', () => {
     const token = makeJwt({
       privKey: priv,
       header: { alg: 'ES256K', kid: VM_ID },
-      payload: {
-        sub: WEBID, iss: WEBID, client_id: WEBID,
-        aud: [POD_ORIGIN], iat: past - 60, exp: past,
-      },
+      payload: claims(past, { iat: past - 60, exp: past }),
     });
     const r = await verifyLwsCidAuth(makeRequest(token));
     assert.match(r.error, /expired/);
+  });
+
+  it('rejects nbf in the future', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: claims(now, { nbf: now + 600 }),
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /not yet valid/);
+  });
+
+  it('rejects iat too far in the future', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: claims(now, { iat: now + 600, exp: now + 1200 }),
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /iat is in the future/);
+  });
+
+  it('rejects iat too old', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: claims(now, { iat: now - 7200, exp: now + 60 }),
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /iat too old/);
+  });
+
+  it('rejects non-numeric exp', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: claims(now, { exp: '9999999999' }),
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /exp claim must be a number/);
+  });
+
+  it('rejects non-numeric iat', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: claims(now, { iat: 'right-now' }),
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /iat claim must be a number/);
+  });
+
+  it('rejects missing aud', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: claims(now, { aud: undefined }),
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /aud claim is required/);
   });
 
   it('rejects when kid does not match any VM in the profile', async () => {
@@ -224,7 +288,7 @@ describe('verifyLwsCidAuth', () => {
     const token = makeJwt({
       privKey: priv,
       header: { alg: 'ES256K', kid: ghostKid },
-      payload: { sub: WEBID, iss: WEBID, client_id: WEBID, iat: Math.floor(Date.now()/1000) },
+      payload: claims(),
     });
     const r = await verifyLwsCidAuth(makeRequest(token));
     assert.match(r.error, /no verificationMethod/);
@@ -235,7 +299,7 @@ describe('verifyLwsCidAuth', () => {
     const token = makeJwt({
       privKey: priv,
       header: { alg: 'ES256K', kid: VM_ID },
-      payload: { sub: WEBID, iss: WEBID, client_id: WEBID, iat: Math.floor(Date.now()/1000) },
+      payload: claims(),
     });
     const r = await verifyLwsCidAuth(makeRequest(token));
     assert.match(r.error, /not listed in authentication/);
@@ -245,23 +309,38 @@ describe('verifyLwsCidAuth', () => {
     const token = makeJwt({
       privKey: priv,
       header: { alg: 'ES256K', kid: VM_ID },
-      payload: {
-        sub: WEBID, iss: WEBID, client_id: WEBID,
-        aud: ['https://elsewhere/'], iat: Math.floor(Date.now()/1000),
-      },
+      payload: claims(undefined, { aud: ['https://elsewhere.example/'] }),
     });
     const r = await verifyLwsCidAuth(makeRequest(token));
     assert.match(r.error, /aud.*does not include/);
   });
 
+  it('honors x-forwarded-proto/host for aud check (behind reverse proxy)', async () => {
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: claims(undefined, { aud: ['https://public.example'] }),
+    });
+    const req = {
+      headers: {
+        authorization: `Bearer ${token}`,
+        host: 'internal:8080',
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'public.example',
+      },
+      protocol: 'http',
+    };
+    const r = await verifyLwsCidAuth(req);
+    assert.strictEqual(r.error, null);
+    assert.strictEqual(r.webId, WEBID);
+  });
+
   it('rejects tampered signature', async () => {
-    const now = Math.floor(Date.now() / 1000);
     const valid = makeJwt({
       privKey: priv,
       header: { alg: 'ES256K', kid: VM_ID },
-      payload: { sub: WEBID, iss: WEBID, client_id: WEBID, aud: [POD_ORIGIN], iat: now, exp: now+60 },
+      payload: claims(),
     });
-    // Flip a bit in the signature.
     const parts = valid.split('.');
     const sigBuf = Buffer.from(parts[2].replace(/-/g, '+').replace(/_/g, '/'), 'base64');
     sigBuf[0] ^= 0xff;
@@ -272,14 +351,12 @@ describe('verifyLwsCidAuth', () => {
   });
 
   it('rejects when VM is signed with different key than JWT', async () => {
-    // Profile advertises VM for one key; token signed with another.
     const otherPriv = secp256k1.utils.randomPrivateKey();
     nextProfile = buildProfile(jwkFromSecp256k1(otherPriv));
-    const now = Math.floor(Date.now() / 1000);
     const token = makeJwt({
       privKey: priv,
       header: { alg: 'ES256K', kid: VM_ID },
-      payload: { sub: WEBID, iss: WEBID, client_id: WEBID, aud: [POD_ORIGIN], iat: now, exp: now+60 },
+      payload: claims(),
     });
     const r = await verifyLwsCidAuth(makeRequest(token));
     assert.match(r.error, /signature/);
@@ -291,9 +368,67 @@ describe('verifyLwsCidAuth', () => {
     const token = makeJwt({
       privKey: priv,
       header: { alg: 'ES256K', kid: VM_ID },
-      payload: { sub: WEBID, iss: WEBID, client_id: WEBID, iat: Math.floor(Date.now()/1000) },
+      payload: claims(),
     });
     const r = await verifyLwsCidAuth(makeRequest(token));
     assert.match(r.error, /could not fetch/);
+  });
+
+  it('SSRF: rejects kid pointing at localhost', async () => {
+    const localKid = 'https://localhost/profile/card.jsonld#me';
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: localKid },
+      payload: claims(undefined, {
+        sub: localKid, iss: localKid, client_id: localKid,
+      }),
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    // SSRF guard fires inside fetchProfile and surfaces as "could not
+    // fetch CID document: SSRF protection: ...".
+    assert.match(r.error, /SSRF protection/);
+  });
+
+  // --- non-ES256K alg coverage (the jose-driven branch) -------------
+
+  describe('non-ES256K algorithms via jose', () => {
+    async function runHappyPath(alg) {
+      const kp = await jose.generateKeyPair(alg, { extractable: true });
+      const publicJwk = await jose.exportJWK(kp.publicKey);
+      publicJwk.alg = alg;
+      nextProfile = buildProfile(publicJwk);
+
+      const now = Math.floor(Date.now() / 1000);
+      const token = await new jose.SignJWT(claims(now))
+        .setProtectedHeader({ alg, kid: VM_ID, typ: 'JWT' })
+        .sign(kp.privateKey);
+      const r = await verifyLwsCidAuth(makeRequest(token));
+      assert.strictEqual(r.error, null, `unexpected error: ${r.error}`);
+      assert.strictEqual(r.webId, WEBID);
+    }
+
+    it('verifies ES256 (P-256)', async () => { await runHappyPath('ES256'); });
+    it('verifies EdDSA (Ed25519)', async () => { await runHappyPath('EdDSA'); });
+    it('verifies RS256 (RSA-2048)', async () => { await runHappyPath('RS256'); });
+
+    it('rejects RS256 with tampered payload', async () => {
+      const kp = await jose.generateKeyPair('RS256', { extractable: true, modulusLength: 2048 });
+      const publicJwk = await jose.exportJWK(kp.publicKey);
+      publicJwk.alg = 'RS256';
+      nextProfile = buildProfile(publicJwk);
+
+      const now = Math.floor(Date.now() / 1000);
+      const token = await new jose.SignJWT(claims(now))
+        .setProtectedHeader({ alg: 'RS256', kid: VM_ID })
+        .sign(kp.privateKey);
+      // Tamper with payload portion (middle section).
+      const parts = token.split('.');
+      const decoded = JSON.parse(Buffer.from(parts[1].replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString());
+      decoded.sub = 'https://attacker.example/#me';
+      parts[1] = b64u(Buffer.from(JSON.stringify(decoded)));
+      const tampered = parts.join('.');
+      const r = await verifyLwsCidAuth(makeRequest(tampered));
+      assert.notStrictEqual(r.error, null);
+    });
   });
 });

--- a/test/lws-cid.test.js
+++ b/test/lws-cid.test.js
@@ -85,10 +85,18 @@ function buildProfile(jwk, { withAuthRef = true, controller = WEBID } = {}) {
 const realFetch = global.fetch;
 let nextProfile = null;
 let nextStatus = 200;
+// Per-URL response overrides — set { status, headers, body } per URL to
+// inject redirects, oversized bodies, or non-default content-types.
+let urlResponses = new Map();
 
 function installFetchStub() {
   global.fetch = async (url) => {
-    if (String(url) === DOC_URL) {
+    const u = String(url);
+    if (urlResponses.has(u)) {
+      const { status = 200, headers = {}, body = '' } = urlResponses.get(u);
+      return new Response(body, { status, headers });
+    }
+    if (u === DOC_URL) {
       return new Response(JSON.stringify(nextProfile), {
         status: nextStatus,
         headers: { 'content-type': 'application/ld+json' },
@@ -158,6 +166,7 @@ describe('verifyLwsCidAuth', () => {
     jwk = jwkFromSecp256k1(priv);
     nextStatus = 200;
     nextProfile = buildProfile(jwk);
+    urlResponses = new Map();
     // Cache must not survive between tests; otherwise nextProfile
     // changes are masked by a stale hit on DOC_URL.
     _clearProfileCacheForTests();
@@ -428,6 +437,95 @@ describe('verifyLwsCidAuth', () => {
     });
     const r = await verifyLwsCidAuth(makeRequest(token));
     assert.match(r.error, /could not fetch/);
+  });
+
+  it('rejects when CID document has no controller / @id / id (vacuous bypass)', async () => {
+    // Profile that's structurally complete enough to find a VM, but has
+    // no top-level controller or @id at all.
+    nextProfile = {
+      '@context': { cid: 'https://www.w3.org/ns/cid/v1#' },
+      verificationMethod: [{
+        id: VM_ID,
+        type: 'JsonWebKey',
+        controller: WEBID,
+        publicKeyJwk: jwk,
+      }],
+      authentication: [VM_ID],
+    };
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: claims(),
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /no controller or @id/);
+  });
+
+  it('handles comma-separated x-forwarded-host (multi-proxy chain)', async () => {
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: claims(undefined, { aud: ['https://public.example'] }),
+    });
+    const req = {
+      headers: {
+        authorization: `Bearer ${token}`,
+        'x-forwarded-proto': 'https, http',
+        'x-forwarded-host': 'public.example, internal.lan',
+      },
+    };
+    const r = await verifyLwsCidAuth(req);
+    assert.strictEqual(r.error, null);
+    assert.strictEqual(r.webId, WEBID);
+  });
+
+  it('refuses cross-origin redirect during profile fetch', async () => {
+    urlResponses.set(DOC_URL, {
+      status: 302,
+      headers: { location: 'https://attacker.example/profile/card.jsonld' },
+    });
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: claims(),
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /cross-origin redirect refused/);
+  });
+
+  it('rejects profile larger than the byte cap', async () => {
+    // 300 KB of JSON — over the 256 KB cap.
+    const huge = 'x'.repeat(300 * 1024);
+    urlResponses.set(DOC_URL, {
+      status: 200,
+      headers: { 'content-type': 'application/ld+json' },
+      body: JSON.stringify({ junk: huge }),
+    });
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: claims(),
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /CID document too large/);
+  });
+
+  it('rejects when Content-Length header announces oversize body', async () => {
+    urlResponses.set(DOC_URL, {
+      status: 200,
+      headers: {
+        'content-type': 'application/ld+json',
+        'content-length': String(10 * 1024 * 1024), // 10 MB declared
+      },
+      body: JSON.stringify({}), // body is small but header lies
+    });
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: claims(),
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /too large/);
   });
 
   it('SSRF: rejects kid pointing at localhost', async () => {

--- a/test/lws-cid.test.js
+++ b/test/lws-cid.test.js
@@ -143,6 +143,24 @@ describe('hasLwsCidAuth', () => {
   it('rejects malformed JWT', () => {
     assert.strictEqual(hasLwsCidAuth(makeRequest('not.a.jwt')), false);
   });
+
+  it('rejects JWT with kid using non-http(s) scheme', () => {
+    const token = makeJwt({
+      privKey: secp256k1.utils.randomPrivateKey(),
+      header: { alg: 'ES256K', kid: 'urn:foo:bar#k1' },
+      payload: { sub: WEBID },
+    });
+    assert.strictEqual(hasLwsCidAuth(makeRequest(token)), false);
+  });
+
+  it('rejects JWT with unaccepted alg (e.g. HS256)', () => {
+    const token = makeJwt({
+      privKey: secp256k1.utils.randomPrivateKey(),
+      header: { alg: 'HS256', kid: VM_ID },
+      payload: { sub: WEBID },
+    });
+    assert.strictEqual(hasLwsCidAuth(makeRequest(token)), false);
+  });
 });
 
 describe('verifyLwsCidAuth', () => {
@@ -439,9 +457,11 @@ describe('verifyLwsCidAuth', () => {
     assert.match(r.error, /could not fetch/);
   });
 
-  it('rejects when CID document has no controller / @id / id (vacuous bypass)', async () => {
-    // Profile that's structurally complete enough to find a VM, but has
-    // no top-level controller or @id at all.
+  it('rejects when CID document declares no subject (no @id / id)', async () => {
+    // Profile that's structurally complete enough to find a VM, but
+    // declares no top-level subject. This is rejected by the
+    // subject-identity check (which fires before the controller check
+    // — both layers exist as defense-in-depth).
     nextProfile = {
       '@context': { cid: 'https://www.w3.org/ns/cid/v1#' },
       verificationMethod: [{
@@ -458,7 +478,25 @@ describe('verifyLwsCidAuth', () => {
       payload: claims(),
     });
     const r = await verifyLwsCidAuth(makeRequest(token));
-    assert.match(r.error, /no controller or @id/);
+    assert.match(r.error, /declares no subject/);
+  });
+
+  it("rejects when CID document's subject differs from JWT sub", async () => {
+    // Profile DOES declare a subject, but it's a different fragment
+    // than the JWT claims. Without this check, an attacker could
+    // serve a profile whose @id is "#bob" while the JWT claims "#alice"
+    // and reuse a VM controlled by bob.
+    nextProfile = {
+      ...buildProfile(jwk),
+      '@id': 'https://example.com/profile/card.jsonld#bob',
+    };
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: claims(), // sub = "...#me"
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /subject.*does not match JWT sub/);
   });
 
   it('normalizes origin (default port and case) on both sides of aud check', async () => {

--- a/test/lws-cid.test.js
+++ b/test/lws-cid.test.js
@@ -461,6 +461,25 @@ describe('verifyLwsCidAuth', () => {
     assert.match(r.error, /no controller or @id/);
   });
 
+  it('normalizes origin (default port and case) on both sides of aud check', async () => {
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      // aud uses the explicit default port and uppercase scheme.
+      payload: claims(undefined, { aud: ['HTTPS://Example.COM:443'] }),
+    });
+    const req = {
+      headers: {
+        authorization: `Bearer ${token}`,
+        host: 'example.com', // no port, lowercase
+      },
+      protocol: 'https',
+    };
+    const r = await verifyLwsCidAuth(req);
+    assert.strictEqual(r.error, null);
+    assert.strictEqual(r.webId, WEBID);
+  });
+
   it('handles comma-separated x-forwarded-host (multi-proxy chain)', async () => {
     const token = makeJwt({
       privKey: priv,

--- a/test/lws-cid.test.js
+++ b/test/lws-cid.test.js
@@ -359,6 +359,18 @@ describe('verifyLwsCidAuth', () => {
     assert.match(r.error, /aud.*does not include/);
   });
 
+  it('rejects when server origin cannot be determined', async () => {
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: claims(),
+    });
+    // No host header, no x-forwarded-host, no fastify hostname.
+    const req = { headers: { authorization: `Bearer ${token}` } };
+    const r = await verifyLwsCidAuth(req);
+    assert.match(r.error, /cannot determine server origin/);
+  });
+
   it('honors x-forwarded-proto/host for aud check (behind reverse proxy)', async () => {
     const token = makeJwt({
       privKey: priv,

--- a/test/lws-cid.test.js
+++ b/test/lws-cid.test.js
@@ -1,0 +1,299 @@
+/**
+ * LWS10-CID JWT verifier tests
+ *
+ * Covers the verifier logic in isolation by stubbing global.fetch so we
+ * can hand-craft both the JWT and the profile document. Real end-to-end
+ * tests against a running server are filed as a follow-up.
+ */
+
+import { describe, it, before, beforeEach, after } from 'node:test';
+import assert from 'node:assert';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { sha256 } from '@noble/hashes/sha256';
+import { hasLwsCidAuth, verifyLwsCidAuth } from '../src/auth/lws-cid.js';
+
+// --- helpers ---------------------------------------------------------
+
+function b64u(bytes) {
+  return Buffer.from(bytes).toString('base64')
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function jwkFromSecp256k1(privKey) {
+  const pub = secp256k1.getPublicKey(privKey, /*compressed=*/false); // 65 bytes: 0x04 || x || y
+  return {
+    kty: 'EC',
+    crv: 'secp256k1',
+    x: b64u(pub.slice(1, 33)),
+    y: b64u(pub.slice(33, 65)),
+    alg: 'ES256K',
+  };
+}
+
+function makeJwt({ privKey, header, payload }) {
+  const h64 = b64u(Buffer.from(JSON.stringify(header)));
+  const p64 = b64u(Buffer.from(JSON.stringify(payload)));
+  const signingInput = Buffer.from(`${h64}.${p64}`, 'utf8');
+  const msgHash = sha256(signingInput);
+  const sig = secp256k1.sign(msgHash, privKey);
+  // Compact 64-byte r||s — what JWS expects.
+  return `${h64}.${p64}.${b64u(sig.toCompactRawBytes())}`;
+}
+
+function makeRequest(token, { host = 'pod.example', proto = 'https' } = {}) {
+  return {
+    headers: {
+      authorization: `Bearer ${token}`,
+      host,
+    },
+    protocol: proto,
+  };
+}
+
+const WEBID = 'https://pod.example/profile/card.jsonld#me';
+const DOC_URL = 'https://pod.example/profile/card.jsonld';
+const VM_ID = `${DOC_URL}#nostr-key-1`;
+const POD_ORIGIN = 'https://pod.example';
+
+// Minimal CID-shaped profile.
+function buildProfile(jwk, { withAuthRef = true, controller = WEBID } = {}) {
+  return {
+    '@context': {
+      cid: 'https://www.w3.org/ns/cid/v1#',
+      controller: { '@id': 'cid:controller', '@type': '@id' },
+      verificationMethod: { '@id': 'cid:verificationMethod', '@container': '@set' },
+      authentication: { '@id': 'cid:authentication', '@type': '@id', '@container': '@set' },
+      publicKeyJwk: { '@id': 'cid:publicKeyJwk', '@type': '@json' },
+    },
+    '@id': WEBID,
+    controller,
+    verificationMethod: [
+      {
+        id: VM_ID,
+        type: 'JsonWebKey',
+        controller: WEBID,
+        publicKeyJwk: jwk,
+      },
+    ],
+    ...(withAuthRef ? { authentication: [VM_ID] } : {}),
+  };
+}
+
+// --- fetch stub ------------------------------------------------------
+
+const realFetch = global.fetch;
+let nextProfile = null;
+let nextStatus = 200;
+
+function installFetchStub() {
+  global.fetch = async (url) => {
+    if (String(url) === DOC_URL) {
+      return new Response(JSON.stringify(nextProfile), {
+        status: nextStatus,
+        headers: { 'content-type': 'application/ld+json' },
+      });
+    }
+    return new Response('not found', { status: 404 });
+  };
+}
+function restoreFetch() { global.fetch = realFetch; }
+
+// --- tests -----------------------------------------------------------
+
+describe('hasLwsCidAuth', () => {
+  it('detects Bearer JWT with URL kid', () => {
+    const token = makeJwt({
+      privKey: secp256k1.utils.randomPrivateKey(),
+      header: { alg: 'ES256K', kid: VM_ID, typ: 'JWT' },
+      payload: { sub: WEBID, iss: WEBID, client_id: WEBID, iat: Math.floor(Date.now()/1000) },
+    });
+    assert.strictEqual(hasLwsCidAuth(makeRequest(token)), true);
+  });
+
+  it('rejects Bearer JWT with opaque fingerprint kid (looks like IDP JWT)', () => {
+    const token = makeJwt({
+      privKey: secp256k1.utils.randomPrivateKey(),
+      header: { alg: 'ES256K', kid: 'c1f52577', typ: 'JWT' },
+      payload: { sub: WEBID, iss: WEBID, client_id: WEBID, iat: Math.floor(Date.now()/1000) },
+    });
+    assert.strictEqual(hasLwsCidAuth(makeRequest(token)), false);
+  });
+
+  it('rejects DPoP', () => {
+    assert.strictEqual(hasLwsCidAuth({ headers: { authorization: 'DPoP eyJ...' } }), false);
+  });
+
+  it('rejects Nostr', () => {
+    assert.strictEqual(hasLwsCidAuth({ headers: { authorization: 'Nostr abc' } }), false);
+  });
+
+  it('rejects no authorization header', () => {
+    assert.strictEqual(hasLwsCidAuth({ headers: {} }), false);
+  });
+
+  it('rejects malformed JWT', () => {
+    assert.strictEqual(hasLwsCidAuth(makeRequest('not.a.jwt')), false);
+  });
+});
+
+describe('verifyLwsCidAuth', () => {
+  let priv;
+  let jwk;
+
+  before(() => {
+    installFetchStub();
+  });
+
+  after(() => {
+    restoreFetch();
+  });
+
+  beforeEach(() => {
+    priv = secp256k1.utils.randomPrivateKey();
+    jwk = jwkFromSecp256k1(priv);
+    nextStatus = 200;
+    nextProfile = buildProfile(jwk);
+  });
+
+  it('verifies a valid ES256K JWT against a CID-shaped profile', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID, typ: 'JWT' },
+      payload: {
+        sub: WEBID, iss: WEBID, client_id: WEBID,
+        aud: [POD_ORIGIN], iat: now, exp: now + 60,
+      },
+    });
+    const result = await verifyLwsCidAuth(makeRequest(token));
+    assert.strictEqual(result.error, null);
+    assert.strictEqual(result.webId, WEBID);
+  });
+
+  it('rejects "none" alg', async () => {
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'none', kid: VM_ID, typ: 'JWT' },
+      payload: { sub: WEBID, iss: WEBID, client_id: WEBID, iat: Math.floor(Date.now()/1000) },
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.strictEqual(r.webId, null);
+    assert.match(r.error, /none/);
+  });
+
+  it('rejects when sub != iss', async () => {
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: {
+        sub: WEBID, iss: 'https://other/#me', client_id: WEBID,
+        iat: Math.floor(Date.now()/1000),
+      },
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /sub.*iss.*client_id/);
+  });
+
+  it('rejects when kid is in a different document than sub', async () => {
+    const otherKid = 'https://other.example/profile/card.jsonld#k1';
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: otherKid },
+      payload: { sub: WEBID, iss: WEBID, client_id: WEBID, iat: Math.floor(Date.now()/1000) },
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /not in the subject/);
+  });
+
+  it('rejects expired JWT', async () => {
+    const past = Math.floor(Date.now() / 1000) - 3600;
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: {
+        sub: WEBID, iss: WEBID, client_id: WEBID,
+        aud: [POD_ORIGIN], iat: past - 60, exp: past,
+      },
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /expired/);
+  });
+
+  it('rejects when kid does not match any VM in the profile', async () => {
+    const ghostKid = `${DOC_URL}#nope`;
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: ghostKid },
+      payload: { sub: WEBID, iss: WEBID, client_id: WEBID, iat: Math.floor(Date.now()/1000) },
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /no verificationMethod/);
+  });
+
+  it('rejects when VM is not in authentication list', async () => {
+    nextProfile = buildProfile(jwk, { withAuthRef: false });
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: { sub: WEBID, iss: WEBID, client_id: WEBID, iat: Math.floor(Date.now()/1000) },
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /not listed in authentication/);
+  });
+
+  it('rejects when audience does not include this server', async () => {
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: {
+        sub: WEBID, iss: WEBID, client_id: WEBID,
+        aud: ['https://elsewhere/'], iat: Math.floor(Date.now()/1000),
+      },
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /aud.*does not include/);
+  });
+
+  it('rejects tampered signature', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const valid = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: { sub: WEBID, iss: WEBID, client_id: WEBID, aud: [POD_ORIGIN], iat: now, exp: now+60 },
+    });
+    // Flip a bit in the signature.
+    const parts = valid.split('.');
+    const sigBuf = Buffer.from(parts[2].replace(/-/g, '+').replace(/_/g, '/'), 'base64');
+    sigBuf[0] ^= 0xff;
+    parts[2] = b64u(sigBuf);
+    const tampered = parts.join('.');
+    const r = await verifyLwsCidAuth(makeRequest(tampered));
+    assert.match(r.error, /signature/);
+  });
+
+  it('rejects when VM is signed with different key than JWT', async () => {
+    // Profile advertises VM for one key; token signed with another.
+    const otherPriv = secp256k1.utils.randomPrivateKey();
+    nextProfile = buildProfile(jwkFromSecp256k1(otherPriv));
+    const now = Math.floor(Date.now() / 1000);
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: { sub: WEBID, iss: WEBID, client_id: WEBID, aud: [POD_ORIGIN], iat: now, exp: now+60 },
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /signature/);
+  });
+
+  it('rejects when profile fetch fails', async () => {
+    nextStatus = 404;
+    nextProfile = null;
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: VM_ID },
+      payload: { sub: WEBID, iss: WEBID, client_id: WEBID, iat: Math.floor(Date.now()/1000) },
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.match(r.error, /could not fetch/);
+  });
+});

--- a/test/lws-cid.test.js
+++ b/test/lws-cid.test.js
@@ -531,6 +531,21 @@ describe('verifyLwsCidAuth', () => {
     assert.strictEqual(r.webId, WEBID);
   });
 
+  it('canonicalizes kid (case/default-port) before matching VM ids', async () => {
+    // JWT carries a non-canonical kid (uppercase scheme + host,
+    // explicit default port); the profile's VM id is canonical.
+    // After URL-parse normalization both should match.
+    const nonCanonicalKid = 'HTTPS://Example.COM:443/profile/card.jsonld#nostr-key-1';
+    const token = makeJwt({
+      privKey: priv,
+      header: { alg: 'ES256K', kid: nonCanonicalKid },
+      payload: claims(),
+    });
+    const r = await verifyLwsCidAuth(makeRequest(token));
+    assert.strictEqual(r.error, null);
+    assert.strictEqual(r.webId, WEBID);
+  });
+
   it('handles comma-separated x-forwarded-host (multi-proxy chain)', async () => {
     const token = makeJwt({
       privKey: priv,


### PR DESCRIPTION
Closes #397. Pairs with JavaScriptSolidServer/doctor#3.

Implements the verifier side of the [LWS 1.0 SSI-via-CID FPWD (2026-04-23)](https://www.w3.org/TR/2026/WD-lws10-authn-ssi-cid-20260423/). An incoming Bearer JWT whose `kid` references a verificationMethod in the subject's WebID profile authenticates as that WebID once the JWT signature checks against the VM's `publicKeyJwk`.

## What's new

- `src/auth/lws-cid.js` — new module: `hasLwsCidAuth()` (cheap header detector) + `verifyLwsCidAuth()` (full verifier)
- Wired into `getWebIdFromRequestAsync` between Solid-OIDC and NIP-98
- 17 unit tests in `test/lws-cid.test.js` — happy path + 10 distinct rejection cases

## Algorithm story

**ES256K (RFC8812 — ECDSA-secp256k1, registered JWS alg)** is the focus, because it lets a Nostr user reuse their existing secp256k1 private key as an LWS-CID auth credential — same key, ECDSA signature instead of Schnorr. Server-side verification uses `@noble/curves` (already in tree from NIP-98), so no new dep. ES256, ES384, EdDSA, RS256 also accepted via `jose` for non-Nostr keys.

## Detection vs existing IDP JWTs

Unambiguous: **LWS-CID `kid` is a URL with a fragment** (the VM's `id`), while IDP-issued JWTs use opaque fingerprints. Routing on header shape avoids any conflict with the existing Bearer fallback that calls `verifyJwtFromIdp`.

## What it enforces

- **FPWD §4**: `sub === iss === client_id` (all the same WebID URI), `aud` includes server origin, `exp` not past, `iat` recent
- **CID 1.0 §3.3**: `kid` resolves to a VM whose `id` matches; that VM is referenced from `authentication`
- **Self-control**: VM `controller` agrees with `profile.controller` (with `@id` fallback) — same rule the doctor's client-side validator uses, normalized through the same JSON-LD shape helper (string / `{@id}` / `{id}` / array)
- **Cross-document protection**: `kid`'s document URL must equal `sub`'s document URL — can't use a key from someone else's profile

## Test plan

- [x] Happy path: valid ES256K JWT against a CID-shaped profile → authenticated
- [x] `none` alg rejected
- [x] `sub`/`iss`/`client_id` divergence rejected
- [x] `kid` in different document than `sub` rejected
- [x] Expired JWT rejected
- [x] Unknown VM `id` rejected
- [x] VM not in `authentication` rejected
- [x] `aud` not matching server origin rejected
- [x] Tampered signature rejected
- [x] Profile-VM-key vs JWT-signing-key mismatch rejected
- [x] Profile fetch failure rejected
- [x] Full suite: 655/655 pass — no regressions
- [ ] Manual end-to-end against JavaScriptSolidServer/doctor#3 once that lands

## Refs

- LWS10-CID FPWD: https://www.w3.org/TR/2026/WD-lws10-authn-ssi-cid-20260423/
- W3C Controlled Identifiers v1.0: https://www.w3.org/TR/cid-1.0/
- RFC8812 (ES256K): https://www.rfc-editor.org/rfc/rfc8812
- #386 — overall convergence tracker (this is Phase 3a, server side)
- #319 — broader LWS auth alignment tracker (this is the #3 CID sub-bullet)
- #306 — auth-method preference order (LWS-CID slots between OIDC and NIP-98)