### PR TITLE
auth: NIP-98 → WebID via verificationMethod lookup (#399)

### DIFF
--- a/src/auth/cid-doc-fetch.js
+++ b/src/auth/cid-doc-fetch.js
@@ -53,6 +53,15 @@ export function _clearProfileCacheForTests() {
  * body-size protections — and a bounded TTL cache so auth-path callers
  * don't refetch on every request.
  *
+ * Content-Type expectation: the response must declare a JSON-bearing
+ * Content-Type (matching `/json/`, e.g. `application/ld+json`,
+ * `application/json`, `application/json+ld`). A missing or non-JSON
+ * Content-Type rejects with a clear error rather than silently
+ * attempting JSON.parse — this caught real misconfigurations during
+ * #398 review where Turtle / HTML error pages were being served at
+ * profile URLs. Deployments serving WebID profiles should make sure
+ * their host returns the correct Content-Type for the CID document.
+ *
  * @param {string} docUrl - URL to fetch (untrusted — comes from JWT
  *   claims or is derived from a request).
  * @param {object} [opts]

--- a/src/auth/cid-doc-fetch.js
+++ b/src/auth/cid-doc-fetch.js
@@ -1,0 +1,129 @@
+/**
+ * Shared CID-document / WebID-profile fetcher.
+ *
+ * Used by both the LWS10-CID JWT verifier (`src/auth/lws-cid.js`) and
+ * the NIP-98 → WebID VM-lookup path (`src/auth/nostr.js`). Centralized
+ * so future SSRF / redirect / DoS hardening only needs to land in one
+ * place.
+ *
+ * Defenses (mirrored from the original lws-cid implementation):
+ *
+ *   - URL validated through `validateExternalUrl` (loopback, private
+ *     IPs, http-in-prod blocked) on the original URL AND every
+ *     redirect Location.
+ *   - Manual redirect handling — no automatic following — capped at
+ *     MAX_REDIRECTS hops.
+ *   - Cross-origin redirects refused (an open redirect on the WebID's
+ *     host can't substitute an attacker-controlled CID document).
+ *   - Body size cap enforced via Content-Length up front AND a
+ *     streaming reader cap (cancel on overage), so untrusted hosts
+ *     can't OOM us with a large payload.
+ *   - 5-second timeout per request via AbortController.
+ *
+ * Throws on any failure; callers convert to whatever they want
+ * (LWS-CID surfaces the error string, the NIP-98 path treats
+ * throw-as-null and falls back to the existing did:nostr resolver).
+ */
+
+import { validateExternalUrl } from '../utils/ssrf.js';
+
+// Default body cap (256 KB) — CID documents are tiny in practice.
+const DEFAULT_MAX_BYTES = 256 * 1024;
+const MAX_REDIRECTS = 5;
+const FETCH_TIMEOUT_MS = 5000;
+
+/**
+ * Fetch and parse a JSON CID document with SSRF, redirect, and
+ * body-size protections.
+ *
+ * @param {string} docUrl - URL to fetch (untrusted — comes from JWT
+ *   claims or is derived from a request).
+ * @param {object} [opts]
+ * @param {number} [opts.maxBytes=DEFAULT_MAX_BYTES]
+ * @returns {Promise<object>} parsed JSON
+ * @throws on any validation, network, redirect, size, or parse failure
+ */
+export async function fetchCidDocument(docUrl, opts = {}) {
+  const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
+  const originalOrigin = new URL(docUrl).origin;
+  let currentUrl = docUrl;
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    const isLastAllowedHop = hop === MAX_REDIRECTS;
+    const validation = await validateExternalUrl(currentUrl, {
+      requireHttps: process.env.NODE_ENV === 'production',
+      blockPrivateIPs: true,
+      resolveDNS: true,
+    });
+    if (!validation.valid) {
+      throw new Error(`SSRF protection: ${validation.error}`);
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    let res;
+    try {
+      res = await fetch(currentUrl, {
+        headers: { Accept: 'application/ld+json, application/json;q=0.9' },
+        redirect: 'manual',
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (res.status >= 300 && res.status < 400) {
+      if (isLastAllowedHop) {
+        throw new Error(`too many redirects (>${MAX_REDIRECTS})`);
+      }
+      const loc = res.headers.get('location');
+      if (!loc) throw new Error(`redirect ${res.status} without Location`);
+      const nextUrl = new URL(loc, currentUrl).toString();
+      const nextOrigin = new URL(nextUrl).origin;
+      if (nextOrigin !== originalOrigin) {
+        throw new Error(`cross-origin redirect refused: ${originalOrigin} → ${nextOrigin}`);
+      }
+      currentUrl = nextUrl;
+      continue;
+    }
+
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+    const ct = (res.headers.get('content-type') || '').toLowerCase();
+    if (!ct.includes('json')) {
+      throw new Error(`unexpected content-type: ${ct || '(none)'}`);
+    }
+
+    const declared = Number(res.headers.get('content-length'));
+    if (Number.isFinite(declared) && declared > maxBytes) {
+      throw new Error(`CID document too large (Content-Length=${declared})`);
+    }
+    const text = await readBodyWithCap(res, maxBytes);
+    return JSON.parse(text);
+  }
+  throw new Error('profile fetch loop exited unexpectedly');
+}
+
+async function readBodyWithCap(res, maxBytes) {
+  const reader = res.body?.getReader?.();
+  if (!reader) {
+    const text = await res.text();
+    if (Buffer.byteLength(text, 'utf8') > maxBytes) {
+      throw new Error(`CID document too large (>${maxBytes} bytes)`);
+    }
+    return text;
+  }
+  const chunks = [];
+  let total = 0;
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      try { await reader.cancel(); } catch { /* noop */ }
+      throw new Error(`CID document too large (>${maxBytes} bytes)`);
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks.map((c) => Buffer.from(c.buffer, c.byteOffset, c.byteLength))).toString('utf8');
+}

--- a/src/auth/cid-doc-fetch.js
+++ b/src/auth/cid-doc-fetch.js
@@ -62,6 +62,13 @@ export function _clearProfileCacheForTests() {
  * profile URLs. Deployments serving WebID profiles should make sure
  * their host returns the correct Content-Type for the CID document.
  *
+ * Cache contract: keyed by `docUrl` only. All callers MUST pass
+ * consistent `opts` (in practice today everyone passes
+ * maxBytes = 256 KB). If a future caller needs a stricter limit, the
+ * cache key needs to incorporate it (or that caller needs its own
+ * cache) — otherwise a permissive entry would be returned to a strict
+ * caller and the cap wouldn't be re-enforced.
+ *
  * @param {string} docUrl - URL to fetch (untrusted — comes from JWT
  *   claims or is derived from a request).
  * @param {object} [opts]

--- a/src/auth/cid-doc-fetch.js
+++ b/src/auth/cid-doc-fetch.js
@@ -32,9 +32,26 @@ const DEFAULT_MAX_BYTES = 256 * 1024;
 const MAX_REDIRECTS = 5;
 const FETCH_TIMEOUT_MS = 5000;
 
+// Auth is on the hot path; refetching the CID document on every
+// request is unacceptable for both latency and reliability (and would
+// amplify self-traffic when the profile is hosted on this same
+// server). Bounded LRU — an attacker could otherwise grow the cache
+// without limit by sending tokens / requests with many distinct
+// document URLs. Mirrors the pattern in did-nostr.js.
+const profileCache = new Map(); // url -> { profile, timestamp, failureTtl?, error? }
+const PROFILE_CACHE_TTL = 5 * 60 * 1000; // 5 minutes for hits
+const PROFILE_FAILURE_TTL = 60 * 1000;   // 1 minute for misses
+const PROFILE_CACHE_MAX = 1000;
+
+/** @internal — exposed for tests */
+export function _clearProfileCacheForTests() {
+  profileCache.clear();
+}
+
 /**
  * Fetch and parse a JSON CID document with SSRF, redirect, and
- * body-size protections.
+ * body-size protections — and a bounded TTL cache so auth-path callers
+ * don't refetch on every request.
  *
  * @param {string} docUrl - URL to fetch (untrusted — comes from JWT
  *   claims or is derived from a request).
@@ -44,6 +61,46 @@ const FETCH_TIMEOUT_MS = 5000;
  * @throws on any validation, network, redirect, size, or parse failure
  */
 export async function fetchCidDocument(docUrl, opts = {}) {
+  // Cache hit (or recent failure) — return immediately. On hit we
+  // delete-then-set so this entry moves to the tail of the Map's
+  // insertion order, giving LRU eviction without a separate structure.
+  const cached = profileCache.get(docUrl);
+  if (cached) {
+    const ttl = cached.failureTtl ? PROFILE_FAILURE_TTL : PROFILE_CACHE_TTL;
+    if (Date.now() - cached.timestamp < ttl) {
+      profileCache.delete(docUrl);
+      profileCache.set(docUrl, cached);
+      if (cached.failureTtl) throw new Error(cached.error);
+      return cached.profile;
+    }
+    profileCache.delete(docUrl);
+  }
+
+  try {
+    const profile = await fetchCidDocumentNoCache(docUrl, opts);
+    setCached(docUrl, { profile, timestamp: Date.now() });
+    return profile;
+  } catch (err) {
+    setCached(docUrl, {
+      timestamp: Date.now(),
+      failureTtl: true,
+      error: err.message,
+    });
+    throw err;
+  }
+}
+
+/** Insert into the bounded LRU; evict the oldest entry past the cap. */
+function setCached(url, entry) {
+  profileCache.set(url, entry);
+  while (profileCache.size > PROFILE_CACHE_MAX) {
+    const oldest = profileCache.keys().next().value;
+    if (oldest === undefined) break;
+    profileCache.delete(oldest);
+  }
+}
+
+async function fetchCidDocumentNoCache(docUrl, opts = {}) {
   const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
   const originalOrigin = new URL(docUrl).origin;
   let currentUrl = docUrl;

--- a/src/auth/cid-doc-fetch.js
+++ b/src/auth/cid-doc-fetch.js
@@ -153,7 +153,7 @@ async function fetchCidDocumentNoCache(docUrl, opts = {}) {
 
     const declared = Number(res.headers.get('content-length'));
     if (Number.isFinite(declared) && declared > maxBytes) {
-      throw new Error(`CID document too large (Content-Length=${declared})`);
+      throw new Error(`CID document too large (Content-Length=${declared} > ${maxBytes})`);
     }
     const text = await readBodyWithCap(res, maxBytes);
     return JSON.parse(text);

--- a/src/auth/lws-cid.js
+++ b/src/auth/lws-cid.js
@@ -35,7 +35,10 @@
 import * as jose from 'jose';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
-import { fetchCidDocument } from './cid-doc-fetch.js';
+import { fetchCidDocument, _clearProfileCacheForTests } from './cid-doc-fetch.js';
+
+// Re-export for the existing test suite, which already calls this.
+export { _clearProfileCacheForTests };
 
 // JWS algorithms we accept. ES256K (RFC8812) is the primary target —
 // secp256k1, the same curve as Nostr — but we support the common JWS
@@ -55,25 +58,11 @@ const MAX_LIFETIME = 3600; // 1 hour
 // Clock skew tolerance for exp/nbf checks (seconds).
 const CLOCK_SKEW = 60;
 
-// Profile fetch cache. Auth is on the hot path; refetching the CID
-// document on every request is unacceptable for both latency and
-// reliability. Mirrors the pattern in did-nostr.js, but bounded — an
-// attacker can otherwise grow the cache without limit by sending tokens
-// with many distinct `sub` URLs.
-const profileCache = new Map(); // url -> { profile, timestamp, failureTtl?, error? }
-const PROFILE_CACHE_TTL = 5 * 60 * 1000; // 5 minutes for hits
-const PROFILE_FAILURE_TTL = 60 * 1000;   // 1 minute for misses
-const PROFILE_CACHE_MAX = 1000;          // simple LRU bound
-
 // Max profile body size — passed to the shared fetcher. CID documents
 // are tiny in practice (~1-5 KB); 256 KB leaves plenty of headroom
-// while bounding any DoS attempt.
+// while bounding any DoS attempt. The cache itself lives in
+// cid-doc-fetch.js so both this module and the NIP-98 path benefit.
 const MAX_PROFILE_BYTES = 256 * 1024;
-
-/** @internal — exposed for tests */
-export function _clearProfileCacheForTests() {
-  profileCache.clear();
-}
 
 /**
  * Cheap detector — does this request carry an LWS-CID JWT?
@@ -425,57 +414,12 @@ function normalizeOrigin(s) {
   }
 }
 
-async function fetchProfile(docUrl) {
-  // Cache hit (or recent failure) — return immediately. On hit we
-  // delete-then-reset so this entry moves to the tail of the Map's
-  // insertion order, giving us LRU eviction without an extra structure.
-  const cached = profileCache.get(docUrl);
-  if (cached) {
-    const ttl = cached.failureTtl ? PROFILE_FAILURE_TTL : PROFILE_CACHE_TTL;
-    if (Date.now() - cached.timestamp < ttl) {
-      profileCache.delete(docUrl);
-      profileCache.set(docUrl, cached);
-      if (cached.failureTtl) throw new Error(cached.error);
-      return cached.profile;
-    }
-    profileCache.delete(docUrl);
-  }
-
-  try {
-    const profile = await fetchProfileNoCache(docUrl);
-    setCached(docUrl, { profile, timestamp: Date.now() });
-    return profile;
-  } catch (err) {
-    setCached(docUrl, {
-      timestamp: Date.now(),
-      failureTtl: true,
-      error: err.message,
-    });
-    throw err;
-  }
-}
-
-/** Insert into the bounded LRU; evict the oldest entry past the cap. */
-function setCached(url, entry) {
-  profileCache.set(url, entry);
-  while (profileCache.size > PROFILE_CACHE_MAX) {
-    // Map iterates in insertion order; first key is the oldest.
-    const oldest = profileCache.keys().next().value;
-    if (oldest === undefined) break;
-    profileCache.delete(oldest);
-  }
-}
-
 /**
- * Fetch the CID document with SSRF protection. Delegates to the
- * shared `fetchCidDocument` helper so the per-request defenses (SSRF
- * validation per hop, manual redirects, same-origin enforcement,
- * body-size cap) live in one place — see src/auth/cid-doc-fetch.js.
- *
- * The cache wrapper around this function (above) is LWS-CID-specific
- * and stays here.
+ * Fetch the CID document. Delegates to the shared `fetchCidDocument`
+ * helper which handles SSRF / redirects / body cap AND a bounded TTL
+ * cache (see src/auth/cid-doc-fetch.js).
  */
-async function fetchProfileNoCache(docUrl) {
+async function fetchProfile(docUrl) {
   return fetchCidDocument(docUrl, { maxBytes: MAX_PROFILE_BYTES });
 }
 

--- a/src/auth/lws-cid.js
+++ b/src/auth/lws-cid.js
@@ -448,7 +448,9 @@ function isInProofPurpose(profile, predicate, kid, baseUrl) {
   return false;
 }
 
-function normalizeControllers(value, baseUrl) {
+// Exported so the NIP-98 → WebID path (src/auth/nostr.js) can perform
+// the same controller consistency check the LWS-CID verifier uses.
+export function normalizeControllers(value, baseUrl) {
   if (value === undefined || value === null) return [];
   const list = Array.isArray(value) ? value : [value];
   const out = [];

--- a/src/auth/lws-cid.js
+++ b/src/auth/lws-cid.js
@@ -35,7 +35,7 @@
 import * as jose from 'jose';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
-import { validateExternalUrl } from '../utils/ssrf.js';
+import { fetchCidDocument } from './cid-doc-fetch.js';
 
 // JWS algorithms we accept. ES256K (RFC8812) is the primary target —
 // secp256k1, the same curve as Nostr — but we support the common JWS
@@ -65,12 +65,10 @@ const PROFILE_CACHE_TTL = 5 * 60 * 1000; // 5 minutes for hits
 const PROFILE_FAILURE_TTL = 60 * 1000;   // 1 minute for misses
 const PROFILE_CACHE_MAX = 1000;          // simple LRU bound
 
-// Manual-redirect cap so a chain can't loop or grind.
-const MAX_REDIRECTS = 5;
-
-// Max profile body size — guards against DoS via giant JSON bodies on
-// untrusted URLs. CID documents are tiny in practice (~1-5 KB).
-const MAX_PROFILE_BYTES = 256 * 1024; // 256 KB
+// Max profile body size — passed to the shared fetcher. CID documents
+// are tiny in practice (~1-5 KB); 256 KB leaves plenty of headroom
+// while bounding any DoS attempt.
+const MAX_PROFILE_BYTES = 256 * 1024;
 
 /** @internal — exposed for tests */
 export function _clearProfileCacheForTests() {
@@ -469,123 +467,16 @@ function setCached(url, entry) {
 }
 
 /**
- * Fetch the CID document with SSRF protection.
+ * Fetch the CID document with SSRF protection. Delegates to the
+ * shared `fetchCidDocument` helper so the per-request defenses (SSRF
+ * validation per hop, manual redirects, same-origin enforcement,
+ * body-size cap) live in one place — see src/auth/cid-doc-fetch.js.
  *
- * docUrl comes from JWT claims (sub, kid) BEFORE the signature is
- * verified, so it's untrusted. We:
- *   1. Validate it through the existing SSRF guard (blocks loopback,
- *      private IPs, http (in production), DNS that resolves to private
- *      addresses).
- *   2. Disable automatic redirects and re-validate every Location to
- *      defeat redirect-based bypasses (mirrors the cors-proxy pattern).
- *      Cross-origin redirects are refused — otherwise a target
- *      attacker-controlled host could serve a substitute CID document
- *      for the WebID's origin.
- *   3. Cap redirects so a chain can't loop.
- *   4. Cap response body size so a giant payload can't OOM us.
- *   5. Always send a fresh Accept and a small read-side timeout.
+ * The cache wrapper around this function (above) is LWS-CID-specific
+ * and stays here.
  */
 async function fetchProfileNoCache(docUrl) {
-  const originalOrigin = new URL(docUrl).origin;
-  let currentUrl = docUrl;
-
-  // Hop 0 is the original request; up to MAX_REDIRECTS subsequent
-  // redirects are followed, after which we throw.
-  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
-    const isLastAllowedHop = hop === MAX_REDIRECTS;
-    const validation = await validateExternalUrl(currentUrl, {
-      // Allow http on dev only — production deploys should always be https.
-      requireHttps: process.env.NODE_ENV === 'production',
-      blockPrivateIPs: true,
-      resolveDNS: true,
-    });
-    if (!validation.valid) {
-      throw new Error(`SSRF protection: ${validation.error}`);
-    }
-
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 5000);
-    let res;
-    try {
-      res = await fetch(currentUrl, {
-        // Prefer JSON-LD but accept plain JSON too — some WebID hosts
-        // serve `application/json` for `card.jsonld`. The body is JSON
-        // either way; we don't perform JSON-LD-specific processing here.
-        headers: { Accept: 'application/ld+json, application/json;q=0.9' },
-        redirect: 'manual',
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timer);
-    }
-
-    // Manual redirect handling — re-validate every Location and require
-    // same-origin so a redirect can't substitute an attacker-controlled
-    // CID document for the WebID's origin.
-    if (res.status >= 300 && res.status < 400) {
-      if (isLastAllowedHop) {
-        throw new Error(`too many redirects (>${MAX_REDIRECTS})`);
-      }
-      const loc = res.headers.get('location');
-      if (!loc) throw new Error(`redirect ${res.status} without Location`);
-      const nextUrl = new URL(loc, currentUrl).toString();
-      const nextOrigin = new URL(nextUrl).origin;
-      if (nextOrigin !== originalOrigin) {
-        throw new Error(
-          `cross-origin redirect refused: ${originalOrigin} → ${nextOrigin}`,
-        );
-      }
-      currentUrl = nextUrl;
-      continue;
-    }
-
-    if (!res.ok) {
-      throw new Error(`HTTP ${res.status}`);
-    }
-
-    // Size guard. Two layers: trust Content-Length when present, then
-    // also enforce as we read so a streaming response can't lie.
-    const declared = Number(res.headers.get('content-length'));
-    if (Number.isFinite(declared) && declared > MAX_PROFILE_BYTES) {
-      throw new Error(
-        `CID document too large (Content-Length=${declared} > ${MAX_PROFILE_BYTES})`,
-      );
-    }
-    const text = await readBodyWithCap(res, MAX_PROFILE_BYTES);
-    return JSON.parse(text);
-  }
-  // Loop exited without returning or redirecting — defensive fallback.
-  throw new Error('profile fetch loop exited unexpectedly');
-}
-
-/**
- * Read response body with a hard byte cap. Aborts the stream as soon as
- * the cap is exceeded so we don't buffer the entire untrusted payload.
- */
-async function readBodyWithCap(res, maxBytes) {
-  const reader = res.body?.getReader?.();
-  if (!reader) {
-    // No streaming reader (older runtimes / mocked responses) — fall
-    // back to .text() but enforce the cap after the fact.
-    const text = await res.text();
-    if (Buffer.byteLength(text, 'utf8') > maxBytes) {
-      throw new Error(`CID document too large (>${maxBytes} bytes)`);
-    }
-    return text;
-  }
-  const chunks = [];
-  let total = 0;
-  for (;;) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    total += value.byteLength;
-    if (total > maxBytes) {
-      try { await reader.cancel(); } catch { /* noop */ }
-      throw new Error(`CID document too large (>${maxBytes} bytes)`);
-    }
-    chunks.push(value);
-  }
-  return Buffer.concat(chunks.map((c) => Buffer.from(c.buffer, c.byteOffset, c.byteLength))).toString('utf8');
+  return fetchCidDocument(docUrl, { maxBytes: MAX_PROFILE_BYTES });
 }
 
 function findVerificationMethod(profile, kid, baseUrl) {

--- a/src/auth/nostr.js
+++ b/src/auth/nostr.js
@@ -297,15 +297,21 @@ async function tryResolveViaCidVerificationMethod(request, pubkeyHex) {
   }
   if (!profile || typeof profile !== 'object' || Array.isArray(profile)) return null;
 
+  // Subject-identity check (mirrors lws-cid.js). The CID document we
+  // just fetched MUST identify itself as the WebID we computed from
+  // the request — otherwise a profile hosted at the expected URL
+  // could declare a different `@id` and trick us into authenticating
+  // as that other identity using a sibling VM. We always return the
+  // computed ownerWebId (never the profile's declared subject) so a
+  // relative-IRI or mismatched `@id` can't substitute identity.
+  const subject = absolutize(profile['@id'] || profile.id, docUrl);
+  if (!subject || subject !== ownerWebId) return null;
+
   const vm = findNostrVmInProfile(profile, pubkeyHex, docUrl);
   if (!vm) return null;
   if (!isInProofPurpose(profile, 'authentication', vm.id, docUrl)) return null;
 
-  // Use the profile's declared subject as the authenticated identity
-  // (with @id fallback). Absolutize so a relative @id resolves.
-  const subject = profile['@id'] || profile.id;
-  if (!subject) return null;
-  return absolutize(subject, docUrl);
+  return ownerWebId;
 }
 
 /**

--- a/src/auth/nostr.js
+++ b/src/auth/nostr.js
@@ -15,7 +15,7 @@ import { verifyEvent, getEventHash } from '../nostr/event.js';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import crypto from 'crypto';
 import { resolveDidNostrToWebId } from './did-nostr.js';
-import { validateExternalUrl } from '../utils/ssrf.js';
+import { fetchCidDocument } from './cid-doc-fetch.js';
 
 // NIP-98 event kind (references RFC 7235)
 const HTTP_AUTH_KIND = 27235;
@@ -28,10 +28,9 @@ const TIMESTAMP_TOLERANCE = 60;
 // the 32-byte x-only Nostr pubkey.
 const MULTICODEC_SECP256K1_PUB_HEX = 'e701';
 
-// Profile-fetch limits — matches the LWS-CID verifier's defenses
-// (cross-origin redirect refusal, hop cap, body-size cap).
+// Profile-fetch body-size cap. Matches the LWS-CID verifier; both
+// callers go through the shared fetchCidDocument helper.
 const MAX_PROFILE_BYTES = 256 * 1024;
-const MAX_PROFILE_REDIRECTS = 5;
 
 /**
  * Check if request has Nostr authentication
@@ -343,9 +342,13 @@ function getPodOwnerWebId(request) {
               || 'https';
   // The Host header / x-forwarded-host can carry a port and may be an
   // IPv6 literal (`[::1]:3000`). For the host-vs-baseDomain comparison
-  // we need a port-stripped hostname that handles IPv6 correctly; for
-  // URL construction we keep the original `host` so non-default ports
-  // round-trip into the WebID.
+  // we need a port-stripped hostname that handles IPv6 correctly. For
+  // URL construction we keep the original `hostRaw` (port included) in
+  // the single-user and path-mode branches so non-default ports
+  // round-trip into the WebID. The subdomain-mode and base-domain
+  // branches deliberately drop the port — these mirror the
+  // canonicalization buildResourceUrl performs, where the WebID is
+  // derived from the deployment's baseDomain (no port).
   const hostRaw = firstHeaderValue(headers['x-forwarded-host'])
                 || firstHeaderValue(headers.host)
                 || request.hostname;
@@ -394,107 +397,18 @@ function getPodOwnerWebId(request) {
 }
 
 /**
- * Fetch a CID document (= WebID profile) with the same defenses as the
- * LWS-CID verifier:
- *
- *   - SSRF validation on the URL (and on every redirect Location).
- *   - Manual redirect handling, capped at MAX_PROFILE_REDIRECTS.
- *   - Cross-origin redirects refused so an open redirect on the WebID's
- *     host can't substitute an attacker-controlled CID document.
- *   - Body cap (Content-Length up front, streaming-reader cap during
- *     read) so an untrusted host can't OOM us.
+ * Fetch a CID document (= WebID profile). Delegates to the shared
+ * fetcher in src/auth/cid-doc-fetch.js so SSRF / redirect / body-cap
+ * defenses don't drift between this and the LWS-CID verifier.
  *
  * Throws on any failure; the caller treats throw-as-null.
+ *
+ * KNOWN GAP (#381): the underlying validateExternalUrl currently
+ * fail-opens when DNS returns no A/AAAA records. Fix belongs in the
+ * shared util so every caller benefits at once.
  */
 async function fetchProfileSafely(docUrl) {
-  const originalOrigin = new URL(docUrl).origin;
-  let currentUrl = docUrl;
-
-  for (let hop = 0; hop <= MAX_PROFILE_REDIRECTS; hop++) {
-    const isLastAllowedHop = hop === MAX_PROFILE_REDIRECTS;
-    const validation = await validateExternalUrl(currentUrl, {
-      requireHttps: process.env.NODE_ENV === 'production',
-      blockPrivateIPs: true,
-      resolveDNS: true,
-    });
-    if (!validation.valid) {
-      throw new Error(`SSRF protection: ${validation.error}`);
-    }
-    // KNOWN GAP (#381): validateExternalUrl currently treats "no
-    // A/AAAA records" as valid (its dns.resolve calls .catch(() => [])
-    // and the empty-set loop never fails). So a hostname that
-    // doesn't resolve at validation time but DOES resolve to a
-    // private IP at fetch time would slip through. The fix belongs in
-    // the shared util — once #381 lands, every safeFetch caller
-    // (LWS-CID, here, idp/provider, ap, ...) benefits. Doing it
-    // locally here would be inconsistent and would still leave the
-    // other callers exposed.
-
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 5000);
-    let res;
-    try {
-      res = await fetch(currentUrl, {
-        headers: { Accept: 'application/ld+json, application/json;q=0.9' },
-        redirect: 'manual',
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timer);
-    }
-
-    if (res.status >= 300 && res.status < 400) {
-      if (isLastAllowedHop) {
-        throw new Error(`too many redirects (>${MAX_PROFILE_REDIRECTS})`);
-      }
-      const loc = res.headers.get('location');
-      if (!loc) throw new Error(`redirect ${res.status} without Location`);
-      const nextUrl = new URL(loc, currentUrl).toString();
-      const nextOrigin = new URL(nextUrl).origin;
-      if (nextOrigin !== originalOrigin) {
-        throw new Error(`cross-origin redirect refused: ${originalOrigin} → ${nextOrigin}`);
-      }
-      currentUrl = nextUrl;
-      continue;
-    }
-
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-
-    const ct = (res.headers.get('content-type') || '').toLowerCase();
-    if (!ct.includes('json')) throw new Error(`unexpected content-type: ${ct || '(none)'}`);
-
-    const declared = Number(res.headers.get('content-length'));
-    if (Number.isFinite(declared) && declared > MAX_PROFILE_BYTES) {
-      throw new Error(`CID document too large (Content-Length=${declared})`);
-    }
-    const text = await readBodyWithCap(res, MAX_PROFILE_BYTES);
-    return JSON.parse(text);
-  }
-  throw new Error('profile fetch loop exited unexpectedly');
-}
-
-async function readBodyWithCap(res, maxBytes) {
-  const reader = res.body?.getReader?.();
-  if (!reader) {
-    const text = await res.text();
-    if (Buffer.byteLength(text, 'utf8') > maxBytes) {
-      throw new Error(`CID document too large (>${maxBytes} bytes)`);
-    }
-    return text;
-  }
-  const chunks = [];
-  let total = 0;
-  for (;;) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    total += value.byteLength;
-    if (total > maxBytes) {
-      try { await reader.cancel(); } catch { /* noop */ }
-      throw new Error(`CID document too large (>${maxBytes} bytes)`);
-    }
-    chunks.push(value);
-  }
-  return Buffer.concat(chunks.map((c) => Buffer.from(c.buffer, c.byteOffset, c.byteLength))).toString('utf8');
+  return fetchCidDocument(docUrl, { maxBytes: MAX_PROFILE_BYTES });
 }
 
 function firstHeaderValue(v) {

--- a/src/auth/nostr.js
+++ b/src/auth/nostr.js
@@ -190,7 +190,7 @@ export async function verifyNostrAuth(request) {
   const protoLower = protoRaw.toLowerCase();
   const protocol = (protoLower === 'http' || protoLower === 'https') ? protoLower : 'http';
   const host = firstHeaderValue(request.headers['x-forwarded-host'])
-            || request.headers.host
+            || firstHeaderValue(request.headers.host)
             || request.hostname;
   const fullUrl = `${protocol}://${host}${request.url}`;
 

--- a/src/auth/nostr.js
+++ b/src/auth/nostr.js
@@ -343,14 +343,14 @@ function getPodOwnerWebId(request) {
               || request.protocol
               || 'https';
   // The Host header / x-forwarded-host can carry a port and may be an
-  // IPv6 literal (`[::1]:3000`). For the host-vs-baseDomain comparison
-  // we need a port-stripped hostname that handles IPv6 correctly. For
-  // URL construction we keep the original `hostRaw` (port included) in
-  // the single-user and path-mode branches so non-default ports
-  // round-trip into the WebID. The subdomain-mode and base-domain
-  // branches deliberately drop the port — these mirror the
-  // canonicalization buildResourceUrl performs, where the WebID is
-  // derived from the deployment's baseDomain (no port).
+  // IPv6 literal (`[::1]:3000`). For all WebID construction we use
+  // the port-stripped, IPv6-bracket-stripped form (`hostNoPort`) to
+  // match what JSS itself stores: subdomain mode derives from
+  // `baseDomain` (no port), and src/handlers/container.js builds
+  // path-mode WebIDs from `request.hostname` (port-stripped). Using
+  // a port-bearing host here would compute a WebID that doesn't
+  // match the stored profile @id, so the subject-identity check
+  // would reject otherwise-valid requests on non-default ports.
   const hostRaw = firstHeaderValue(headers['x-forwarded-host'])
                 || firstHeaderValue(headers.host)
                 || request.hostname;
@@ -375,11 +375,16 @@ function getPodOwnerWebId(request) {
 
   // Single-user deployment. The pod is either at the host root or
   // mounted under `/<singleUserName>/`; both shapes are supported.
+  // Use the port-stripped form to match what JSS itself stores in
+  // the profile @id at pod-creation time (src/handlers/container.js
+  // builds with `request.hostname`, port-stripped). Otherwise a
+  // request arriving on a non-default port would compute a WebID
+  // the subject-identity check rejects.
   if (request.singleUser) {
     const name = request.singleUserName;
     return name
-      ? `${proto}://${hostRaw}/${name}/profile/card.jsonld#me`
-      : `${proto}://${hostRaw}/profile/card.jsonld#me`;
+      ? `${proto}://${hostNoPort}/${name}/profile/card.jsonld#me`
+      : `${proto}://${hostNoPort}/profile/card.jsonld#me`;
   }
 
   // Subdomain mode (request already on a pod's subdomain).
@@ -398,10 +403,13 @@ function getPodOwnerWebId(request) {
     return null;
   }
 
-  // Path mode (JSS default): pod is the first URL segment.
+  // Path mode (JSS default): pod is the first URL segment. Match
+  // src/handlers/container.js which builds path-mode WebIDs from
+  // `request.hostname` (port-stripped), so the computed ownerWebId
+  // equals the @id JSS itself wrote at pod-creation time.
   const m = (request.url || '').match(/^\/([^/?#]+)/);
   if (m && !m[1].startsWith('.') && !m[1].includes('.')) {
-    return `${proto}://${hostRaw}/${m[1]}/profile/card.jsonld#me`;
+    return `${proto}://${hostNoPort}/${m[1]}/profile/card.jsonld#me`;
   }
   return null;
 }

--- a/src/auth/nostr.js
+++ b/src/auth/nostr.js
@@ -27,6 +27,11 @@ const TIMESTAMP_TOLERANCE = 60;
 // the 32-byte x-only Nostr pubkey.
 const MULTICODEC_SECP256K1_PUB_HEX = 'e701';
 
+// Profile-fetch limits — matches the LWS-CID verifier's defenses
+// (cross-origin redirect refusal, hop cap, body-size cap).
+const MAX_PROFILE_BYTES = 256 * 1024;
+const MAX_PROFILE_REDIRECTS = 5;
+
 /**
  * Check if request has Nostr authentication
  * Supports both "Nostr <token>" and "Basic <base64(nostr:token)>" formats
@@ -280,27 +285,12 @@ async function tryResolveViaCidVerificationMethod(request, pubkeyHex) {
 
   // SSRF guard. The owner WebID is derived from server-side request
   // data, so it shouldn't be attacker-controllable, but route through
-  // the same guard as the LWS-CID verifier as defense-in-depth.
-  const validation = await validateExternalUrl(docUrl, {
-    requireHttps: process.env.NODE_ENV === 'production',
-    blockPrivateIPs: true,
-    resolveDNS: true,
-  });
-  if (!validation.valid) return null;
-
+  // the same defense-in-depth as the LWS-CID verifier — including
+  // manual redirect handling with same-origin enforcement, and a
+  // body-size cap to deflect oversized-payload DoS.
   let profile;
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 5000);
-    const res = await fetch(docUrl, {
-      headers: { Accept: 'application/ld+json' },
-      signal: controller.signal,
-    });
-    clearTimeout(timer);
-    if (!res.ok) return null;
-    const ct = (res.headers.get('content-type') || '').toLowerCase();
-    if (!ct.includes('json')) return null;
-    profile = await res.json();
+    profile = await fetchProfileSafely(docUrl);
   } catch {
     return null;
   }
@@ -320,34 +310,160 @@ async function tryResolveViaCidVerificationMethod(request, pubkeyHex) {
 /**
  * Derive the pod-owner WebID URL from a Fastify request.
  *
- * Subdomain mode: the pod's domain IS the request's hostname.
- * Path mode: the pod's name is the first path segment.
- * Single-user / unknown: returns null (the caller falls back).
+ * JSS supports three pod-addressing modes (see src/idp/interactions.js
+ * around the createPod path for the canonical list):
+ *
+ *   - **Subdomain mode** — `subdomainsEnabled` is true, request hits a
+ *     subdomain like `alice.example.com`. WebID is at the subdomain
+ *     root: `https://alice.example.com/profile/card.jsonld#me`.
+ *   - **Path mode** — the JSS default (`subdomainsEnabled` off). Pod
+ *     is at the first URL path segment:
+ *     `https://example.com/alice/foo` → WebID
+ *     `https://example.com/alice/profile/card.jsonld#me`.
+ *   - **Path-mode-on-base** — subdomains are enabled but the request
+ *     hits the base domain with a path. The internal canonical form
+ *     rewrites this to the subdomain shape (per buildResourceUrl).
+ *
+ * Returns null when no pod name can be derived (single-user
+ * deployments will hit this path; the caller falls back to the
+ * existing did:nostr DID-doc resolver / did:nostr identity).
  */
 function getPodOwnerWebId(request) {
-  const proto = (request.headers?.['x-forwarded-proto'] || '').split(',')[0].trim()
+  const headers = request.headers || {};
+  const proto = firstHeaderValue(headers['x-forwarded-proto'])
               || request.protocol
               || 'https';
-  const host  = (request.headers?.['x-forwarded-host'] || '').split(',')[0].trim()
-              || request.headers?.host
+  const host  = firstHeaderValue(headers['x-forwarded-host'])
+              || firstHeaderValue(headers.host)
               || request.hostname;
   if (!host) return null;
 
-  // Subdomain mode: hostname carries the pod name.
-  if (request.subdomainsEnabled && request.podName) {
+  // Subdomain mode (request already on a pod's subdomain).
+  if (request.subdomainsEnabled && request.podName && request.baseDomain) {
     return `${proto}://${request.podName}.${request.baseDomain}/profile/card.jsonld#me`;
   }
 
-  // Path mode on the base domain: first path segment is the pod name.
+  // Subdomain-enabled deployment, request landed on the base domain
+  // with a path (e.g. https://example.com/alice/...). The canonical
+  // form is the subdomain — match the rewriting buildResourceUrl does.
   if (request.subdomainsEnabled && request.baseDomain && host === request.baseDomain) {
     const m = (request.url || '').match(/^\/([^/?#]+)/);
     if (m && !m[1].startsWith('.') && !m[1].includes('.')) {
       return `${proto}://${m[1]}.${request.baseDomain}/profile/card.jsonld#me`;
     }
+    return null;
   }
 
-  // Default: assume the host itself is a single-pod deployment.
-  return `${proto}://${host}/profile/card.jsonld#me`;
+  // Path mode (JSS default): pod is the first URL segment.
+  const m = (request.url || '').match(/^\/([^/?#]+)/);
+  if (m && !m[1].startsWith('.') && !m[1].includes('.')) {
+    return `${proto}://${host}/${m[1]}/profile/card.jsonld#me`;
+  }
+  return null;
+}
+
+/**
+ * Fetch a CID document (= WebID profile) with the same defenses as the
+ * LWS-CID verifier:
+ *
+ *   - SSRF validation on the URL (and on every redirect Location).
+ *   - Manual redirect handling, capped at MAX_PROFILE_REDIRECTS.
+ *   - Cross-origin redirects refused so an open redirect on the WebID's
+ *     host can't substitute an attacker-controlled CID document.
+ *   - Body cap (Content-Length up front, streaming-reader cap during
+ *     read) so an untrusted host can't OOM us.
+ *
+ * Throws on any failure; the caller treats throw-as-null.
+ */
+async function fetchProfileSafely(docUrl) {
+  const originalOrigin = new URL(docUrl).origin;
+  let currentUrl = docUrl;
+
+  for (let hop = 0; hop <= MAX_PROFILE_REDIRECTS; hop++) {
+    const isLastAllowedHop = hop === MAX_PROFILE_REDIRECTS;
+    const validation = await validateExternalUrl(currentUrl, {
+      requireHttps: process.env.NODE_ENV === 'production',
+      blockPrivateIPs: true,
+      resolveDNS: true,
+    });
+    if (!validation.valid) {
+      throw new Error(`SSRF protection: ${validation.error}`);
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5000);
+    let res;
+    try {
+      res = await fetch(currentUrl, {
+        headers: { Accept: 'application/ld+json, application/json;q=0.9' },
+        redirect: 'manual',
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (res.status >= 300 && res.status < 400) {
+      if (isLastAllowedHop) {
+        throw new Error(`too many redirects (>${MAX_PROFILE_REDIRECTS})`);
+      }
+      const loc = res.headers.get('location');
+      if (!loc) throw new Error(`redirect ${res.status} without Location`);
+      const nextUrl = new URL(loc, currentUrl).toString();
+      const nextOrigin = new URL(nextUrl).origin;
+      if (nextOrigin !== originalOrigin) {
+        throw new Error(`cross-origin redirect refused: ${originalOrigin} → ${nextOrigin}`);
+      }
+      currentUrl = nextUrl;
+      continue;
+    }
+
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+    const ct = (res.headers.get('content-type') || '').toLowerCase();
+    if (!ct.includes('json')) throw new Error(`unexpected content-type: ${ct || '(none)'}`);
+
+    const declared = Number(res.headers.get('content-length'));
+    if (Number.isFinite(declared) && declared > MAX_PROFILE_BYTES) {
+      throw new Error(`CID document too large (Content-Length=${declared})`);
+    }
+    const text = await readBodyWithCap(res, MAX_PROFILE_BYTES);
+    return JSON.parse(text);
+  }
+  throw new Error('profile fetch loop exited unexpectedly');
+}
+
+async function readBodyWithCap(res, maxBytes) {
+  const reader = res.body?.getReader?.();
+  if (!reader) {
+    const text = await res.text();
+    if (Buffer.byteLength(text, 'utf8') > maxBytes) {
+      throw new Error(`CID document too large (>${maxBytes} bytes)`);
+    }
+    return text;
+  }
+  const chunks = [];
+  let total = 0;
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      try { await reader.cancel(); } catch { /* noop */ }
+      throw new Error(`CID document too large (>${maxBytes} bytes)`);
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks.map((c) => Buffer.from(c.buffer, c.byteOffset, c.byteLength))).toString('utf8');
+}
+
+function firstHeaderValue(v) {
+  if (!v) return null;
+  // Fastify/Node header values can be string or string[].
+  const s = Array.isArray(v) ? v[0] : v;
+  if (typeof s !== 'string') return null;
+  const first = s.split(',')[0].trim();
+  return first || null;
 }
 
 /**

--- a/src/auth/nostr.js
+++ b/src/auth/nostr.js
@@ -339,9 +339,16 @@ async function tryResolveViaCidVerificationMethod(request, pubkeyHex) {
  */
 function getPodOwnerWebId(request) {
   const headers = request.headers || {};
-  const proto = firstHeaderValue(headers['x-forwarded-proto'])
-              || request.protocol
-              || 'https';
+  // Lowercase + allowlist the protocol. Some proxies send
+  // `X-Forwarded-Proto: HTTPS` (or other casings); without
+  // normalization the constructed ownerWebId would carry that
+  // casing and the subject-identity check would reject the match
+  // against a profile @id that uses lowercase `https://`.
+  const protoRaw = firstHeaderValue(headers['x-forwarded-proto'])
+                 || request.protocol
+                 || 'https';
+  const protoLower = protoRaw.toLowerCase();
+  const proto = (protoLower === 'http' || protoLower === 'https') ? protoLower : 'https';
   // The Host header / x-forwarded-host can carry a port and may be an
   // IPv6 literal (`[::1]:3000`). For all WebID construction we use
   // the port-stripped, IPv6-bracket-stripped form (`hostNoPort`) to
@@ -369,6 +376,16 @@ function getPodOwnerWebId(request) {
   // U+005D (])"). The baseDomain comparison uses the un-bracketed
   // form, so we strip them here. Don't remove this branch — it is
   // reachable for any IPv6 host header.
+  //
+  // Known limitation (deferred): URL construction below interpolates
+  // `hostNoPort` into the WebID string, which produces an invalid
+  // URL for IPv6 (bracket-less) hosts. Solid deployments on IPv6
+  // literals are effectively non-existent, and JSS itself has the
+  // same shape (see src/handlers/container.js building with
+  // `${proto}://${request.hostname}` for path-mode pods), so fixing
+  // this here would actually create a mismatch with the stored
+  // @id. The right fix is at the JSS pod-creation layer; this
+  // module follows that convention to stay consistent.
   if (hostNoPort.startsWith('[') && hostNoPort.endsWith(']')) {
     hostNoPort = hostNoPort.slice(1, -1);
   }

--- a/src/auth/nostr.js
+++ b/src/auth/nostr.js
@@ -394,8 +394,9 @@ function getPodOwnerWebId(request) {
   const proto = (protoLower === 'http' || protoLower === 'https') ? protoLower : 'https';
   // The Host header / x-forwarded-host can carry a port and may be an
   // IPv6 literal (`[::1]:3000`). For all WebID construction we use
-  // the port-stripped, IPv6-bracket-stripped form (`hostNoPort`) to
-  // match what JSS itself stores: subdomain mode derives from
+  // `hostNoPort` — the URL parser's port-stripped hostname (still
+  // bracketed for IPv6 here; we bail out on IPv6 below). This
+  // matches what JSS itself stores: subdomain mode derives from
   // `baseDomain` (no port), and src/handlers/container.js builds
   // path-mode WebIDs from `request.hostname` (port-stripped). Using
   // a port-bearing host here would compute a WebID that doesn't

--- a/src/auth/nostr.js
+++ b/src/auth/nostr.js
@@ -7,8 +7,18 @@
  *
  * Authorization header format: "Nostr <base64-encoded-event>"
  *
- * The authenticated identity is returned as a did:nostr URI:
- *   did:nostr:<64-char-hex-pubkey>
+ * Identity resolution chain (after a successful Schnorr verification):
+ *
+ *   1. Look up the Nostr pubkey in the resource owner's WebID profile
+ *      as a CID v1 verificationMethod referenced from `authentication`.
+ *      Match by f-form Multikey or by JsonWebKey x/y coordinates. If
+ *      found, authenticate as the WebID. (#399 — pairs with the
+ *      LWS10-CID verifier.)
+ *   2. Resolve via the existing did:nostr DID-document path
+ *      (nostr.social `.well-known` + bidirectional alsoKnownAs).
+ *      If found, authenticate as the WebID it points to.
+ *   3. Otherwise return `did:nostr:<64-char-hex-pubkey>` as the
+ *      agent identity (the original behavior).
  */
 
 import { verifyEvent, getEventHash } from '../nostr/event.js';

--- a/src/auth/nostr.js
+++ b/src/auth/nostr.js
@@ -26,6 +26,7 @@ import { secp256k1 } from '@noble/curves/secp256k1';
 import crypto from 'crypto';
 import { resolveDidNostrToWebId } from './did-nostr.js';
 import { fetchCidDocument } from './cid-doc-fetch.js';
+import { normalizeControllers } from './lws-cid.js';
 
 // NIP-98 event kind (references RFC 7235)
 const HTTP_AUTH_KIND = 27235;
@@ -176,9 +177,21 @@ export async function verifyNostrAuth(request) {
     return { webId: null, error: 'Event timestamp outside acceptable window (±60s)' };
   }
 
-  // Build full URL for validation
-  const protocol = request.protocol || 'http';
-  const host = request.headers.host || request.hostname;
+  // Build full URL for validation. Behind a reverse proxy the public-
+  // facing URL is what the client signed, but request.headers.host /
+  // request.protocol carry the internal upstream values. Honor the
+  // forwarded headers (matching the conventions in src/ap/* and the
+  // LWS-CID verifier) so a NIP-98 sig for the public URL still
+  // matches in proxied deployments. Proto is lowercased + allowlisted
+  // to avoid casing-mismatches from misconfigured proxies.
+  const protoRaw = firstHeaderValue(request.headers['x-forwarded-proto'])
+                || request.protocol
+                || 'http';
+  const protoLower = protoRaw.toLowerCase();
+  const protocol = (protoLower === 'http' || protoLower === 'https') ? protoLower : 'http';
+  const host = firstHeaderValue(request.headers['x-forwarded-host'])
+            || request.headers.host
+            || request.hostname;
   const fullUrl = `${protocol}://${host}${request.url}`;
 
   // Validate URL tag matches request URL
@@ -319,6 +332,17 @@ async function tryResolveViaCidVerificationMethod(request, pubkeyHex) {
   const vm = findNostrVmInProfile(profile, pubkeyHex, docUrl);
   if (!vm) return null;
   if (!isInProofPurpose(profile, 'authentication', vm.id, docUrl)) return null;
+
+  // Controller consistency: the VM's `controller` MUST be in the
+  // profile's expected controller set (declared `controller`, with
+  // @id fallback). Without this, a profile with a Nostr-keyed VM
+  // controlled by some unrelated identity could still upgrade us to
+  // the WebID — a key-binding the actual subject never asserted.
+  // Mirrors the lws-cid.js check using the same normalizer.
+  const expectedCtrls = normalizeControllers(profile.controller ?? profile['@id'] ?? profile.id, docUrl);
+  if (expectedCtrls.length === 0) return null;
+  const vmCtrls = normalizeControllers(vm.controller, docUrl);
+  if (!vmCtrls.some((c) => expectedCtrls.includes(c))) return null;
 
   return ownerWebId;
 }

--- a/src/auth/nostr.js
+++ b/src/auth/nostr.js
@@ -402,27 +402,23 @@ function getPodOwnerWebId(request) {
   let hostNoPort;
   try { hostNoPort = new URL(`${proto}://${hostRaw}`).hostname; }
   catch { return null; }
-  // Strip surrounding brackets the URL parser keeps on .hostname for
-  // IPv6 literals. Verified on Node v24.5.0:
+  // Detect IPv6 literal hosts and bail early. URL.hostname keeps
+  // brackets for IPv6 (verified Node v24.5.0:
   //   new URL('https://[2001:db8::1]:8443/x').hostname === '[2001:db8::1]'
-  // matching WHATWG URL §host serializing rule for IPv6 addresses
-  // ("return U+005B ([), followed by IPv6 serializer, followed by
-  // U+005D (])"). The baseDomain comparison uses the un-bracketed
-  // form, so we strip them here. Don't remove this branch — it is
-  // reachable for any IPv6 host header.
+  // per WHATWG URL §host serializing rule). Continuing into the
+  // URL-construction branches with a bracket-less form would yield a
+  // malformed string like `https://2001:db8::1/...` — invalid, would
+  // throw at parse time and could pollute the shared CID-profile
+  // cache with a failure entry under that bogus key.
   //
-  // Known limitation (deferred): URL construction below interpolates
-  // `hostNoPort` into the WebID string, which produces an invalid
-  // URL for IPv6 (bracket-less) hosts. Solid deployments on IPv6
-  // literals are effectively non-existent, and JSS itself has the
-  // same shape (see src/handlers/container.js building with
-  // `${proto}://${request.hostname}` for path-mode pods), so fixing
-  // this here would actually create a mismatch with the stored
-  // @id. The right fix is at the JSS pod-creation layer; this
-  // module follows that convention to stay consistent.
-  if (hostNoPort.startsWith('[') && hostNoPort.endsWith(']')) {
-    hostNoPort = hostNoPort.slice(1, -1);
-  }
+  // Solid deployments on raw IPv6 literals are effectively
+  // non-existent; cleanly skipping the VM-lookup upgrade for them
+  // (caller falls back to the existing did:nostr resolver) is the
+  // right behavior. JSS itself has a parallel limitation in
+  // src/handlers/container.js — fixing IPv6 needs to happen at that
+  // pod-creation layer first.
+  const isIpv6 = hostNoPort.startsWith('[') && hostNoPort.endsWith(']');
+  if (isIpv6) return null;
 
   // Single-user deployment. The pod is either at the host root or
   // mounted under `/<singleUserName>/`; both shapes are supported.

--- a/src/auth/nostr.js
+++ b/src/auth/nostr.js
@@ -192,6 +192,15 @@ export async function verifyNostrAuth(request) {
   const host = firstHeaderValue(request.headers['x-forwarded-host'])
             || firstHeaderValue(request.headers.host)
             || request.hostname;
+  // Reject URL-meaningful characters in the host before interpolation
+  // — same defense as in getPodOwnerWebId. Otherwise a Host like
+  // `example.com@attacker.com` would produce a fullUrl that parses
+  // with attacker.com as the hostname, which a sophisticated client
+  // could try to align with a NIP-98 `u` tag for an external
+  // resource.
+  if (host && /[@/\s?#\\]/.test(host)) {
+    return { webId: null, error: 'Host header contains invalid characters' };
+  }
   const fullUrl = `${protocol}://${host}${request.url}`;
 
   // Validate URL tag matches request URL
@@ -396,6 +405,14 @@ function getPodOwnerWebId(request) {
                 || firstHeaderValue(headers.host)
                 || request.hostname;
   if (!hostRaw) return null;
+  // Reject host strings that carry URL-special characters before we
+  // hand them to the URL parser. Without this, a Host like
+  // `example.com@attacker.com` would parse as userinfo + attacker.com
+  // and steer the computed owner WebID at the attacker's domain.
+  // A well-formed Host header carries hostname[:port][[]] only —
+  // reject any other URL-meaningful character (`@`, `/`, `?`, `#`,
+  // whitespace, query/fragment delimiters).
+  if (/[@/\s?#\\]/.test(hostRaw)) return null;
   // `request.hostname` is port-stripped per Fastify but doesn't survive
   // x-forwarded-host parsing. Round-trip through URL semantics so
   // IPv6 brackets and ports are handled by the parser, not split(':').

--- a/src/auth/nostr.js
+++ b/src/auth/nostr.js
@@ -12,6 +12,7 @@
  */
 
 import { verifyEvent, getEventHash } from '../nostr/event.js';
+import { secp256k1 } from '@noble/curves/secp256k1';
 import crypto from 'crypto';
 import { resolveDidNostrToWebId } from './did-nostr.js';
 import { validateExternalUrl } from '../utils/ssrf.js';
@@ -334,19 +335,32 @@ function getPodOwnerWebId(request) {
   const proto = firstHeaderValue(headers['x-forwarded-proto'])
               || request.protocol
               || 'https';
-  // Use request.hostname (port-stripped) for the host comparison and
-  // for derivation. The Host header / x-forwarded-host can carry a
-  // port (e.g. "example.com:8080") which would prevent the
-  // host === baseDomain check below from matching.
-  const host  = firstHeaderValue(headers['x-forwarded-host'])
-              || request.hostname
-              || firstHeaderValue(headers.host);
-  if (!host) return null;
-  const hostNoPort = host.split(':')[0];
+  // The Host header / x-forwarded-host can carry a port and may be an
+  // IPv6 literal (`[::1]:3000`). For the host-vs-baseDomain comparison
+  // we need a port-stripped hostname that handles IPv6 correctly; for
+  // URL construction we keep the original `host` so non-default ports
+  // round-trip into the WebID.
+  const hostRaw = firstHeaderValue(headers['x-forwarded-host'])
+                || firstHeaderValue(headers.host)
+                || request.hostname;
+  if (!hostRaw) return null;
+  // `request.hostname` is port-stripped per Fastify but doesn't survive
+  // x-forwarded-host parsing. Round-trip through URL semantics so
+  // IPv6 brackets and ports are handled by the parser, not split(':').
+  let hostNoPort;
+  try { hostNoPort = new URL(`${proto}://${hostRaw}`).hostname; }
+  catch { return null; }
+  // Strip surrounding brackets the URL parser keeps on the .hostname for
+  // IPv6 literals (`[::1]` → `::1`). Comparison strings against
+  // baseDomain are written without brackets; URL construction below
+  // re-wraps explicitly when needed.
+  if (hostNoPort.startsWith('[') && hostNoPort.endsWith(']')) {
+    hostNoPort = hostNoPort.slice(1, -1);
+  }
 
   // Single-user deployment: one pod at the host root.
   if (request.singleUser) {
-    return `${proto}://${hostNoPort}/profile/card.jsonld#me`;
+    return `${proto}://${hostRaw}/profile/card.jsonld#me`;
   }
 
   // Subdomain mode (request already on a pod's subdomain).
@@ -368,7 +382,7 @@ function getPodOwnerWebId(request) {
   // Path mode (JSS default): pod is the first URL segment.
   const m = (request.url || '').match(/^\/([^/?#]+)/);
   if (m && !m[1].startsWith('.') && !m[1].includes('.')) {
-    return `${proto}://${hostNoPort}/${m[1]}/profile/card.jsonld#me`;
+    return `${proto}://${hostRaw}/${m[1]}/profile/card.jsonld#me`;
   }
   return null;
 }
@@ -400,6 +414,15 @@ async function fetchProfileSafely(docUrl) {
     if (!validation.valid) {
       throw new Error(`SSRF protection: ${validation.error}`);
     }
+    // KNOWN GAP (#381): validateExternalUrl currently treats "no
+    // A/AAAA records" as valid (its dns.resolve calls .catch(() => [])
+    // and the empty-set loop never fails). So a hostname that
+    // doesn't resolve at validation time but DOES resolve to a
+    // private IP at fetch time would slip through. The fix belongs in
+    // the shared util — once #381 lands, every safeFetch caller
+    // (LWS-CID, here, idp/provider, ap, ...) benefits. Doing it
+    // locally here would be inconsistent and would still leave the
+    // other callers exposed.
 
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), 5000);
@@ -502,7 +525,7 @@ function findNostrVmInProfile(profile, pubkeyHex, baseUrl) {
     if (vm.publicKeyJwk && typeof vm.publicKeyJwk === 'object') {
       const jwk = vm.publicKeyJwk;
       if (jwk.kty === 'EC' && (jwk.crv === 'secp256k1' || jwk.crv === 'P-256K')) {
-        if (typeof jwk.x === 'string' && jwk.x === targetB64u) {
+        if (jwkMatchesNostrPubkey(jwk, target, targetB64u)) {
           return { ...vm, id: absolutize(vmId, baseUrl) };
         }
       }
@@ -531,6 +554,44 @@ function decodeFFormSecp256k1(mb) {
 function hexToBase64url(hex) {
   return Buffer.from(hex, 'hex').toString('base64')
     .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * Does the JWK encode the given Nostr x-only pubkey?
+ *
+ * EC keys are (x, y) pairs — two distinct valid points share the same
+ * x with opposite y parities. Matching on x alone would let an
+ * attacker craft a JWK with the target x and a wrong y, which we'd
+ * then accept as the user's Nostr key. So we also derive the
+ * BIP-340-canonical y (even-parity) for the target x and require the
+ * JWK's y to match.
+ *
+ * Returns false if the JWK's coordinates aren't on-curve, can't be
+ * decoded, or don't match the BIP-340 canonical point for `targetHex`.
+ */
+function jwkMatchesNostrPubkey(jwk, targetHex, targetB64u) {
+  if (typeof jwk.x !== 'string' || typeof jwk.y !== 'string') return false;
+  if (jwk.x !== targetB64u) return false;
+  // Decompress the BIP-340 even-y point for the target x. Then compare
+  // the JWK's declared y against this canonical y.
+  let canonicalY;
+  try {
+    // Compressed SEC1 point, even-y prefix (0x02) || x.
+    const compressed = '02' + targetHex;
+    const point = secp256k1.ProjectivePoint.fromHex(compressed);
+    const affine = point.toAffine();
+    canonicalY = affine.y.toString(16).padStart(64, '0');
+  } catch {
+    return false;
+  }
+  let jwkYHex;
+  try {
+    jwkYHex = Buffer.from(jwk.y.replace(/-/g, '+').replace(/_/g, '/'), 'base64')
+      .toString('hex').toLowerCase();
+  } catch {
+    return false;
+  }
+  return jwkYHex === canonicalY;
 }
 
 function isInProofPurpose(profile, predicate, vmId, baseUrl) {

--- a/src/auth/nostr.js
+++ b/src/auth/nostr.js
@@ -361,10 +361,14 @@ function getPodOwnerWebId(request) {
   let hostNoPort;
   try { hostNoPort = new URL(`${proto}://${hostRaw}`).hostname; }
   catch { return null; }
-  // Strip surrounding brackets the URL parser keeps on the .hostname for
-  // IPv6 literals (`[::1]` → `::1`). Comparison strings against
-  // baseDomain are written without brackets; URL construction below
-  // re-wraps explicitly when needed.
+  // Strip surrounding brackets the URL parser keeps on .hostname for
+  // IPv6 literals. Verified on Node v24.5.0:
+  //   new URL('https://[2001:db8::1]:8443/x').hostname === '[2001:db8::1]'
+  // matching WHATWG URL §host serializing rule for IPv6 addresses
+  // ("return U+005B ([), followed by IPv6 serializer, followed by
+  // U+005D (])"). The baseDomain comparison uses the un-bracketed
+  // form, so we strip them here. Don't remove this branch — it is
+  // reachable for any IPv6 host header.
   if (hostNoPort.startsWith('[') && hostNoPort.endsWith(']')) {
     hostNoPort = hostNoPort.slice(1, -1);
   }

--- a/src/auth/nostr.js
+++ b/src/auth/nostr.js
@@ -310,9 +310,11 @@ async function tryResolveViaCidVerificationMethod(request, pubkeyHex) {
 /**
  * Derive the pod-owner WebID URL from a Fastify request.
  *
- * JSS supports three pod-addressing modes (see src/idp/interactions.js
+ * JSS supports four pod-addressing modes (see src/idp/interactions.js
  * around the createPod path for the canonical list):
  *
+ *   - **Single-user mode** — `request.singleUser` is true. There's
+ *     one pod at the host root: WebID is `https://host/profile/card.jsonld#me`.
  *   - **Subdomain mode** — `subdomainsEnabled` is true, request hits a
  *     subdomain like `alice.example.com`. WebID is at the subdomain
  *     root: `https://alice.example.com/profile/card.jsonld#me`.
@@ -324,19 +326,28 @@ async function tryResolveViaCidVerificationMethod(request, pubkeyHex) {
  *     hits the base domain with a path. The internal canonical form
  *     rewrites this to the subdomain shape (per buildResourceUrl).
  *
- * Returns null when no pod name can be derived (single-user
- * deployments will hit this path; the caller falls back to the
- * existing did:nostr DID-doc resolver / did:nostr identity).
+ * Returns null when no pod name can be derived; the caller falls back
+ * to the existing did:nostr DID-doc resolver / did:nostr identity.
  */
 function getPodOwnerWebId(request) {
   const headers = request.headers || {};
   const proto = firstHeaderValue(headers['x-forwarded-proto'])
               || request.protocol
               || 'https';
+  // Use request.hostname (port-stripped) for the host comparison and
+  // for derivation. The Host header / x-forwarded-host can carry a
+  // port (e.g. "example.com:8080") which would prevent the
+  // host === baseDomain check below from matching.
   const host  = firstHeaderValue(headers['x-forwarded-host'])
-              || firstHeaderValue(headers.host)
-              || request.hostname;
+              || request.hostname
+              || firstHeaderValue(headers.host);
   if (!host) return null;
+  const hostNoPort = host.split(':')[0];
+
+  // Single-user deployment: one pod at the host root.
+  if (request.singleUser) {
+    return `${proto}://${hostNoPort}/profile/card.jsonld#me`;
+  }
 
   // Subdomain mode (request already on a pod's subdomain).
   if (request.subdomainsEnabled && request.podName && request.baseDomain) {
@@ -346,7 +357,7 @@ function getPodOwnerWebId(request) {
   // Subdomain-enabled deployment, request landed on the base domain
   // with a path (e.g. https://example.com/alice/...). The canonical
   // form is the subdomain — match the rewriting buildResourceUrl does.
-  if (request.subdomainsEnabled && request.baseDomain && host === request.baseDomain) {
+  if (request.subdomainsEnabled && request.baseDomain && hostNoPort === request.baseDomain) {
     const m = (request.url || '').match(/^\/([^/?#]+)/);
     if (m && !m[1].startsWith('.') && !m[1].includes('.')) {
       return `${proto}://${m[1]}.${request.baseDomain}/profile/card.jsonld#me`;
@@ -357,7 +368,7 @@ function getPodOwnerWebId(request) {
   // Path mode (JSS default): pod is the first URL segment.
   const m = (request.url || '').match(/^\/([^/?#]+)/);
   if (m && !m[1].startsWith('.') && !m[1].includes('.')) {
-    return `${proto}://${host}/${m[1]}/profile/card.jsonld#me`;
+    return `${proto}://${hostNoPort}/${m[1]}/profile/card.jsonld#me`;
   }
   return null;
 }

--- a/src/auth/nostr.js
+++ b/src/auth/nostr.js
@@ -14,12 +14,18 @@
 import { verifyEvent, getEventHash } from '../nostr/event.js';
 import crypto from 'crypto';
 import { resolveDidNostrToWebId } from './did-nostr.js';
+import { validateExternalUrl } from '../utils/ssrf.js';
 
 // NIP-98 event kind (references RFC 7235)
 const HTTP_AUTH_KIND = 27235;
 
 // Timestamp tolerance in seconds
 const TIMESTAMP_TOLERANCE = 60;
+
+// Multicodec varint for secp256k1-pub: 0xe7 0x01 → "e701" hex.
+// Used to decode f-form Multikey verificationMethod values back into
+// the 32-byte x-only Nostr pubkey.
+const MULTICODEC_SECP256K1_PUB_HEX = 'e701';
 
 /**
  * Check if request has Nostr authentication
@@ -229,9 +235,19 @@ export async function verifyNostrAuth(request) {
     return { webId: null, error: 'Invalid Schnorr signature' };
   }
 
-  // Try to resolve did:nostr to a linked WebID
-  // This checks if the pubkey has an alsoKnownAs pointing to a WebID
-  // and verifies the WebID links back to did:nostr (bidirectional)
+  // First lookup: the resource's owner WebID profile. If the pod owner
+  // declared this pubkey as a verificationMethod (CID v1 / LWS-CID
+  // shape — produced by the doctor's B.2 path), authenticate as the
+  // WebID. This is profile-only (no DID-doc fetch) and works for any
+  // user who's added a Nostr VM to their profile — see #386 / #399.
+  const vmWebId = await tryResolveViaCidVerificationMethod(request, event.pubkey);
+  if (vmWebId) {
+    return { webId: vmWebId, error: null };
+  }
+
+  // Second lookup: existing did:nostr DID-document resolver. Fetches
+  // an external DID doc (e.g. nostr.social/.well-known/...) and checks
+  // bidirectional alsoKnownAs ↔ WebID linking.
   const resolvedWebId = await resolveDidNostrToWebId(event.pubkey);
   if (resolvedWebId) {
     return { webId: resolvedWebId, error: null };
@@ -241,6 +257,188 @@ export async function verifyNostrAuth(request) {
   const didNostr = pubkeyToDidNostr(event.pubkey);
 
   return { webId: didNostr, error: null };
+}
+
+/**
+ * Attempt to upgrade a verified Nostr pubkey to a WebID by looking it
+ * up in the resource owner's CID document (= WebID profile).
+ *
+ * Returns the WebID if:
+ *   - the pod-owner WebID can be derived from the request
+ *   - the profile fetches cleanly (passes SSRF guard, JSON-LD)
+ *   - one of its `verificationMethod` entries carries this pubkey
+ *     (either as f-form Multikey or as a secp256k1 JsonWebKey)
+ *   - that VM is referenced from `authentication`
+ *
+ * Returns null in any other case — the caller falls back to the
+ * existing DID-doc / did:nostr-identity paths.
+ */
+async function tryResolveViaCidVerificationMethod(request, pubkeyHex) {
+  const ownerWebId = getPodOwnerWebId(request);
+  if (!ownerWebId) return null;
+  const docUrl = stripHash(ownerWebId);
+
+  // SSRF guard. The owner WebID is derived from server-side request
+  // data, so it shouldn't be attacker-controllable, but route through
+  // the same guard as the LWS-CID verifier as defense-in-depth.
+  const validation = await validateExternalUrl(docUrl, {
+    requireHttps: process.env.NODE_ENV === 'production',
+    blockPrivateIPs: true,
+    resolveDNS: true,
+  });
+  if (!validation.valid) return null;
+
+  let profile;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5000);
+    const res = await fetch(docUrl, {
+      headers: { Accept: 'application/ld+json' },
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    if (!res.ok) return null;
+    const ct = (res.headers.get('content-type') || '').toLowerCase();
+    if (!ct.includes('json')) return null;
+    profile = await res.json();
+  } catch {
+    return null;
+  }
+  if (!profile || typeof profile !== 'object' || Array.isArray(profile)) return null;
+
+  const vm = findNostrVmInProfile(profile, pubkeyHex, docUrl);
+  if (!vm) return null;
+  if (!isInProofPurpose(profile, 'authentication', vm.id, docUrl)) return null;
+
+  // Use the profile's declared subject as the authenticated identity
+  // (with @id fallback). Absolutize so a relative @id resolves.
+  const subject = profile['@id'] || profile.id;
+  if (!subject) return null;
+  return absolutize(subject, docUrl);
+}
+
+/**
+ * Derive the pod-owner WebID URL from a Fastify request.
+ *
+ * Subdomain mode: the pod's domain IS the request's hostname.
+ * Path mode: the pod's name is the first path segment.
+ * Single-user / unknown: returns null (the caller falls back).
+ */
+function getPodOwnerWebId(request) {
+  const proto = (request.headers?.['x-forwarded-proto'] || '').split(',')[0].trim()
+              || request.protocol
+              || 'https';
+  const host  = (request.headers?.['x-forwarded-host'] || '').split(',')[0].trim()
+              || request.headers?.host
+              || request.hostname;
+  if (!host) return null;
+
+  // Subdomain mode: hostname carries the pod name.
+  if (request.subdomainsEnabled && request.podName) {
+    return `${proto}://${request.podName}.${request.baseDomain}/profile/card.jsonld#me`;
+  }
+
+  // Path mode on the base domain: first path segment is the pod name.
+  if (request.subdomainsEnabled && request.baseDomain && host === request.baseDomain) {
+    const m = (request.url || '').match(/^\/([^/?#]+)/);
+    if (m && !m[1].startsWith('.') && !m[1].includes('.')) {
+      return `${proto}://${m[1]}.${request.baseDomain}/profile/card.jsonld#me`;
+    }
+  }
+
+  // Default: assume the host itself is a single-pod deployment.
+  return `${proto}://${host}/profile/card.jsonld#me`;
+}
+
+/**
+ * Find a verificationMethod whose key material matches the Nostr
+ * x-only pubkey hex. Two encodings supported:
+ *   - f-form Multikey:  publicKeyMultibase = "f" + "e701" + parity + xonly
+ *   - JsonWebKey:       publicKeyJwk.x = base64url(xonly)  (kty:EC, crv:secp256k1)
+ *
+ * Returns the entry (object form) on match, normalized so .id is the
+ * absolute IRI. Returns null on no match.
+ */
+function findNostrVmInProfile(profile, pubkeyHex, baseUrl) {
+  const target = pubkeyHex.toLowerCase();
+  const targetB64u = hexToBase64url(target);
+  const vms = asArray(profile.verificationMethod);
+  for (const vm of vms) {
+    if (!vm || typeof vm !== 'object') continue;
+    const vmId = vm.id || vm['@id'];
+    if (typeof vmId !== 'string') continue;
+
+    if (typeof vm.publicKeyMultibase === 'string') {
+      const xonly = decodeFFormSecp256k1(vm.publicKeyMultibase);
+      if (xonly === target) return { ...vm, id: absolutize(vmId, baseUrl) };
+    }
+    if (vm.publicKeyJwk && typeof vm.publicKeyJwk === 'object') {
+      const jwk = vm.publicKeyJwk;
+      if (jwk.kty === 'EC' && (jwk.crv === 'secp256k1' || jwk.crv === 'P-256K')) {
+        if (typeof jwk.x === 'string' && jwk.x === targetB64u) {
+          return { ...vm, id: absolutize(vmId, baseUrl) };
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Decode an f-form Multikey for secp256k1-pub back into the 32-byte
+ * x-only pubkey hex. Returns null if the input isn't this shape.
+ */
+function decodeFFormSecp256k1(mb) {
+  if (typeof mb !== 'string' || !mb.startsWith('f')) return null;
+  const hex = mb.slice(1).toLowerCase();
+  if (!/^[0-9a-f]+$/.test(hex)) return null;
+  if (!hex.startsWith(MULTICODEC_SECP256K1_PUB_HEX)) return null;
+  const rest = hex.slice(MULTICODEC_SECP256K1_PUB_HEX.length);
+  // Expect parity byte (02/03) + 32-byte xonly = 66 hex chars.
+  if (rest.length !== 66) return null;
+  const parity = rest.slice(0, 2);
+  if (parity !== '02' && parity !== '03') return null;
+  return rest.slice(2);
+}
+
+function hexToBase64url(hex) {
+  return Buffer.from(hex, 'hex').toString('base64')
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function isInProofPurpose(profile, predicate, vmId, baseUrl) {
+  const entries = asArray(profile[predicate]);
+  if (entries.length === 0) return false;
+  for (const ent of entries) {
+    if (typeof ent === 'string') {
+      if (absolutize(ent, baseUrl) === vmId) return true;
+    } else if (ent && typeof ent === 'object') {
+      const id = ent['@id'] ?? ent.id;
+      if (id && absolutize(id, baseUrl) === vmId) return true;
+    }
+  }
+  return false;
+}
+
+function asArray(v) {
+  if (v === undefined || v === null) return [];
+  return Array.isArray(v) ? v : [v];
+}
+
+function absolutize(u, base) {
+  if (!u) return u;
+  try { return new URL(u, base).toString(); } catch { return u; }
+}
+
+function stripHash(u) {
+  if (typeof u !== 'string') return u;
+  try {
+    const url = new URL(u);
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return u.split('#')[0];
+  }
 }
 
 /**

--- a/src/auth/nostr.js
+++ b/src/auth/nostr.js
@@ -319,8 +319,10 @@ async function tryResolveViaCidVerificationMethod(request, pubkeyHex) {
  * JSS supports four pod-addressing modes (see src/idp/interactions.js
  * around the createPod path for the canonical list):
  *
- *   - **Single-user mode** — `request.singleUser` is true. There's
- *     one pod at the host root: WebID is `https://host/profile/card.jsonld#me`.
+ *   - **Single-user mode** — `request.singleUser` is true. The pod
+ *     either lives at the host root (WebID
+ *     `https://host/profile/card.jsonld#me`) or, when
+ *     `request.singleUserName` is set, at `/<name>/profile/card.jsonld#me`.
  *   - **Subdomain mode** — `subdomainsEnabled` is true, request hits a
  *     subdomain like `alice.example.com`. WebID is at the subdomain
  *     root: `https://alice.example.com/profile/card.jsonld#me`.
@@ -367,9 +369,13 @@ function getPodOwnerWebId(request) {
     hostNoPort = hostNoPort.slice(1, -1);
   }
 
-  // Single-user deployment: one pod at the host root.
+  // Single-user deployment. The pod is either at the host root or
+  // mounted under `/<singleUserName>/`; both shapes are supported.
   if (request.singleUser) {
-    return `${proto}://${hostRaw}/profile/card.jsonld#me`;
+    const name = request.singleUserName;
+    return name
+      ? `${proto}://${hostRaw}/${name}/profile/card.jsonld#me`
+      : `${proto}://${hostRaw}/profile/card.jsonld#me`;
   }
 
   // Subdomain mode (request already on a pod's subdomain).

--- a/test/nostr-cid-vm.test.js
+++ b/test/nostr-cid-vm.test.js
@@ -183,6 +183,27 @@ describe('NIP-98 + CID verificationMethod lookup (#399)', () => {
     assert.strictEqual(r.webId, WEBID);
   });
 
+  it("rejects when CID document's subject differs from computed owner WebID", async () => {
+    // Profile sits at the expected docUrl but declares a DIFFERENT
+    // @id. Without the subject check, this would let an attacker
+    // host a card.jsonld whose @id is "...#bob" + a Nostr VM under
+    // bob's name, and trick us into authenticating as bob when the
+    // request URL says alice.
+    nextProfile = {
+      ...buildProfile({ pubkey: pk }),
+      '@id': `${DOC_URL}#bob`,
+      controller: `${DOC_URL}#bob`,
+    };
+    const url = `https://${POD_HOST}/private/data.ttl`;
+    const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    const req = makeRequest({ url });
+    req.headers.authorization = authHeader;
+
+    const r = await verifyNostrAuth(req);
+    // Falls back to did:nostr — VM lookup refused due to subject mismatch.
+    assert.strictEqual(r.webId, `did:nostr:${pk}`);
+  });
+
   it('rejects a JWK with the right x but wrong y (curve-point integrity)', async () => {
     const goodJwk = evenYJwk(pk);
     // Flip the y to invalid — same x, different y → not on canonical

--- a/test/nostr-cid-vm.test.js
+++ b/test/nostr-cid-vm.test.js
@@ -1,0 +1,206 @@
+/**
+ * NIP-98 → WebID via verificationMethod lookup (#399)
+ *
+ * Covers `verifyNostrAuth`'s new tryResolveViaCidVerificationMethod
+ * step: when a Nostr-signed request hits a pod whose owner's WebID
+ * profile declares the request's signing pubkey as a CID-v1
+ * verificationMethod (in `authentication`), authenticate as the
+ * WebID rather than as `did:nostr:<pubkey>`.
+ *
+ * Stubs global.fetch so we hand-craft the profile document. Real
+ * Schnorr signatures are produced via the in-tree nostr/event
+ * primitives.
+ */
+
+import { describe, it, before, beforeEach, after } from 'node:test';
+import assert from 'node:assert';
+import { generateSecretKey, getPublicKey, finalizeEvent } from '../src/nostr/event.js';
+import { verifyNostrAuth } from '../src/auth/nostr.js';
+
+// --- helpers ---------------------------------------------------------
+
+function nip98Authorization({ method, url, secretKey, createdAt }) {
+  const event = finalizeEvent({
+    kind: 27235,
+    created_at: createdAt ?? Math.floor(Date.now() / 1000),
+    tags: [['u', url], ['method', method.toUpperCase()]],
+    content: '',
+  }, secretKey);
+  const token = Buffer.from(JSON.stringify(event)).toString('base64');
+  return { authHeader: `Nostr ${token}`, event };
+}
+
+function makeRequest({ method = 'GET', url, host = 'alice.example.com', extra = {} } = {}) {
+  const fullUrl = url ?? `https://${host}/private/data.ttl`;
+  const path = new URL(fullUrl).pathname;
+  return {
+    method,
+    url: path,
+    protocol: 'https',
+    hostname: host,
+    headers: { authorization: '', host, ...extra.headers },
+    subdomainsEnabled: true,
+    baseDomain: 'example.com',
+    podName: host.split('.')[0] === 'example' ? null : host.split('.')[0],
+  };
+}
+
+// f-form Multikey for the CCG-compromise Nostr recipe:
+// "f" + "e701" + parity (default 02) + 32-byte xonly hex.
+function nostrPubkeyToFformMultikey(pubHex, parity = '02') {
+  return `f` + 'e701' + parity + pubHex.toLowerCase();
+}
+
+// --- profile fixtures ------------------------------------------------
+
+const POD_HOST = 'alice.example.com';
+const WEBID = `https://${POD_HOST}/profile/card.jsonld#me`;
+const DOC_URL = `https://${POD_HOST}/profile/card.jsonld`;
+
+function buildProfile({ pubkey, vmId = `${DOC_URL}#nostr-key-1`, withAuth = true, jwk = null } = {}) {
+  const vm = jwk
+    ? { id: vmId, type: 'JsonWebKey', controller: WEBID, publicKeyJwk: jwk }
+    : { id: vmId, type: 'Multikey',  controller: WEBID,
+        publicKeyMultibase: nostrPubkeyToFformMultikey(pubkey) };
+  return {
+    '@context': {
+      cid: 'https://www.w3.org/ns/cid/v1#',
+      controller: { '@id': 'cid:controller', '@type': '@id' },
+      verificationMethod: { '@id': 'cid:verificationMethod', '@container': '@set' },
+      authentication: { '@id': 'cid:authentication', '@type': '@id', '@container': '@set' },
+      publicKeyMultibase: { '@id': 'cid:publicKeyMultibase' },
+      publicKeyJwk: { '@id': 'cid:publicKeyJwk', '@type': '@json' },
+    },
+    '@id': WEBID,
+    controller: WEBID,
+    verificationMethod: [vm],
+    ...(withAuth ? { authentication: [vmId] } : {}),
+  };
+}
+
+// --- fetch stub ------------------------------------------------------
+
+const realFetch = global.fetch;
+let nextProfile = null;
+let nextStatus = 200;
+
+function installFetchStub() {
+  global.fetch = async (url) => {
+    if (String(url) === DOC_URL) {
+      return new Response(JSON.stringify(nextProfile), {
+        status: nextStatus,
+        headers: { 'content-type': 'application/ld+json' },
+      });
+    }
+    // Anything else (the did-nostr.js DID-doc resolver fallback) — 404
+    // so the secondary lookup short-circuits.
+    return new Response('not found', { status: 404 });
+  };
+}
+function restoreFetch() { global.fetch = realFetch; }
+
+// --- tests -----------------------------------------------------------
+
+describe('NIP-98 + CID verificationMethod lookup (#399)', () => {
+  let sk, pk;
+
+  before(() => {
+    installFetchStub();
+  });
+  after(() => {
+    restoreFetch();
+  });
+
+  beforeEach(() => {
+    sk = generateSecretKey();
+    pk = getPublicKey(sk);
+    nextStatus = 200;
+    nextProfile = buildProfile({ pubkey: pk });
+  });
+
+  it('upgrades did:nostr → WebID when the pubkey is in the profile as f-form Multikey VM', async () => {
+    const url = `https://${POD_HOST}/private/data.ttl`;
+    const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    const req = makeRequest({ url });
+    req.headers.authorization = authHeader;
+
+    const r = await verifyNostrAuth(req);
+    assert.strictEqual(r.error, null);
+    assert.strictEqual(r.webId, WEBID);
+  });
+
+  it('upgrades did:nostr → WebID when the pubkey is in the profile as JsonWebKey VM', async () => {
+    // x-coord is the hex pubkey base64url-encoded.
+    const x = Buffer.from(pk, 'hex').toString('base64')
+      .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    nextProfile = buildProfile({
+      pubkey: pk,
+      jwk: { kty: 'EC', crv: 'secp256k1', alg: 'ES256K', x, y: 'irrelevant-for-this-match' },
+    });
+    const url = `https://${POD_HOST}/private/data.ttl`;
+    const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    const req = makeRequest({ url });
+    req.headers.authorization = authHeader;
+
+    const r = await verifyNostrAuth(req);
+    assert.strictEqual(r.error, null);
+    assert.strictEqual(r.webId, WEBID);
+  });
+
+  it('falls back to did:nostr when the profile has no matching VM', async () => {
+    const otherSk = generateSecretKey();
+    const otherPk = getPublicKey(otherSk);
+    nextProfile = buildProfile({ pubkey: otherPk }); // VM has a different key
+
+    const url = `https://${POD_HOST}/private/data.ttl`;
+    const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    const req = makeRequest({ url });
+    req.headers.authorization = authHeader;
+
+    const r = await verifyNostrAuth(req);
+    assert.strictEqual(r.error, null);
+    assert.strictEqual(r.webId, `did:nostr:${pk}`);
+  });
+
+  it('falls back to did:nostr when the matching VM is NOT in authentication', async () => {
+    nextProfile = buildProfile({ pubkey: pk, withAuth: false });
+
+    const url = `https://${POD_HOST}/private/data.ttl`;
+    const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    const req = makeRequest({ url });
+    req.headers.authorization = authHeader;
+
+    const r = await verifyNostrAuth(req);
+    assert.strictEqual(r.error, null);
+    assert.strictEqual(r.webId, `did:nostr:${pk}`);
+  });
+
+  it('falls back to did:nostr when the profile fetch fails', async () => {
+    nextStatus = 404;
+    nextProfile = null;
+
+    const url = `https://${POD_HOST}/private/data.ttl`;
+    const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    const req = makeRequest({ url });
+    req.headers.authorization = authHeader;
+
+    const r = await verifyNostrAuth(req);
+    assert.strictEqual(r.error, null);
+    assert.strictEqual(r.webId, `did:nostr:${pk}`);
+  });
+
+  it('still rejects an invalid signature regardless of the profile', async () => {
+    const url = `https://${POD_HOST}/private/data.ttl`;
+    const { authHeader, event } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    // Tamper: re-encode the event with a flipped signature byte.
+    const decoded = JSON.parse(Buffer.from(authHeader.slice(6), 'base64').toString());
+    decoded.sig = decoded.sig.slice(0, -2) + (decoded.sig.endsWith('00') ? 'ff' : '00');
+    const tampered = `Nostr ${Buffer.from(JSON.stringify(decoded)).toString('base64')}`;
+    const req = makeRequest({ url });
+    req.headers.authorization = tampered;
+
+    const r = await verifyNostrAuth(req);
+    assert.strictEqual(r.webId, null);
+    assert.match(r.error, /signature/);
+  });
+});

--- a/test/nostr-cid-vm.test.js
+++ b/test/nostr-cid-vm.test.js
@@ -449,6 +449,21 @@ describe('NIP-98 + CID verificationMethod lookup (#399)', () => {
     assert.strictEqual(r.webId, `did:nostr:${pk}`);
   });
 
+  it('lowercases x-forwarded-proto so HTTPS still matches profile @id', async () => {
+    // Some proxies send `X-Forwarded-Proto: HTTPS` (uppercase). The
+    // computed WebID must use the lowercase form so the subject-identity
+    // check still matches a profile @id that uses lowercase `https://`.
+    const url = `https://${POD_HOST}/private/data.ttl`;
+    const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    const req = makeRequest({ url });
+    req.headers.authorization = authHeader;
+    req.headers['x-forwarded-proto'] = 'HTTPS';
+
+    const r = await verifyNostrAuth(req);
+    assert.strictEqual(r.error, null);
+    assert.strictEqual(r.webId, WEBID);
+  });
+
   it('handles array-valued forwarded headers without throwing', async () => {
     // Fastify can yield x-forwarded-* as an array when duplicated.
     const url = `https://${POD_HOST}/private/data.ttl`;

--- a/test/nostr-cid-vm.test.js
+++ b/test/nostr-cid-vm.test.js
@@ -217,6 +217,65 @@ describe('NIP-98 + CID verificationMethod lookup (#399)', () => {
     assert.strictEqual(r.webId, `did:nostr:${pk}`);
   });
 
+  it('upgrades did:nostr → WebID in single-user mode', async () => {
+    // Single-user: one pod at the host root, WebID at /profile/card.jsonld#me.
+    const SINGLE_HOST = 'pod.example.com';
+    const SINGLE_DOC = `https://${SINGLE_HOST}/profile/card.jsonld`;
+    const SINGLE_WEBID = `${SINGLE_DOC}#me`;
+    urlResponses.set(SINGLE_DOC, {
+      status: 200,
+      headers: { 'content-type': 'application/ld+json' },
+      body: JSON.stringify(buildProfile({
+        pubkey: pk,
+        vmId: `${SINGLE_DOC}#nostr-key-1`,
+        webId: SINGLE_WEBID,
+      })),
+    });
+    const url = `https://${SINGLE_HOST}/private/data.ttl`;
+    const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    const req = makeRequest({ url, host: SINGLE_HOST, mode: 'path' });
+    req.singleUser = true;
+    req.subdomainsEnabled = false;
+    req.headers.authorization = authHeader;
+
+    const r = await verifyNostrAuth(req);
+    assert.strictEqual(r.error, null);
+    assert.strictEqual(r.webId, SINGLE_WEBID);
+  });
+
+  it('handles host:port without breaking baseDomain match', async () => {
+    // Subdomain-enabled deployment, request landed on base domain
+    // with a port. The base-domain comparison must work when the
+    // host carries a port — without port stripping, hostNoPort !==
+    // baseDomain and the path-mode-on-base branch never matches.
+    const PORT_HOST = 'example.com:8080';
+    const SUB_HOST = 'alice.example.com';
+    const SUB_DOC = `https://${SUB_HOST}/profile/card.jsonld`;
+    const SUB_WEBID = `${SUB_DOC}#me`;
+    urlResponses.set(SUB_DOC, {
+      status: 200,
+      headers: { 'content-type': 'application/ld+json' },
+      body: JSON.stringify(buildProfile({
+        pubkey: pk,
+        vmId: `${SUB_DOC}#nostr-key-1`,
+        webId: SUB_WEBID,
+      })),
+    });
+    // Sign with the same host:port the request will carry, so the
+    // existing NIP-98 URL-match check passes — this test is about the
+    // base-domain comparison in WebID derivation, not URL matching.
+    const url = `https://${PORT_HOST}/alice/private/data.ttl`;
+    const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    const req = makeRequest({ url, host: PORT_HOST, mode: 'subdomain' });
+    // Hit the base domain (no podName).
+    req.podName = null;
+    req.headers.authorization = authHeader;
+
+    const r = await verifyNostrAuth(req);
+    assert.strictEqual(r.error, null);
+    assert.strictEqual(r.webId, SUB_WEBID);
+  });
+
   it('upgrades did:nostr → WebID in path mode (subdomains disabled, JSS default)', async () => {
     // JSS's default deployment shape: pod is the first URL segment
     // and the WebID lives under that path.
@@ -285,7 +344,7 @@ describe('NIP-98 + CID verificationMethod lookup (#399)', () => {
 
   it('still rejects an invalid signature regardless of the profile', async () => {
     const url = `https://${POD_HOST}/private/data.ttl`;
-    const { authHeader, event } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
     // Tamper: re-encode the event with a flipped signature byte.
     const decoded = JSON.parse(Buffer.from(authHeader.slice(6), 'base64').toString());
     decoded.sig = decoded.sig.slice(0, -2) + (decoded.sig.endsWith('00') ? 'ff' : '00');

--- a/test/nostr-cid-vm.test.js
+++ b/test/nostr-cid-vm.test.js
@@ -449,6 +449,20 @@ describe('NIP-98 + CID verificationMethod lookup (#399)', () => {
     assert.strictEqual(r.webId, `did:nostr:${pk}`);
   });
 
+  it('rejects malformed Host header (URL-injection defense)', async () => {
+    // Host carries `@` which would steer the computed owner WebID at
+    // attacker.com if we naively passed it through new URL().
+    const url = `https://${POD_HOST}/private/data.ttl`;
+    const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    const req = makeRequest({ url });
+    req.headers.authorization = authHeader;
+    req.headers.host = `${POD_HOST}@attacker.example`;
+
+    const r = await verifyNostrAuth(req);
+    // The URL match runs first and rejects on the malformed host.
+    assert.match(r.error, /invalid characters/);
+  });
+
   it('lowercases x-forwarded-proto so HTTPS still matches profile @id', async () => {
     // Some proxies send `X-Forwarded-Proto: HTTPS` (uppercase). The
     // computed WebID must use the lowercase form so the subject-identity

--- a/test/nostr-cid-vm.test.js
+++ b/test/nostr-cid-vm.test.js
@@ -291,6 +291,34 @@ describe('NIP-98 + CID verificationMethod lookup (#399)', () => {
     assert.strictEqual(r.webId, SINGLE_WEBID);
   });
 
+  it('upgrades did:nostr → WebID in single-user mode with a named pod', async () => {
+    // singleUser=true + singleUserName='alice' mounts the pod at
+    // /alice/, with WebID at /alice/profile/card.jsonld#me.
+    const NAMED_HOST = 'pod.example.com';
+    const NAMED_DOC = `https://${NAMED_HOST}/alice/profile/card.jsonld`;
+    const NAMED_WEBID = `${NAMED_DOC}#me`;
+    urlResponses.set(NAMED_DOC, {
+      status: 200,
+      headers: { 'content-type': 'application/ld+json' },
+      body: JSON.stringify(buildProfile({
+        pubkey: pk,
+        vmId: `${NAMED_DOC}#nostr-key-1`,
+        webId: NAMED_WEBID,
+      })),
+    });
+    const url = `https://${NAMED_HOST}/alice/private/data.ttl`;
+    const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    const req = makeRequest({ url, host: NAMED_HOST, mode: 'path' });
+    req.singleUser = true;
+    req.singleUserName = 'alice';
+    req.subdomainsEnabled = false;
+    req.headers.authorization = authHeader;
+
+    const r = await verifyNostrAuth(req);
+    assert.strictEqual(r.error, null);
+    assert.strictEqual(r.webId, NAMED_WEBID);
+  });
+
   it('handles IPv6 literal host without crashing the host parser', async () => {
     // host.split(':')[0] would mangle '[::1]:3000' to '['. Make sure
     // the URL-aware parser gives a usable hostname.

--- a/test/nostr-cid-vm.test.js
+++ b/test/nostr-cid-vm.test.js
@@ -374,6 +374,29 @@ describe('NIP-98 + CID verificationMethod lookup (#399)', () => {
     assert.strictEqual(r.webId, SUB_WEBID);
   });
 
+  it('upgrades did:nostr → WebID in path mode even when host carries a port', async () => {
+    // Reverse proxies forward Host with port (e.g. example.com:8080).
+    // The computed ownerWebId must match what JSS stores at pod
+    // creation, which uses request.hostname (port-stripped). Otherwise
+    // the subject-identity check would reject valid requests.
+    pathProfile = buildProfile({
+      pubkey: pk,
+      vmId: `${PATH_DOC_URL}#nostr-key-1`,
+      webId: PATH_WEBID,
+    });
+    // Sign with the port-included URL so the existing NIP-98 URL-match
+    // check passes — this test is about WebID derivation, not URL matching.
+    const PORT_HOST = `${PATH_HOST}:8080`;
+    const url = `https://${PORT_HOST}/${PATH_PODNAME}/private/data.ttl`;
+    const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    const req = makeRequest({ url, host: PORT_HOST, mode: 'path' });
+    req.headers.authorization = authHeader;
+
+    const r = await verifyNostrAuth(req);
+    assert.strictEqual(r.error, null);
+    assert.strictEqual(r.webId, PATH_WEBID); // canonical, port-stripped
+  });
+
   it('upgrades did:nostr → WebID in path mode (subdomains disabled, JSS default)', async () => {
     // JSS's default deployment shape: pod is the first URL segment
     // and the WebID lives under that path.

--- a/test/nostr-cid-vm.test.js
+++ b/test/nostr-cid-vm.test.js
@@ -14,8 +14,20 @@
 
 import { describe, it, before, beforeEach, after } from 'node:test';
 import assert from 'node:assert';
+import { secp256k1 } from '@noble/curves/secp256k1';
 import { generateSecretKey, getPublicKey, finalizeEvent } from '../src/nostr/event.js';
 import { verifyNostrAuth } from '../src/auth/nostr.js';
+
+/** Compute the BIP-340 even-y JWK coordinates for an x-only Nostr pubkey. */
+function evenYJwk(xOnlyHex) {
+  const point = secp256k1.ProjectivePoint.fromHex('02' + xOnlyHex);
+  const aff = point.toAffine();
+  const xHex = aff.x.toString(16).padStart(64, '0');
+  const yHex = aff.y.toString(16).padStart(64, '0');
+  const b64u = (hex) => Buffer.from(hex, 'hex').toString('base64')
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return { kty: 'EC', crv: 'secp256k1', alg: 'ES256K', x: b64u(xHex), y: b64u(yHex) };
+}
 
 // --- helpers ---------------------------------------------------------
 
@@ -158,13 +170,9 @@ describe('NIP-98 + CID verificationMethod lookup (#399)', () => {
   });
 
   it('upgrades did:nostr → WebID when the pubkey is in the profile as JsonWebKey VM', async () => {
-    // x-coord is the hex pubkey base64url-encoded.
-    const x = Buffer.from(pk, 'hex').toString('base64')
-      .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-    nextProfile = buildProfile({
-      pubkey: pk,
-      jwk: { kty: 'EC', crv: 'secp256k1', alg: 'ES256K', x, y: 'irrelevant-for-this-match' },
-    });
+    // Construct a real even-y JWK so the verifier's full-point match
+    // succeeds (matching by x alone would be unsafe — see #400 pass 3).
+    nextProfile = buildProfile({ pubkey: pk, jwk: evenYJwk(pk) });
     const url = `https://${POD_HOST}/private/data.ttl`;
     const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
     const req = makeRequest({ url });
@@ -173,6 +181,21 @@ describe('NIP-98 + CID verificationMethod lookup (#399)', () => {
     const r = await verifyNostrAuth(req);
     assert.strictEqual(r.error, null);
     assert.strictEqual(r.webId, WEBID);
+  });
+
+  it('rejects a JWK with the right x but wrong y (curve-point integrity)', async () => {
+    const goodJwk = evenYJwk(pk);
+    // Flip the y to invalid — same x, different y → not on canonical
+    // BIP-340 point, so should NOT match the Nostr key.
+    const badJwk = { ...goodJwk, y: goodJwk.y.slice(0, -1) + (goodJwk.y.endsWith('A') ? 'B' : 'A') };
+    nextProfile = buildProfile({ pubkey: pk, jwk: badJwk });
+    const url = `https://${POD_HOST}/private/data.ttl`;
+    const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    const req = makeRequest({ url });
+    req.headers.authorization = authHeader;
+
+    const r = await verifyNostrAuth(req);
+    assert.strictEqual(r.webId, `did:nostr:${pk}`); // fell through to did:nostr
   });
 
   it('falls back to did:nostr when the profile has no matching VM', async () => {
@@ -241,6 +264,28 @@ describe('NIP-98 + CID verificationMethod lookup (#399)', () => {
     const r = await verifyNostrAuth(req);
     assert.strictEqual(r.error, null);
     assert.strictEqual(r.webId, SINGLE_WEBID);
+  });
+
+  it('handles IPv6 literal host without crashing the host parser', async () => {
+    // host.split(':')[0] would mangle '[::1]:3000' to '['. Make sure
+    // the URL-aware parser gives a usable hostname.
+    const url = `https://${POD_HOST}/private/data.ttl`;
+    const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    const req = makeRequest({ url });
+    req.headers.authorization = authHeader;
+    // Inject an IPv6 forwarded host with port. This shouldn't match
+    // any of our deployment-shape branches (it's neither baseDomain
+    // nor a pod-shaped URL), so we expect did:nostr fallback — the
+    // important thing is we don't crash on the parse.
+    req.headers['x-forwarded-host'] = '[2001:db8::1]:8443';
+    // Force path-mode so the URL pod-segment branch runs.
+    req.subdomainsEnabled = false;
+
+    const r = await verifyNostrAuth(req);
+    // Either path-segment match (alice's pod) or did:nostr fallback
+    // is acceptable; the goal is "no crash on IPv6 parsing".
+    assert.ok(r.webId === WEBID || r.webId === `did:nostr:${pk}`,
+      `unexpected webId ${r.webId}`);
   });
 
   it('handles host:port without breaking baseDomain match', async () => {

--- a/test/nostr-cid-vm.test.js
+++ b/test/nostr-cid-vm.test.js
@@ -30,19 +30,26 @@ function nip98Authorization({ method, url, secretKey, createdAt }) {
   return { authHeader: `Nostr ${token}`, event };
 }
 
-function makeRequest({ method = 'GET', url, host = 'alice.example.com', extra = {} } = {}) {
+function makeRequest({ method = 'GET', url, host = 'alice.example.com', mode = 'subdomain', extra = {} } = {}) {
   const fullUrl = url ?? `https://${host}/private/data.ttl`;
   const path = new URL(fullUrl).pathname;
-  return {
+  const base = {
     method,
     url: path,
     protocol: 'https',
     hostname: host,
     headers: { authorization: '', host, ...extra.headers },
-    subdomainsEnabled: true,
-    baseDomain: 'example.com',
-    podName: host.split('.')[0] === 'example' ? null : host.split('.')[0],
   };
+  if (mode === 'subdomain') {
+    return {
+      ...base,
+      subdomainsEnabled: true,
+      baseDomain: 'example.com',
+      podName: host.split('.')[0] === 'example' ? null : host.split('.')[0],
+    };
+  }
+  // Path mode (JSS default): no subdomains, pod is first URL segment.
+  return { ...base, subdomainsEnabled: false };
 }
 
 // f-form Multikey for the CCG-compromise Nostr recipe:
@@ -57,10 +64,16 @@ const POD_HOST = 'alice.example.com';
 const WEBID = `https://${POD_HOST}/profile/card.jsonld#me`;
 const DOC_URL = `https://${POD_HOST}/profile/card.jsonld`;
 
-function buildProfile({ pubkey, vmId = `${DOC_URL}#nostr-key-1`, withAuth = true, jwk = null } = {}) {
+// Path-mode equivalents (JSS's default deployment shape).
+const PATH_HOST = 'example.com';
+const PATH_PODNAME = 'alice';
+const PATH_WEBID = `https://${PATH_HOST}/${PATH_PODNAME}/profile/card.jsonld#me`;
+const PATH_DOC_URL = `https://${PATH_HOST}/${PATH_PODNAME}/profile/card.jsonld`;
+
+function buildProfile({ pubkey, vmId = `${DOC_URL}#nostr-key-1`, withAuth = true, jwk = null, webId = WEBID } = {}) {
   const vm = jwk
-    ? { id: vmId, type: 'JsonWebKey', controller: WEBID, publicKeyJwk: jwk }
-    : { id: vmId, type: 'Multikey',  controller: WEBID,
+    ? { id: vmId, type: 'JsonWebKey', controller: webId, publicKeyJwk: jwk }
+    : { id: vmId, type: 'Multikey',  controller: webId,
         publicKeyMultibase: nostrPubkeyToFformMultikey(pubkey) };
   return {
     '@context': {
@@ -71,8 +84,8 @@ function buildProfile({ pubkey, vmId = `${DOC_URL}#nostr-key-1`, withAuth = true
       publicKeyMultibase: { '@id': 'cid:publicKeyMultibase' },
       publicKeyJwk: { '@id': 'cid:publicKeyJwk', '@type': '@json' },
     },
-    '@id': WEBID,
-    controller: WEBID,
+    '@id': webId,
+    controller: webId,
     verificationMethod: [vm],
     ...(withAuth ? { authentication: [vmId] } : {}),
   };
@@ -83,12 +96,25 @@ function buildProfile({ pubkey, vmId = `${DOC_URL}#nostr-key-1`, withAuth = true
 const realFetch = global.fetch;
 let nextProfile = null;
 let nextStatus = 200;
+let urlResponses = new Map();
+let pathProfile = null;
 
 function installFetchStub() {
   global.fetch = async (url) => {
-    if (String(url) === DOC_URL) {
+    const u = String(url);
+    if (urlResponses.has(u)) {
+      const { status = 200, headers = {}, body = '' } = urlResponses.get(u);
+      return new Response(body, { status, headers });
+    }
+    if (u === DOC_URL) {
       return new Response(JSON.stringify(nextProfile), {
         status: nextStatus,
+        headers: { 'content-type': 'application/ld+json' },
+      });
+    }
+    if (u === PATH_DOC_URL) {
+      return new Response(JSON.stringify(pathProfile), {
+        status: pathProfile ? 200 : 404,
         headers: { 'content-type': 'application/ld+json' },
       });
     }
@@ -116,6 +142,8 @@ describe('NIP-98 + CID verificationMethod lookup (#399)', () => {
     pk = getPublicKey(sk);
     nextStatus = 200;
     nextProfile = buildProfile({ pubkey: pk });
+    pathProfile = null;
+    urlResponses = new Map();
   });
 
   it('upgrades did:nostr → WebID when the pubkey is in the profile as f-form Multikey VM', async () => {
@@ -187,6 +215,72 @@ describe('NIP-98 + CID verificationMethod lookup (#399)', () => {
     const r = await verifyNostrAuth(req);
     assert.strictEqual(r.error, null);
     assert.strictEqual(r.webId, `did:nostr:${pk}`);
+  });
+
+  it('upgrades did:nostr → WebID in path mode (subdomains disabled, JSS default)', async () => {
+    // JSS's default deployment shape: pod is the first URL segment
+    // and the WebID lives under that path.
+    pathProfile = buildProfile({
+      pubkey: pk,
+      vmId: `${PATH_DOC_URL}#nostr-key-1`,
+      webId: PATH_WEBID,
+    });
+    const url = `https://${PATH_HOST}/${PATH_PODNAME}/private/data.ttl`;
+    const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    const req = makeRequest({ url, host: PATH_HOST, mode: 'path' });
+    req.headers.authorization = authHeader;
+
+    const r = await verifyNostrAuth(req);
+    assert.strictEqual(r.error, null);
+    assert.strictEqual(r.webId, PATH_WEBID);
+  });
+
+  it('refuses cross-origin redirect during profile fetch (falls back to did:nostr)', async () => {
+    // Pod-owner profile URL 302s to an attacker-controlled host. The
+    // redirect must be refused regardless of where it points; the VM
+    // lookup gets nothing and we fall through to did:nostr.
+    urlResponses.set(DOC_URL, {
+      status: 302,
+      headers: { location: 'https://attacker.example/profile/card.jsonld' },
+    });
+    const url = `https://${POD_HOST}/private/data.ttl`;
+    const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    const req = makeRequest({ url });
+    req.headers.authorization = authHeader;
+
+    const r = await verifyNostrAuth(req);
+    assert.strictEqual(r.error, null);
+    assert.strictEqual(r.webId, `did:nostr:${pk}`);
+  });
+
+  it('refuses oversized profile bodies (falls back to did:nostr)', async () => {
+    const huge = 'x'.repeat(300 * 1024);
+    urlResponses.set(DOC_URL, {
+      status: 200,
+      headers: { 'content-type': 'application/ld+json' },
+      body: JSON.stringify({ junk: huge }),
+    });
+    const url = `https://${POD_HOST}/private/data.ttl`;
+    const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    const req = makeRequest({ url });
+    req.headers.authorization = authHeader;
+
+    const r = await verifyNostrAuth(req);
+    assert.strictEqual(r.webId, `did:nostr:${pk}`);
+  });
+
+  it('handles array-valued forwarded headers without throwing', async () => {
+    // Fastify can yield x-forwarded-* as an array when duplicated.
+    const url = `https://${POD_HOST}/private/data.ttl`;
+    const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
+    const req = makeRequest({ url });
+    req.headers.authorization = authHeader;
+    req.headers['x-forwarded-proto'] = ['https', 'http'];
+    req.headers['x-forwarded-host'] = [POD_HOST, 'internal.lan'];
+
+    const r = await verifyNostrAuth(req);
+    assert.strictEqual(r.error, null);
+    assert.strictEqual(r.webId, WEBID);
   });
 
   it('still rejects an invalid signature regardless of the profile', async () => {

--- a/test/nostr-cid-vm.test.js
+++ b/test/nostr-cid-vm.test.js
@@ -17,6 +17,7 @@ import assert from 'node:assert';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { generateSecretKey, getPublicKey, finalizeEvent } from '../src/nostr/event.js';
 import { verifyNostrAuth } from '../src/auth/nostr.js';
+import { _clearProfileCacheForTests } from '../src/auth/cid-doc-fetch.js';
 
 /** Compute the BIP-340 even-y JWK coordinates for an x-only Nostr pubkey. */
 function evenYJwk(xOnlyHex) {
@@ -156,6 +157,9 @@ describe('NIP-98 + CID verificationMethod lookup (#399)', () => {
     nextProfile = buildProfile({ pubkey: pk });
     pathProfile = null;
     urlResponses = new Map();
+    // Cache lives in cid-doc-fetch.js now and is shared with lws-cid.js;
+    // must clear so a previous test's profile doesn't satisfy this one.
+    _clearProfileCacheForTests();
   });
 
   it('upgrades did:nostr → WebID when the pubkey is in the profile as f-form Multikey VM', async () => {

--- a/test/nostr-cid-vm.test.js
+++ b/test/nostr-cid-vm.test.js
@@ -320,25 +320,25 @@ describe('NIP-98 + CID verificationMethod lookup (#399)', () => {
   });
 
   it('handles IPv6 literal host without crashing the host parser', async () => {
-    // host.split(':')[0] would mangle '[::1]:3000' to '['. Make sure
-    // the URL-aware parser gives a usable hostname.
-    const url = `https://${POD_HOST}/private/data.ttl`;
+    // host.split(':')[0] would mangle '[::1]:3000' to '['. The
+    // URL-aware parser must give a usable hostname instead of
+    // crashing. Sign with the IPv6 host so the existing NIP-98
+    // URL-match check passes — this test is about getPodOwnerWebId
+    // not crashing, not about URL matching.
+    const v6Host = '[2001:db8::1]:8443';
+    const url = `https://${v6Host}/private/data.ttl`;
     const { authHeader } = nip98Authorization({ method: 'GET', url, secretKey: sk });
-    const req = makeRequest({ url });
+    const req = makeRequest({ url, host: v6Host, mode: 'path' });
     req.headers.authorization = authHeader;
-    // Inject an IPv6 forwarded host with port. This shouldn't match
-    // any of our deployment-shape branches (it's neither baseDomain
-    // nor a pod-shaped URL), so we expect did:nostr fallback — the
-    // important thing is we don't crash on the parse.
-    req.headers['x-forwarded-host'] = '[2001:db8::1]:8443';
-    // Force path-mode so the URL pod-segment branch runs.
     req.subdomainsEnabled = false;
 
     const r = await verifyNostrAuth(req);
-    // Either path-segment match (alice's pod) or did:nostr fallback
-    // is acceptable; the goal is "no crash on IPv6 parsing".
-    assert.ok(r.webId === WEBID || r.webId === `did:nostr:${pk}`,
-      `unexpected webId ${r.webId}`);
+    // No crash. The IPv6 path-mode WebID is malformed (a known
+    // limitation matching JSS pod creation, see in-source comment),
+    // so this falls back to did:nostr — that's the explicit
+    // acceptable outcome.
+    assert.strictEqual(r.error, null);
+    assert.strictEqual(r.webId, `did:nostr:${pk}`);
   });
 
   it('handles host:port without breaking baseDomain match', async () => {


### PR DESCRIPTION
Closes #399. Refs #4 (Phase 2A redirected onto CID), #386 (Phase 4 cross-protocol unification).

## What this changes

A Nostr-signed request whose pubkey is declared in the resource owner's WebID profile (as a CID v1 `verificationMethod` referenced from `authentication`) now authenticates as **the WebID** instead of `did:nostr:<pubkey>`.

That means: if you've used [doctor B.2](https://jss.live/doctor/) to add your Nostr key to your profile, signing a NIP-98 request with that key gives you write access to your own resources via WAC, no extra ACL entries for `did:nostr:` needed.

## Lookup chain in `verifyNostrAuth`

After the existing Schnorr signature verification:

1. **NEW**: VM lookup against the resource's owner WebID profile. Match by f-form Multikey (B.2's output) or by JsonWebKey x-coord (B.3's output). VM must be in `authentication`.
2. Existing did:nostr DID-document resolver (`nostr.social` `.well-known` + bidirectional `alsoKnownAs` check).
3. Fall back to `did:nostr:<pubkey>`.

Each layer falls through cleanly to the next on no-match / fetch-failure, so existing flows are unaffected.

## Pod-owner WebID derivation

Inline (avoids circular import with `middleware.js`):
- Subdomain mode → uses `request.podName` / `baseDomain`
- Path mode on base domain → first URL path segment
- Single-pod deployments → request host

Routed through the same `validateExternalUrl` SSRF guard as the LWS-CID verifier.

## Why this approach

- **Smaller delta than original Phase 2A** (no `owl:sameAs` predicate, no dedicated `/idp/nostr-login` endpoint, no client-side change)
- **Reuses the K→W primitive** the LWS-CID verifier already established — same VM-lookup pattern, different auth method, one mental model
- **Lights up automatically** for any user who's used doctor B.2 (Nostr Multikey) or B.3 (JsonWebKey)
- **No regression** — profiles without a matching VM still authenticate as `did:nostr:`

## Test plan

- [x] Multikey VM match → returns WebID
- [x] JsonWebKey VM match → returns WebID
- [x] No matching key in profile → falls back to `did:nostr:`
- [x] Matching VM but not in `authentication` → falls back to `did:nostr:`
- [x] Profile fetch fails (404) → falls back to `did:nostr:`
- [x] Invalid Schnorr signature → still rejects regardless of profile state
- [x] Full suite: 685 → 691 pass, no regressions
- [ ] Manual smoke test against deployed solid.social pod

## Out of scope (separate work)

- Phase 2B: Nostr-first registration with auto-pod-create (still tracked in #4)
- Phase 3: relay discovery / NIP-97 (still tracked in #4)
- Profile-fetch caching (lws-cid.js has it; could be extracted into a shared helper later)