### PR TITLE
conneg: GET on container with index.html returns HTML to browsers (#409)

### DIFF
--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -161,11 +161,14 @@ export async function handleGet(request, reply) {
       const wantsTurtle = negotiated === RDF_TYPES.TURTLE
         || negotiated === RDF_TYPES.N3
         || negotiated === 'application/n-triples';
-      // Only treat as JSON-LD when Accept *explicitly* asks for JSON;
-      // otherwise selectContentType's `*/*` fallback wrongly diverts
-      // browser GETs (which include `*/*;q=0.8`) into the RDF branch and
-      // serves the embedded data island instead of the index.html body.
-      // Mirrors the HEAD-handler logic later in this file (#409).
+      // Only treat as JSON-LD when Accept *explicitly* asks for JSON.
+      // selectContentType doesn't recognize text/html or
+      // application/xhtml+xml, so for a browser Accept like
+      // `text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8`
+      // it walks past those unsupported types and lands on `*/*`, which
+      // returns JSON-LD — diverting plain browser GETs into the RDF
+      // branch and serving the embedded data island instead of the
+      // index.html body. Mirrors the HEAD-handler logic below (#409).
       const explicitJson = /\b(application\/ld\+json|application\/json)\b/i.test(acceptHeader);
       const wantsJsonLd = negotiated === RDF_TYPES.JSON_LD && explicitJson;
 

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -28,6 +28,14 @@ const LIVE_RELOAD_SCRIPT = `<script>(function(){var ws=new WebSocket((location.p
 // where a cached data variant was served on top-level navigation (#315).
 const RDF_CACHE_CONTROL = 'private, no-cache, must-revalidate';
 
+// Detects when the request's Accept header explicitly names a JSON
+// media type. Used by the container/index.html branches of GET and HEAD
+// to decide whether to surface the embedded JSON-LD data island —
+// without this guard, selectContentType's `*/*` arm would divert plain
+// browser requests into the RDF branch (#409). Hoisted so GET and HEAD
+// can't drift apart silently.
+const EXPLICIT_JSON_RE = /\b(application\/ld\+json|application\/json)\b/i;
+
 /**
  * Inject live reload script into HTML content
  */
@@ -169,7 +177,7 @@ export async function handleGet(request, reply) {
       // returns JSON-LD — diverting plain browser GETs into the RDF
       // branch and serving the embedded data island instead of the
       // index.html body. Mirrors the HEAD-handler logic below (#409).
-      const explicitJson = /\b(application\/ld\+json|application\/json)\b/i.test(acceptHeader);
+      const explicitJson = EXPLICIT_JSON_RE.test(acceptHeader);
       const wantsJsonLd = negotiated === RDF_TYPES.JSON_LD && explicitJson;
 
       if (wantsTurtle || wantsJsonLd) {
@@ -610,7 +618,7 @@ export async function handleHead(request, reply) {
         // For an index.html container, only override to JSON-LD if the
         // Accept header explicitly asked for JSON; otherwise fall back
         // to text/html so HEAD matches the index.html that GET serves.
-        const explicitJson = /\b(application\/ld\+json|application\/json)\b/i.test(acceptHeader);
+        const explicitJson = EXPLICIT_JSON_RE.test(acceptHeader);
         contentType = (indexExists && !explicitJson) ? 'text/html' : 'application/ld+json';
       } else {
         contentType = indexExists ? 'text/html' : 'application/ld+json';

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -161,7 +161,13 @@ export async function handleGet(request, reply) {
       const wantsTurtle = negotiated === RDF_TYPES.TURTLE
         || negotiated === RDF_TYPES.N3
         || negotiated === 'application/n-triples';
-      const wantsJsonLd = negotiated === RDF_TYPES.JSON_LD;
+      // Only treat as JSON-LD when Accept *explicitly* asks for JSON;
+      // otherwise selectContentType's `*/*` fallback wrongly diverts
+      // browser GETs (which include `*/*;q=0.8`) into the RDF branch and
+      // serves the embedded data island instead of the index.html body.
+      // Mirrors the HEAD-handler logic later in this file (#409).
+      const explicitJson = /\b(application\/ld\+json|application\/json)\b/i.test(acceptHeader);
+      const wantsJsonLd = negotiated === RDF_TYPES.JSON_LD && explicitJson;
 
       if (wantsTurtle || wantsJsonLd) {
         // Extract JSON-LD from HTML data island

--- a/test/conneg.test.js
+++ b/test/conneg.test.js
@@ -738,5 +738,25 @@ describe('Content Negotiation — q-weights and HEAD/GET parity (#325)', () => {
       const body = await res.text();
       assert.ok(body.includes('Carol'), 'turtle output should contain the data island content');
     });
+
+    // The original bug was specifically GET vs HEAD divergence — the HEAD
+    // handler already had the explicitJson guard, GET didn't. Pin the
+    // parity here so any future drift between the two branches fails.
+    const parityCases = [
+      ['browser Accept',  { Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' }],
+      ['Accept: text/html', { Accept: 'text/html' }],
+      ['Accept: application/ld+json', { Accept: 'application/ld+json' }],
+      ['Accept: text/turtle', { Accept: 'text/turtle' }]
+    ];
+    for (const [label, headers] of parityCases) {
+      it(`HEAD === GET content-type — ${label}`, async () => {
+        const get = await request('/qwtest/public/page/', { headers });
+        const head = await request('/qwtest/public/page/', { method: 'HEAD', headers });
+        assert.strictEqual(get.status, 200);
+        assert.strictEqual(head.status, 200);
+        assert.strictEqual(ct(head), ct(get),
+          `HEAD ct (${ct(head)}) must equal GET ct (${ct(get)}) for ${label}`);
+      });
+    }
   });
 });

--- a/test/conneg.test.js
+++ b/test/conneg.test.js
@@ -681,10 +681,12 @@ describe('Content Negotiation — q-weights and HEAD/GET parity (#325)', () => {
   describe('container with index.html — browser Accept (#409)', () => {
     // Regression: a container that has an index.html with a *valid*
     // <script type="application/ld+json"> data island used to return that
-    // data island as application/ld+json to plain browser GETs, because
-    // selectContentType's `*/*` fallback short-circuits before it sees
-    // text/html. Browsers send `Accept: text/html, ..., */*;q=0.8`, so
-    // the user-visible page silently flipped to JSON.
+    // data island as application/ld+json to plain browser GETs.
+    // selectContentType iterates the Accept list — for a browser sending
+    // `Accept: text/html, ..., */*;q=0.8` it sees text/html (and other
+    // HTML-ish types) but doesn't recognize any of them, then hits the
+    // `*/*` arm and returns JSON-LD, so the user-visible page silently
+    // flipped to JSON.
     const HTML_WITH_JSONLD = '<!DOCTYPE html><html><head><title>Home</title>'
       + '<script type="application/ld+json">'
       + JSON.stringify({ '@context': { foaf: 'http://xmlns.com/foaf/0.1/' }, '@id': '#me', 'foaf:name': 'Carol' })

--- a/test/conneg.test.js
+++ b/test/conneg.test.js
@@ -677,4 +677,64 @@ describe('Content Negotiation — q-weights and HEAD/GET parity (#325)', () => {
       assert.strictEqual(ct(authed), ct(anon));
     });
   });
+
+  describe('container with index.html — browser Accept (#409)', () => {
+    // Regression: a container that has an index.html with a *valid*
+    // <script type="application/ld+json"> data island used to return that
+    // data island as application/ld+json to plain browser GETs, because
+    // selectContentType's `*/*` fallback short-circuits before it sees
+    // text/html. Browsers send `Accept: text/html, ..., */*;q=0.8`, so
+    // the user-visible page silently flipped to JSON.
+    const HTML_WITH_JSONLD = '<!DOCTYPE html><html><head><title>Home</title>'
+      + '<script type="application/ld+json">'
+      + JSON.stringify({ '@context': { foaf: 'http://xmlns.com/foaf/0.1/' }, '@id': '#me', 'foaf:name': 'Carol' })
+      + '</script></head><body><h1>hello</h1></body></html>';
+
+    before(async () => {
+      // Container with an index.html containing a parseable JSON-LD island.
+      await request('/qwtest/public/page/', { method: 'PUT', auth: 'qwtest' });
+      await request('/qwtest/public/page/index.html', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'text/html' },
+        body: HTML_WITH_JSONLD,
+        auth: 'qwtest'
+      });
+    });
+
+    it('browser Accept (text/html with */*;q=0.8) → text/html, not JSON-LD', async () => {
+      const res = await request('/qwtest/public/page/', {
+        headers: { Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' }
+      });
+      assertStatus(res, 200);
+      assert.strictEqual(ct(res), 'text/html',
+        'browser GET on a container with index.html must return the HTML body, not the embedded data island');
+      const body = await res.text();
+      assert.ok(body.includes('<h1>hello</h1>'), 'response should be the index.html body');
+    });
+
+    it('plain Accept: text/html → text/html', async () => {
+      const res = await request('/qwtest/public/page/', { headers: { Accept: 'text/html' } });
+      assertStatus(res, 200);
+      assert.strictEqual(ct(res), 'text/html');
+    });
+
+    it('explicit Accept: application/ld+json → JSON-LD from data island still works', async () => {
+      const res = await request('/qwtest/public/page/', {
+        headers: { Accept: 'application/ld+json' }
+      });
+      assertStatus(res, 200);
+      assert.strictEqual(ct(res), 'application/ld+json');
+      const body = await res.json();
+      assert.strictEqual(body['foaf:name'], 'Carol',
+        'should still extract the data island when JSON-LD is explicitly asked for');
+    });
+
+    it('explicit Accept: text/turtle → Turtle from data island still works', async () => {
+      const res = await request('/qwtest/public/page/', { headers: { Accept: 'text/turtle' } });
+      assertStatus(res, 200);
+      assert.strictEqual(ct(res), 'text/turtle');
+      const body = await res.text();
+      assert.ok(body.includes('Carol'), 'turtle output should contain the data island content');
+    });
+  });
 });


### PR DESCRIPTION
Closes #409.

## Summary

- Browsers requesting a container that has an `index.html` containing a parseable `<script type="application/ld+json">` data island were getting `Content-Type: application/ld+json` instead of the HTML body.
- Root cause: `selectContentType` short-circuits on `*/*` and returns `JSON_LD`. Every browser sends `Accept: text/html, …, */*;q=0.8`, so the GET handler treated the request as wanting RDF and served the data island.
- The HEAD handler (~line 600) already guards against this with an `explicitJson` check; GET just hadn't been brought in line. This PR mirrors that guard.

## Change

`src/handlers/resource.js` — in the container/index.html branch, only set `wantsJsonLd` when Accept explicitly names `application/ld+json` or `application/json`:

```js
const explicitJson = /\b(application\/ld\+json|application\/json)\b/i.test(acceptHeader);
const wantsJsonLd = negotiated === RDF_TYPES.JSON_LD && explicitJson;
```

Turtle and explicit JSON-LD requests are unaffected — they take their respective branches as before.

## Tests

Added a `#409` describe block in `test/conneg.test.js` covering:

- `Accept: text/html, …, */*;q=0.8` → `text/html` (regression)
- `Accept: text/html` → `text/html`
- `Accept: application/ld+json` → JSON-LD from data island (preserved)
- `Accept: text/turtle` → Turtle from data island (preserved)

Stash-and-rerun confirms the new tests fail without the fix and pass with it. Full suite is green:

```
ℹ tests 50
ℹ pass 50
ℹ fail 0
```

## Notes

- The deeper fix is in `selectContentType` itself (it should not return `JSON_LD` when text/html outranks `*/*`), but it has 5 call sites — at least one passes the result to `fromJsonLd` as a target type, so changing the return contract needs a wider audit. This PR takes the same minimal, intent-matching approach already used in the HEAD handler. Happy to follow up with a broader refactor if desired.
- Found while debugging melvincarvalho.com, which had a well-formed data island. melvin.me hides the bug only because its data island has a trailing comma — `JSON.parse` throws, and the catch falls through to HTML.

## Test plan
- [x] `node --test test/conneg.test.js` — 50 pass
- [x] Manual repro: `curl -i -H 'Accept: text/html,…,*/*;q=0.8' /` returns `text/html` (was `application/ld+json`)
- [x] Manual: `curl -i -H 'Accept: application/ld+json' /` still returns JSON-LD