### PR TITLE
docs/lws.md: flip Phase B + Phase 3 to shipped, add NIP-98 upgrade

### DIFF
--- a/docs/lws.md
+++ b/docs/lws.md
@@ -1,16 +1,17 @@
 # LWS / Controlled Identifiers (CID v1)
 
-JSS pod profiles are aligned with the W3C [Linked Web Storage 1.0 Authentication Suite](https://www.w3.org/news/2026/first-public-working-drafts-for-the-linked-web-storage-lws-1-0-authentication-suite/) (FPWDs published 2026-04-23) and its substrate, [W3C Controlled Identifiers v1.0](https://www.w3.org/TR/cid-1.0/).
+JSS is aligned end-to-end with the W3C [Linked Web Storage 1.0 Authentication Suite](https://www.w3.org/news/2026/first-public-working-drafts-for-the-linked-web-storage-lws-1-0-authentication-suite/) (FPWDs published 2026-04-23) and its substrate, [W3C Controlled Identifiers v1.0](https://www.w3.org/TR/cid-1.0/) — pod profiles are CID-shaped, users add keys via the [doctor](https://jss.live/doctor/), and the server accepts strict LWS10-CID JWTs as an HTTP auth method alongside the existing Solid-OIDC and NIP-98 paths.
 
-The work is phased — see [#386](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/issues/386) for the convergence tracker and [#319](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/issues/319) for the FPWD-alignment audit.
+Convergence tracker: [#386](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/issues/386). FPWD-alignment audit: [#319](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/issues/319).
 
-## Three levels of compatibility
+## Compatibility, by level
 
 | | What it means | Status |
 |---|---|---|
 | **1. Profile shape** | A WebID profile that's structurally a W3C Controlled Identifier document — right `@context`, right vocabulary, parseable as a CID document by any LWS-aware tool | ✅ **Yes** (since v0.0.174, [#388](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/pull/388)) |
-| **2. Profile carries keys** | The CID document actually declares `verificationMethod` entries an LWS verifier can look up by `kid` | ❌ Phase B — a separate "doctor / add-keys" app PATCHes them in after authentication. Out of JSS server scope. |
-| **3. Server accepts LWS-CID JWTs** | An incoming request with an LWS-CID self-signed JWT (`sub`/`iss`/`client_id` triple-equality, `kid` lookup against the WebID's `verificationMethod`, signature check) | ❌ Phase 3 of [#386](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/issues/386) — JSS still only knows OIDC/DPoP, NIP-98, passkey, simple bearer |
+| **2. Profile carries keys** | The CID document actually declares `verificationMethod` entries an LWS verifier can look up by `kid` | ✅ Browser-side via the [doctor](https://jss.live/doctor/) — [B.2](https://github.com/JavaScriptSolidServer/doctor/pull/2) for Nostr/Multikey, [B.3](https://github.com/JavaScriptSolidServer/doctor/pull/4) for ES256K/JsonWebKey. The doctor authenticates as the WebID owner via Solid-OIDC and PATCHes the VM into the profile. |
+| **3. Server accepts LWS-CID JWTs** | An incoming request with an LWS-CID self-signed JWT (`sub`/`iss`/`client_id` triple-equality, `kid` lookup against the WebID's `verificationMethod`, signature check) | ✅ Shipped in v0.0.177 ([#398](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/pull/398)). Strict FPWD §4 — ES256K is the focus algorithm; ES256, ES384, EdDSA, RS256 also accepted. |
+| **Bonus: NIP-98 → WebID** | A Schnorr-signed NIP-98 request authenticates as the WebID (not `did:nostr:`) when the pubkey is declared as a CID `verificationMethod` referenced from `authentication` | ✅ Shipped in v0.0.178 ([#400](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/pull/400)). No client-side change — the doctor's B.2 output is enough to light it up. |
 
 ## What Phase A actually does
 
@@ -37,35 +38,42 @@ A freshly-created pod's `profile/card.jsonld` looks like this (excerpt — the e
 }
 ```
 
-## What Phase B will add
+## Adding keys (Phase B — via the doctor)
 
-A standalone web app (separate repo, no JSS coupling) where the WebID owner authenticates via existing means (OIDC, NIP-98, passkey) and PATCHes their profile with one or more verification methods:
+The [doctor](https://jss.live/doctor/) is a separate browser-side tool that signs in to your pod via Solid-OIDC and writes verificationMethod entries to your profile. After the round-trip your profile has:
 
 ```jsonld
 "verificationMethod": [
-  { "id": "...#nostr-1", "type": "Multikey",   "controller": "...#me",
-    "publicKeyMultibase": "fe70102..." },
-  { "id": "...#did-key-1", "type": "Multikey", "controller": "...#me",
-    "publicKeyMultibase": "z6MkpT..." },
-  { "id": "...#passkey-1", "type": "JsonWebKey", "controller": "...#me",
-    "publicKeyJwk": { "kty": "EC", "crv": "P-256", "x": "...", "y": "..." } }
+  { "id": "...#nostr-key-1", "type": "Multikey",   "controller": "...#me",
+    "publicKeyMultibase": "fe70102…" },
+  { "id": "...#lws-key-1",   "type": "JsonWebKey", "controller": "...#me",
+    "publicKeyJwk": { "kty": "EC", "crv": "secp256k1", "alg": "ES256K", "x": "…", "y": "…" } }
 ],
-"authentication": ["...#nostr-1", "...#did-key-1", "...#passkey-1"]
+"authentication": ["...#nostr-key-1", "...#lws-key-1"]
 ```
+
+The Multikey entry handles did:nostr binding + NIP-98 lookup; the JsonWebKey entry handles strict LWS10-CID JWT auth. Both can be the same secp256k1 key — different signature schemes (Schnorr vs ECDSA), same private key.
 
 Because Phase A already declared the context terms, this is a pure data-layer PATCH — no `@context` rewrite needed.
 
-## What Phase 3 will add (server-side verifier)
+## Server-side verifier (Phase 3 — `src/auth/lws-cid.js`)
 
-When an incoming request carries an LWS-CID JWT, JSS will:
+When an incoming request carries an LWS-CID JWT (detected by an `Authorization: Bearer <jwt>` whose JWT-header `kid` is an http(s) URL with a fragment), JSS:
 
-1. Confirm `sub`/`iss`/`client_id` are the same URI (the caller's WebID)
-2. Dereference the WebID, parse it as a CID document
-3. Look up `kid` in the document's `verificationMethod` array
-4. Confirm the method is in `authentication`
-5. Verify the JWT signature with that public key
+1. Confirms `sub === iss === client_id` (canonicalized via URL parsing) — that URI is the WebID being claimed
+2. Validates `aud` includes the server origin, `exp` not past, `iat` recent, lifetime ≤ 1 hour
+3. Fetches the WebID profile through the shared SSRF guard — manual redirects with same-origin enforcement, 256 KB body cap, bounded LRU cache
+4. Confirms the profile's `@id` equals the JWT's `sub` (closes a profile-substitution attack)
+5. Looks up `kid` in `verificationMethod`; the entry must be referenced from `authentication` and its `controller` must match the profile's outer `controller`
+6. Verifies the JWT signature per RFC7515 §5.2. ES256K via `@noble/curves` (already in tree from NIP-98); ES256, ES384, EdDSA, RS256 via `jose`
 
-The verifier joins the existing auth methods (OIDC, NIP-98, etc.) — preference ordering tracked in [#306](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/issues/306).
+The verifier joins the existing auth methods (Solid-OIDC, NIP-98, Bearer-JWT-from-IDP, WebID-TLS) — preference order is OIDC → LWS-CID → NIP-98 → Bearer fallback (per [#306](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/issues/306)).
+
+## NIP-98 → WebID upgrade (`src/auth/nostr.js`)
+
+Built on top of the LWS-CID infrastructure ([#400](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/pull/400)): when a NIP-98 request's signing pubkey is declared as a CID `verificationMethod` (and the VM is in `authentication`) on the resource owner's WebID profile, the request authenticates as the WebID instead of `did:nostr:<pubkey>`. Match is by f-form Multikey or by JsonWebKey full-point (x AND y, BIP-340 even-y). Profile fetch uses the same SSRF guard / cache as the LWS-CID verifier. No client-side change — Nostr clients sign as today.
+
+So: anyone who's used the doctor's B.2 to add a Nostr Multikey VM gets WebID-based NIP-98 sign-in for free.
 
 ## Spec references
 
@@ -76,9 +84,12 @@ The verifier joins the existing auth methods (OIDC, NIP-98, etc.) — preference
 
 ## Related
 
-- [`docs/authentication.md`](authentication.md) — current JSS auth surface (OIDC, NIP-98, passkey, etc.)
+- [`docs/authentication.md`](authentication.md) — full JSS auth surface (OIDC, NIP-98, LWS-CID, passkey, etc.)
 - [`docs/nostr.md`](nostr.md) — Nostr relay + did:nostr resolution
+- [doctor](https://github.com/JavaScriptSolidServer/doctor) — the browser-side diagnostic + add-keys app
 - [#386](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/issues/386) — convergence tracker
-- [#388](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/pull/388) — Phase A PR
+- [#388](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/pull/388) — Phase A (profile shape)
+- [#398](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/pull/398) — Phase 3 (LWS-CID JWT verifier)
+- [#400](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/pull/400) — NIP-98 → WebID via VM lookup
 - [#389](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/issues/389) — `@context` array form support (turtle conneg)
 - [#390](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/issues/390) — `@type:'@json'` literal handling (turtle conneg)


### PR DESCRIPTION
Closes the JSS half of #401. Companion PR for the Docusaurus mirror at JavaScriptSolidServer/docs follows.

Phase A doc was framed around things forthcoming. Reality moved:

- **Phase B** (profile carries keys) shipped via doctor [B.2](https://github.com/JavaScriptSolidServer/doctor/pull/2) and [B.3](https://github.com/JavaScriptSolidServer/doctor/pull/4)
- **Phase 3** (LWS-CID JWT verifier) shipped in v0.0.177 via #398
- **Bonus** beyond original roadmap: NIP-98 → WebID via VM lookup shipped in v0.0.178 (#400)

Compatibility table is now ✅ across the board. The "What Phase B will add" / "What Phase 3 will add" sections retitled to describe what's deployed. Added a new section for the NIP-98 upgrade. Refreshed the related-links list with the doctor repo + post-#388 PRs.

Targeted edits — preserved the existing structure and the Phase A profile-shape example block intact.