### PR TITLE
Index subdomain-mode pods (#411)

### DIFF
--- a/src/idp/well-known-did-nostr.js
+++ b/src/idp/well-known-did-nostr.js
@@ -138,45 +138,72 @@ async function rebuildPubkeyIndex() {
       continue;
     }
     if (!account?.webId) continue;
-    const profilePath = profilePathFromWebId(dataRoot, account.webId, accountId);
-    if (!profilePath) continue;
-    let profile;
+    // Probe candidate paths in order until one ALSO passes the @id
+    // check. Multiple candidates can exist on disk simultaneously
+    // (e.g. a root pod and named pods coexisting under the same
+    // dataRoot, or a subdomain pod with a coincidentally-named
+    // path-mode pod). The path-mode candidate may exist but belong
+    // to a different account — keep going until we find one whose
+    // declared `@id` matches account.webId.
+    const candidates = profilePathCandidates(dataRoot, account.webId);
+    let profile = null;
+    let profilePath = null;
     let mtimeMs = 0;
-    try {
-      const stat = await fs.stat(profilePath);
-      mtimeMs = stat.mtimeMs;
-      // Size cap to bound per-rebuild memory/CPU. A user can write
-      // their own profile, and TTL-expired rebuilds can be triggered
-      // by attacker-driven NIP-98 traffic — without this an
-      // adversarially-large profile could pin the event loop on
-      // JSON.parse during the rebuild loop.
+    let firstError = null;
+    for (const candidate of candidates) {
+      let stat;
+      try {
+        stat = await fs.stat(candidate);
+      } catch (err) {
+        // Remember the first error for log diagnostics if NO
+        // candidate is reachable. ENOENT is the normal "wrong
+        // candidate, try next" — don't surface it.
+        if (firstError === null && err.code !== 'ENOENT') firstError = err;
+        continue;
+      }
+      if (!stat.isFile()) continue;
       if (stat.size > MAX_PROFILE_BYTES) {
         console.error(
-          `well-known-did-nostr: skipping account ${accountId} ` +
-          `— profile size ${stat.size} > ${MAX_PROFILE_BYTES} bytes`,
+          `well-known-did-nostr: skipping candidate ${candidate} for ` +
+          `account ${accountId} — size ${stat.size} > ${MAX_PROFILE_BYTES} bytes`,
         );
         continue;
       }
-      const text = await fs.readFile(profilePath, 'utf8');
-      profile = JSON.parse(text);
-    } catch (err) {
-      // Log so operators can debug "why isn't my pubkey publishing?".
-      // Rate-limited per account so a single perpetually-broken
-      // profile can't flood logs every TTL cycle.
-      logProfileFailure(accountId, profilePath, err);
-      continue; // unreadable / malformed — skip
+      let parsed;
+      try {
+        parsed = JSON.parse(await fs.readFile(candidate, 'utf8'));
+      } catch (err) {
+        if (firstError === null) firstError = err;
+        continue;
+      }
+      // First-line @id check. Other CID-semantics checks happen
+      // below; if those fail we don't fall through to another
+      // candidate (they apply to the profile's content, not its
+      // location, so re-probing wouldn't help).
+      const declaredSubject = absolutize(parsed?.['@id'] || parsed?.id, stripHashIfAny(account.webId));
+      if (declaredSubject !== account.webId) continue;
+      profile = parsed;
+      profilePath = candidate;
+      mtimeMs = stat.mtimeMs;
+      break;
     }
-    // CID semantics — match the resource-side checks:
-    // (1) profile's @id MUST match the account's webId (no fragment-
-    //     swapping attack via a stored profile that claims to be
-    //     someone else)
+    if (!profile) {
+      // Nothing on disk matched. Surface the issue for operators —
+      // either the profile genuinely doesn't exist (ENOENT on every
+      // candidate) or each candidate's `@id` mismatched. Either way
+      // worth logging once per hour per account.
+      const tried = candidates.length ? candidates.join(' | ') : '(no candidates)';
+      const err = firstError || { code: 'ENOENT', message: 'no candidate matched account.webId' };
+      logProfileFailure(accountId, tried, err);
+      continue;
+    }
+    // CID semantics (continued) — match the resource-side checks:
     // (2) VM's controller MUST be in the profile's expected controller
     //     set (declared `controller`, with @id fallback)
     // (3) VM MUST be referenced from `authentication` — a key in
     //     verificationMethod alone (no auth membership) shouldn't be
     //     published as authentic
-    const profileSubject = absolutize(profile?.['@id'] || profile?.id, stripHashIfAny(account.webId));
-    if (!profileSubject || profileSubject !== account.webId) continue;
+    const profileSubject = account.webId;  // already validated above
     const expectedControllers = collectControllerIds(profile, profileSubject);
     if (expectedControllers.size === 0) continue;
     // Pass the already-validated absolute subject as the base. Without
@@ -259,6 +286,56 @@ export function profilePathFromWebId(dataRoot, webId, accountId = 'unknown') {
   }
   return resolved;
 }
+
+/**
+ * Build the candidate filesystem paths to probe for a given WebID,
+ * covering the deployment shapes JSS supports:
+ *
+ *   1. Path-mode named pod  (host=`example.com`, path=`/alice/profile/card.jsonld`)
+ *      → `<dataRoot>/alice/profile/card.jsonld`
+ *   2. Root pod (single-user) (host=`example.com`, path=`/profile/card.jsonld`)
+ *      → `<dataRoot>/profile/card.jsonld`
+ *   3. Subdomain-mode pod   (host=`alice.example.com`, path=`/profile/card.jsonld`)
+ *      → `<dataRoot>/alice/profile/card.jsonld`
+ *
+ * Cases (1) and (2) both fall out of `profilePathFromWebId` (path mode
+ * and root pod share the same derivation rule). Case (3) needs an
+ * extra "host first label as pod dir" candidate, which the original
+ * implementation didn't have — that's #411.
+ *
+ * Containment-checked. All candidates resolve to absolute paths that
+ * are at-or-under `dataRootAbs`. Caller fs.stats each in order and
+ * uses the first that exists; the @id-vs-account.webId check
+ * downstream rejects any false positive (reading the wrong file
+ * gets a profile whose `@id` won't match `account.webId`).
+ *
+ * @internal exported for tests
+ */
+export function profilePathCandidates(dataRoot, webId) {
+  if (typeof webId !== 'string') return [];
+  let url;
+  try { url = new URL(webId); } catch { return []; }
+  const pathnameRel = url.pathname.replace(/^\/+/, '');
+  const dataRootAbs = path.resolve(dataRoot);
+  const insideRoot = (p) => p === dataRootAbs || p.startsWith(dataRootAbs + path.sep);
+  const out = [];
+  const add = (...parts) => {
+    const r = path.resolve(dataRootAbs, ...parts);
+    if (insideRoot(r) && !out.includes(r)) out.push(r);
+  };
+  // Path-mode named pod OR root pod.
+  add(pathnameRel);
+  // Subdomain mode: take the first DNS label of the host as the pod
+  // directory under dataRoot. Only meaningful for hosts with at
+  // least two labels (`alice.example.com`); a bare host like
+  // `example.com` falls back to candidate #1 above (root/path mode).
+  const hostLabels = url.hostname.split('.');
+  if (hostLabels.length >= 2 && hostLabels[0]) {
+    add(hostLabels[0], pathnameRel);
+  }
+  return out;
+}
+
 
 function collectControllerIds(source, baseUrl) {
   const out = new Set();

--- a/src/idp/well-known-did-nostr.js
+++ b/src/idp/well-known-did-nostr.js
@@ -145,7 +145,7 @@ async function rebuildPubkeyIndex() {
     // path-mode pod). The path-mode candidate may exist but belong
     // to a different account — keep going until we find one whose
     // declared `@id` matches account.webId.
-    const candidates = profilePathCandidates(dataRoot, account.webId);
+    const candidates = profilePathCandidates(dataRoot, account.webId, account.podName);
     let profile = null;
     let profilePath = null;
     let mtimeMs = 0;
@@ -298,20 +298,25 @@ export function profilePathFromWebId(dataRoot, webId, accountId = 'unknown') {
  *   3. Subdomain-mode pod   (host=`alice.example.com`, path=`/profile/card.jsonld`)
  *      → `<dataRoot>/alice/profile/card.jsonld`
  *
- * Cases (1) and (2) both fall out of `profilePathFromWebId` (path mode
- * and root pod share the same derivation rule). Case (3) needs an
- * extra "host first label as pod dir" candidate, which the original
- * implementation didn't have — that's #411.
+ * Cases (1) and (2) share the same derivation rule (just join
+ * pathname under dataRoot). Case (3) needs an extra "host first
+ * label as pod dir" candidate, which the original implementation
+ * didn't have — that's #411.
+ *
+ * The subdomain candidate is gated on the optional `podName` arg:
+ * we only emit it when `<podName>.` is the host's actual first
+ * label. Without that gate, a root-pod WebID (`example.com`) would
+ * also emit `<dataRoot>/example/profile/...`, which could be a
+ * different account's pod dir — wasted probes plus noisier failure
+ * logs. The `@id` check downstream rejects mis-indexing either way,
+ * but precision here keeps logs clean.
  *
  * Containment-checked. All candidates resolve to absolute paths that
- * are at-or-under `dataRootAbs`. Caller fs.stats each in order and
- * uses the first that exists; the @id-vs-account.webId check
- * downstream rejects any false positive (reading the wrong file
- * gets a profile whose `@id` won't match `account.webId`).
+ * are at-or-under `dataRootAbs`.
  *
  * @internal exported for tests
  */
-export function profilePathCandidates(dataRoot, webId) {
+export function profilePathCandidates(dataRoot, webId, podName = null) {
   if (typeof webId !== 'string') return [];
   let url;
   try { url = new URL(webId); } catch { return []; }
@@ -325,13 +330,15 @@ export function profilePathCandidates(dataRoot, webId) {
   };
   // Path-mode named pod OR root pod.
   add(pathnameRel);
-  // Subdomain mode: take the first DNS label of the host as the pod
-  // directory under dataRoot. Only meaningful for hosts with at
-  // least two labels (`alice.example.com`); a bare host like
-  // `example.com` falls back to candidate #1 above (root/path mode).
-  const hostLabels = url.hostname.split('.');
-  if (hostLabels.length >= 2 && hostLabels[0]) {
-    add(hostLabels[0], pathnameRel);
+  // Subdomain mode: only when the WebID host's first DNS label
+  // ACTUALLY matches the account's podName. Case-insensitive
+  // because DNS is case-insensitive.
+  if (typeof podName === 'string' && podName.length > 0) {
+    const host = url.hostname.toLowerCase();
+    const expected = podName.toLowerCase() + '.';
+    if (host.startsWith(expected)) {
+      add(podName, pathnameRel);
+    }
   }
   return out;
 }

--- a/src/idp/well-known-did-nostr.js
+++ b/src/idp/well-known-did-nostr.js
@@ -168,11 +168,13 @@ async function rebuildPubkeyIndex() {
         continue;
       }
       if (stat.size > MAX_PROFILE_BYTES) {
+        // Funnel through the rate-limited per-account logger
+        // (when no candidate matches at all). Direct console.error
+        // would spam logs every TTL rebuild for any account whose
+        // profile is oversized at one candidate but matches at
+        // another — and on every rebuild for genuinely-oversized
+        // accounts.
         reasons.push(`${candidate}: oversized (${stat.size} > ${MAX_PROFILE_BYTES})`);
-        console.error(
-          `well-known-did-nostr: skipping candidate ${candidate} for ` +
-          `account ${accountId} — size ${stat.size} > ${MAX_PROFILE_BYTES} bytes`,
-        );
         continue;
       }
       let parsed;
@@ -198,10 +200,15 @@ async function rebuildPubkeyIndex() {
       // genuinely missing) from @id mismatch (wrong subdomain config?)
       // from containment rejection (malformed webId path) without
       // having to grep the file system.
+      //
+      // Keep the `path` argument to logProfileFailure path-shaped so
+      // downstream log readers don't get a giant summary string in
+      // the `profile=...` field. Per-candidate detail goes into
+      // `err.message` as a single line.
       const summary = reasons.length ? reasons.join(' | ') : '(no candidates)';
-      logProfileFailure(accountId, summary, {
+      logProfileFailure(accountId, '(multiple candidates)', {
         code: 'NO_CANDIDATE_MATCHED',
-        message: `no candidate profile matched account.webId for ${account.webId}`,
+        message: `no candidate profile matched ${account.webId} — tried: ${summary}`,
       });
       continue;
     }

--- a/src/idp/well-known-did-nostr.js
+++ b/src/idp/well-known-did-nostr.js
@@ -140,29 +140,35 @@ async function rebuildPubkeyIndex() {
     if (!account?.webId) continue;
     // Probe candidate paths in order until one ALSO passes the @id
     // check. Multiple candidates can exist on disk simultaneously
-    // (e.g. a root pod and named pods coexisting under the same
+    // (e.g. root pod and named pods coexisting under the same
     // dataRoot, or a subdomain pod with a coincidentally-named
-    // path-mode pod). The path-mode candidate may exist but belong
+    // path-mode dir). The path-mode candidate may exist but belong
     // to a different account — keep going until we find one whose
     // declared `@id` matches account.webId.
-    const candidates = profilePathCandidates(dataRoot, account.webId, account.podName);
+    const { paths: candidates, skipped: containmentSkipped } =
+      profilePathCandidates(dataRoot, account.webId, account.podName);
+    // Track per-candidate failure reasons so operators get a precise
+    // diagnostic when nothing matches — distinguishing
+    // "profile genuinely missing" from "@id mismatch" from "oversized"
+    // from "containment rejected".
+    const reasons = containmentSkipped.map(s => `${s.path}: ${s.reason}`);
     let profile = null;
     let profilePath = null;
     let mtimeMs = 0;
-    let firstError = null;
     for (const candidate of candidates) {
       let stat;
       try {
         stat = await fs.stat(candidate);
       } catch (err) {
-        // Remember the first error for log diagnostics if NO
-        // candidate is reachable. ENOENT is the normal "wrong
-        // candidate, try next" — don't surface it.
-        if (firstError === null && err.code !== 'ENOENT') firstError = err;
+        reasons.push(`${candidate}: ${err.code || 'stat-error'}`);
         continue;
       }
-      if (!stat.isFile()) continue;
+      if (!stat.isFile()) {
+        reasons.push(`${candidate}: not-a-regular-file`);
+        continue;
+      }
       if (stat.size > MAX_PROFILE_BYTES) {
+        reasons.push(`${candidate}: oversized (${stat.size} > ${MAX_PROFILE_BYTES})`);
         console.error(
           `well-known-did-nostr: skipping candidate ${candidate} for ` +
           `account ${accountId} — size ${stat.size} > ${MAX_PROFILE_BYTES} bytes`,
@@ -173,28 +179,30 @@ async function rebuildPubkeyIndex() {
       try {
         parsed = JSON.parse(await fs.readFile(candidate, 'utf8'));
       } catch (err) {
-        if (firstError === null) firstError = err;
+        reasons.push(`${candidate}: parse-error (${err.message})`);
         continue;
       }
-      // First-line @id check. Other CID-semantics checks happen
-      // below; if those fail we don't fall through to another
-      // candidate (they apply to the profile's content, not its
-      // location, so re-probing wouldn't help).
       const declaredSubject = absolutize(parsed?.['@id'] || parsed?.id, stripHashIfAny(account.webId));
-      if (declaredSubject !== account.webId) continue;
+      if (declaredSubject !== account.webId) {
+        reasons.push(`${candidate}: @id-mismatch (declared=${declaredSubject || '(none)'})`);
+        continue;
+      }
       profile = parsed;
       profilePath = candidate;
       mtimeMs = stat.mtimeMs;
       break;
     }
     if (!profile) {
-      // Nothing on disk matched. Surface the issue for operators —
-      // either the profile genuinely doesn't exist (ENOENT on every
-      // candidate) or each candidate's `@id` mismatched. Either way
-      // worth logging once per hour per account.
-      const tried = candidates.length ? candidates.join(' | ') : '(no candidates)';
-      const err = firstError || { code: 'ENOENT', message: 'no candidate matched account.webId' };
-      logProfileFailure(accountId, tried, err);
+      // Nothing on disk matched. Surface the precise per-candidate
+      // failure reasons so operators can distinguish ENOENT (profile
+      // genuinely missing) from @id mismatch (wrong subdomain config?)
+      // from containment rejection (malformed webId path) without
+      // having to grep the file system.
+      const summary = reasons.length ? reasons.join(' | ') : '(no candidates)';
+      logProfileFailure(accountId, summary, {
+        code: 'NO_CANDIDATE_MATCHED',
+        message: `no candidate profile matched account.webId for ${account.webId}`,
+      });
       continue;
     }
     // CID semantics (continued) — match the resource-side checks:
@@ -298,49 +306,50 @@ export function profilePathFromWebId(dataRoot, webId, accountId = 'unknown') {
  *   3. Subdomain-mode pod   (host=`alice.example.com`, path=`/profile/card.jsonld`)
  *      → `<dataRoot>/alice/profile/card.jsonld`
  *
- * Cases (1) and (2) share the same derivation rule (just join
- * pathname under dataRoot). Case (3) needs an extra "host first
- * label as pod dir" candidate, which the original implementation
- * didn't have — that's #411.
+ * The subdomain candidate (3) is gated on `podName` matching the
+ * WebID host's first DNS label — without that gate, a root-pod
+ * WebID (`example.com`) would also emit `<dataRoot>/example/...`,
+ * which could be a different account's pod dir.
  *
- * The subdomain candidate is gated on the optional `podName` arg:
- * we only emit it when `<podName>.` is the host's actual first
- * label. Without that gate, a root-pod WebID (`example.com`) would
- * also emit `<dataRoot>/example/profile/...`, which could be a
- * different account's pod dir — wasted probes plus noisier failure
- * logs. The `@id` check downstream rejects mis-indexing either way,
- * but precision here keeps logs clean.
- *
- * Containment-checked. All candidates resolve to absolute paths that
- * are at-or-under `dataRootAbs`.
+ * Returns `{ paths, skipped }`:
+ *   - `paths` — absolute, containment-passed candidates to probe
+ *     in order
+ *   - `skipped` — diagnostic entries for paths rejected at this
+ *     stage (today only "outside-dataRoot"). Surfaced through the
+ *     rebuild loop's failure log so operators can distinguish
+ *     traversal / misconfig from "profile not on disk."
  *
  * @internal exported for tests
  */
 export function profilePathCandidates(dataRoot, webId, podName = null) {
-  if (typeof webId !== 'string') return [];
+  if (typeof webId !== 'string') return { paths: [], skipped: [] };
   let url;
-  try { url = new URL(webId); } catch { return []; }
+  try { url = new URL(webId); } catch { return { paths: [], skipped: [] }; }
   const pathnameRel = url.pathname.replace(/^\/+/, '');
   const dataRootAbs = path.resolve(dataRoot);
   const insideRoot = (p) => p === dataRootAbs || p.startsWith(dataRootAbs + path.sep);
-  const out = [];
-  const add = (...parts) => {
+  const paths = [];
+  const skipped = [];
+  const consider = (...parts) => {
     const r = path.resolve(dataRootAbs, ...parts);
-    if (insideRoot(r) && !out.includes(r)) out.push(r);
+    if (!insideRoot(r)) {
+      skipped.push({ path: r, reason: 'outside-dataRoot' });
+      return;
+    }
+    if (!paths.includes(r)) paths.push(r);
   };
   // Path-mode named pod OR root pod.
-  add(pathnameRel);
+  consider(pathnameRel);
   // Subdomain mode: only when the WebID host's first DNS label
-  // ACTUALLY matches the account's podName. Case-insensitive
-  // because DNS is case-insensitive.
+  // matches the account's podName (case-insensitive — DNS is).
   if (typeof podName === 'string' && podName.length > 0) {
     const host = url.hostname.toLowerCase();
     const expected = podName.toLowerCase() + '.';
     if (host.startsWith(expected)) {
-      add(podName, pathnameRel);
+      consider(podName, pathnameRel);
     }
   }
-  return out;
+  return { paths, skipped };
 }
 
 

--- a/src/idp/well-known-did-nostr.js
+++ b/src/idp/well-known-did-nostr.js
@@ -153,7 +153,6 @@ async function rebuildPubkeyIndex() {
     // from "containment rejected".
     const reasons = containmentSkipped.map(s => `${s.path}: ${s.reason}`);
     let profile = null;
-    let profilePath = null;
     let mtimeMs = 0;
     for (const candidate of candidates) {
       let stat;
@@ -190,7 +189,6 @@ async function rebuildPubkeyIndex() {
         continue;
       }
       profile = parsed;
-      profilePath = candidate;
       mtimeMs = stat.mtimeMs;
       break;
     }

--- a/test/well-known-did-nostr.test.js
+++ b/test/well-known-did-nostr.test.js
@@ -715,8 +715,8 @@ describe('profilePathCandidates — deployment-shape coverage (#411)', () => {
       `expected root-pod candidate; got ${cands.join(', ')}`);
   });
 
-  it('subdomain-mode pod: emits <dataRoot>/<host-first-label>/profile/...', () => {
-    const cands = profilePathCandidates(DATA_ROOT, 'https://test.solid.social/profile/card.jsonld#me');
+  it('subdomain-mode pod: emits <dataRoot>/<podName>/profile/... when host first label matches podName', () => {
+    const cands = profilePathCandidates(DATA_ROOT, 'https://test.solid.social/profile/card.jsonld#me', 'test');
     // BOTH should be there — the path-mode candidate (which won't
     // exist on disk for a subdomain-mode pod) and the subdomain
     // candidate. The caller fs.stats each in order.
@@ -726,11 +726,29 @@ describe('profilePathCandidates — deployment-shape coverage (#411)', () => {
       `expected subdomain candidate; got ${cands.join(', ')}`);
   });
 
+  it('does NOT emit a subdomain candidate when podName is omitted', () => {
+    // Without podName, we can't tell whether the host's first
+    // label is actually this pod's subdomain — could be a totally
+    // unrelated user's pod dir on a different account. Skip the
+    // subdomain candidate and rely on the path-mode/root candidate.
+    const cands = profilePathCandidates(DATA_ROOT, 'https://test.solid.social/profile/card.jsonld#me');
+    assert.deepStrictEqual(cands, ['/srv/jss/data/profile/card.jsonld']);
+  });
+
+  it('does NOT emit a subdomain candidate when podName does not match the host first label', () => {
+    // Important: a root-pod WebID `https://example.com/profile/...`
+    // with podName='me' must NOT produce `<dataRoot>/example/...`
+    // — that'd be a different account's pod dir and only
+    // accidentally rejected by the @id check.
+    const cands = profilePathCandidates(DATA_ROOT, 'https://example.com/profile/card.jsonld#me', 'me');
+    assert.deepStrictEqual(cands, ['/srv/jss/data/profile/card.jsonld']);
+  });
+
   it('does NOT emit a subdomain candidate for a single-label host', () => {
     // `localhost` has only one label — there's no "host first label
     // as pod dir" candidate to add (it would just duplicate the
     // path-mode one).
-    const cands = profilePathCandidates(DATA_ROOT, 'http://localhost/profile/card.jsonld#me');
+    const cands = profilePathCandidates(DATA_ROOT, 'http://localhost/profile/card.jsonld#me', 'localhost');
     assert.deepStrictEqual(cands, ['/srv/jss/data/profile/card.jsonld']);
   });
 
@@ -741,16 +759,18 @@ describe('profilePathCandidates — deployment-shape coverage (#411)', () => {
 
   it('every candidate stays inside dataRootAbs', () => {
     // The same containment invariant that profilePathFromWebId
-    // enforces — extended to ALL emitted candidates.
-    for (const w of [
-      'https://example.com/alice/profile/card.jsonld#me',
-      'https://alice.example.com/profile/card.jsonld#me',
-      'https://h/../../../etc/passwd',
-      'https://h.com/../../../etc/passwd',
-    ]) {
-      for (const c of profilePathCandidates(DATA_ROOT, w)) {
+    // enforces — extended to ALL emitted candidates, including
+    // the subdomain candidate (when a matching podName is passed).
+    const cases = [
+      ['https://example.com/alice/profile/card.jsonld#me', 'alice'],
+      ['https://alice.example.com/profile/card.jsonld#me', 'alice'],
+      ['https://h/../../../etc/passwd', null],
+      ['https://h.com/../../../etc/passwd', 'h'],
+    ];
+    for (const [w, podName] of cases) {
+      for (const c of profilePathCandidates(DATA_ROOT, w, podName)) {
         assert.ok(c === DATA_ROOT || c.startsWith(DATA_ROOT + path.sep),
-          `${w} → ${c} escaped DATA_ROOT`);
+          `${w} (podName=${podName}) → ${c} escaped DATA_ROOT`);
       }
     }
   });

--- a/test/well-known-did-nostr.test.js
+++ b/test/well-known-did-nostr.test.js
@@ -704,63 +704,46 @@ describe('profilePathCandidates — deployment-shape coverage (#411)', () => {
   const DATA_ROOT = '/srv/jss/data';
 
   it('path-mode named pod: <dataRoot>/<pod>/profile/card.jsonld', () => {
-    const cands = profilePathCandidates(DATA_ROOT, 'https://example.com/alice/profile/card.jsonld#me');
-    assert.ok(cands.includes('/srv/jss/data/alice/profile/card.jsonld'),
-      `expected path-mode candidate; got ${cands.join(', ')}`);
+    const { paths } = profilePathCandidates(DATA_ROOT, 'https://example.com/alice/profile/card.jsonld#me');
+    assert.ok(paths.includes('/srv/jss/data/alice/profile/card.jsonld'),
+      `expected path-mode candidate; got ${paths.join(', ')}`);
   });
 
   it('root pod: <dataRoot>/profile/card.jsonld', () => {
-    const cands = profilePathCandidates(DATA_ROOT, 'https://example.com/profile/card.jsonld#me');
-    assert.ok(cands.includes('/srv/jss/data/profile/card.jsonld'),
-      `expected root-pod candidate; got ${cands.join(', ')}`);
+    const { paths } = profilePathCandidates(DATA_ROOT, 'https://example.com/profile/card.jsonld#me');
+    assert.ok(paths.includes('/srv/jss/data/profile/card.jsonld'),
+      `expected root-pod candidate; got ${paths.join(', ')}`);
   });
 
   it('subdomain-mode pod: emits <dataRoot>/<podName>/profile/... when host first label matches podName', () => {
-    const cands = profilePathCandidates(DATA_ROOT, 'https://test.solid.social/profile/card.jsonld#me', 'test');
-    // BOTH should be there — the path-mode candidate (which won't
-    // exist on disk for a subdomain-mode pod) and the subdomain
-    // candidate. The caller fs.stats each in order.
-    assert.ok(cands.includes('/srv/jss/data/profile/card.jsonld'),
-      `expected path-mode candidate; got ${cands.join(', ')}`);
-    assert.ok(cands.includes('/srv/jss/data/test/profile/card.jsonld'),
-      `expected subdomain candidate; got ${cands.join(', ')}`);
+    const { paths } = profilePathCandidates(DATA_ROOT, 'https://test.solid.social/profile/card.jsonld#me', 'test');
+    assert.ok(paths.includes('/srv/jss/data/profile/card.jsonld'),
+      `expected path-mode candidate; got ${paths.join(', ')}`);
+    assert.ok(paths.includes('/srv/jss/data/test/profile/card.jsonld'),
+      `expected subdomain candidate; got ${paths.join(', ')}`);
   });
 
   it('does NOT emit a subdomain candidate when podName is omitted', () => {
-    // Without podName, we can't tell whether the host's first
-    // label is actually this pod's subdomain — could be a totally
-    // unrelated user's pod dir on a different account. Skip the
-    // subdomain candidate and rely on the path-mode/root candidate.
-    const cands = profilePathCandidates(DATA_ROOT, 'https://test.solid.social/profile/card.jsonld#me');
-    assert.deepStrictEqual(cands, ['/srv/jss/data/profile/card.jsonld']);
+    const { paths } = profilePathCandidates(DATA_ROOT, 'https://test.solid.social/profile/card.jsonld#me');
+    assert.deepStrictEqual(paths, ['/srv/jss/data/profile/card.jsonld']);
   });
 
   it('does NOT emit a subdomain candidate when podName does not match the host first label', () => {
-    // Important: a root-pod WebID `https://example.com/profile/...`
-    // with podName='me' must NOT produce `<dataRoot>/example/...`
-    // — that'd be a different account's pod dir and only
-    // accidentally rejected by the @id check.
-    const cands = profilePathCandidates(DATA_ROOT, 'https://example.com/profile/card.jsonld#me', 'me');
-    assert.deepStrictEqual(cands, ['/srv/jss/data/profile/card.jsonld']);
+    const { paths } = profilePathCandidates(DATA_ROOT, 'https://example.com/profile/card.jsonld#me', 'me');
+    assert.deepStrictEqual(paths, ['/srv/jss/data/profile/card.jsonld']);
   });
 
   it('does NOT emit a subdomain candidate for a single-label host', () => {
-    // `localhost` has only one label — there's no "host first label
-    // as pod dir" candidate to add (it would just duplicate the
-    // path-mode one).
-    const cands = profilePathCandidates(DATA_ROOT, 'http://localhost/profile/card.jsonld#me', 'localhost');
-    assert.deepStrictEqual(cands, ['/srv/jss/data/profile/card.jsonld']);
+    const { paths } = profilePathCandidates(DATA_ROOT, 'http://localhost/profile/card.jsonld#me', 'localhost');
+    assert.deepStrictEqual(paths, ['/srv/jss/data/profile/card.jsonld']);
   });
 
-  it('returns [] for an unparseable webId', () => {
-    assert.deepStrictEqual(profilePathCandidates(DATA_ROOT, 'not a url'), []);
-    assert.deepStrictEqual(profilePathCandidates(DATA_ROOT, null), []);
+  it('returns empty paths for an unparseable webId', () => {
+    assert.deepStrictEqual(profilePathCandidates(DATA_ROOT, 'not a url'), { paths: [], skipped: [] });
+    assert.deepStrictEqual(profilePathCandidates(DATA_ROOT, null), { paths: [], skipped: [] });
   });
 
   it('every candidate stays inside dataRootAbs', () => {
-    // The same containment invariant that profilePathFromWebId
-    // enforces — extended to ALL emitted candidates, including
-    // the subdomain candidate (when a matching podName is passed).
     const cases = [
       ['https://example.com/alice/profile/card.jsonld#me', 'alice'],
       ['https://alice.example.com/profile/card.jsonld#me', 'alice'],
@@ -768,10 +751,35 @@ describe('profilePathCandidates — deployment-shape coverage (#411)', () => {
       ['https://h.com/../../../etc/passwd', 'h'],
     ];
     for (const [w, podName] of cases) {
-      for (const c of profilePathCandidates(DATA_ROOT, w, podName)) {
+      const { paths } = profilePathCandidates(DATA_ROOT, w, podName);
+      for (const c of paths) {
         assert.ok(c === DATA_ROOT || c.startsWith(DATA_ROOT + path.sep),
           `${w} (podName=${podName}) → ${c} escaped DATA_ROOT`);
       }
     }
+  });
+
+  it('returns the `{ paths, skipped }` shape so the caller can surface diagnostics', () => {
+    // Restructure of pass-2: the function returns BOTH the
+    // containment-passed paths AND a `skipped` list of rejected
+    // candidates with reasons. rebuildPubkeyIndex folds `skipped`
+    // into its per-account failure log so operators can
+    // distinguish "traversal/misconfig" from "profile not on disk."
+    //
+    // Through normal URL-parsed input the `skipped` list stays
+    // empty (URL normalization prevents traversal in pathname,
+    // and the podName-gated subdomain candidate rejects mismatches
+    // before path-resolve ever runs). The field exists as
+    // defense-in-depth for any future caller that bypasses URL
+    // parsing or feeds an externally-derived podName, AND so the
+    // rebuild loop's failure log has a hook to surface
+    // containment rejections instead of dropping them silently.
+    const result = profilePathCandidates(DATA_ROOT,
+      'https://alice.example.com/profile/card.jsonld#me', 'alice');
+    assert.ok(Array.isArray(result.paths), 'paths must be an array');
+    assert.ok(Array.isArray(result.skipped), 'skipped must be an array');
+    assert.ok(result.paths.length > 0, 'happy-path must yield paths');
+    assert.deepStrictEqual(result.skipped, [],
+      'normal URL-parsed input must produce no skipped entries');
   });
 });

--- a/test/well-known-did-nostr.test.js
+++ b/test/well-known-did-nostr.test.js
@@ -323,9 +323,22 @@ describe('GET /.well-known/did/nostr/:pubkey (#407)', () => {
     // fails the @id check, and the loop must fall through to the
     // subdomain candidate. Self-contained — doesn't depend on
     // earlier tests' fixtures or test-execution order.
+    //
+    // Snapshot any pre-existing file at the decoy path so the
+    // earlier "indexes root-level pods" test's fixture (or any
+    // future fixture sharing that path) can be restored after
+    // this test runs. Without this snapshot, deleting the decoy
+    // unconditionally would silently wipe legitimate state.
     const decoyPk = getPublicKey(generateSecretKey()); // unrelated key
     const decoyProfilePath = path.join(TEST_DATA_DIR, 'profile', 'card.jsonld');
     const decoyWebId = `${baseUrl}/profile/card.jsonld#decoy`;
+    let decoySnapshot = null;
+    try {
+      decoySnapshot = await fs.readFile(decoyProfilePath, 'utf8');
+    } catch (e) {
+      if (e.code !== 'ENOENT') throw e;
+      // didn't exist — nothing to restore
+    }
     await fs.ensureDir(path.dirname(decoyProfilePath));
     await fs.writeJson(decoyProfilePath, {
       '@context': 'https://www.w3.org/ns/solid/v1',
@@ -376,9 +389,21 @@ describe('GET /.well-known/did/nostr/:pubkey (#407)', () => {
     assert.strictEqual(doc.id, `did:nostr:${subPk}`);
     assert.strictEqual(doc.alsoKnownAs[0], subWebId);
 
-    // Cleanup: leave neither the decoy nor the index entry behind
-    // so the test isolates correctly even when re-run / reordered.
-    await fs.remove(decoyProfilePath);
+    // Cleanup: leave neither the decoy nor the subdomain
+    // fixture behind. Restore (or delete) the decoy file so
+    // any prior fixture state at that path is preserved.
+    if (decoySnapshot !== null) {
+      await fs.writeFile(decoyProfilePath, decoySnapshot, 'utf8');
+    } else {
+      await fs.remove(decoyProfilePath);
+    }
+    await fs.remove(subProfilePath);
+    // Also remove the parent `<TEST_DATA_DIR>/sub` dir if empty
+    // (won't be if other tests added siblings — that's fine).
+    try {
+      await fs.rmdir(path.dirname(subProfilePath));
+      await fs.rmdir(path.dirname(path.dirname(subProfilePath)));
+    } catch { /* not empty / already gone — fine */ }
     delete idx[subWebId];
     await fs.writeJson(indexPath, idx, { spaces: 2 });
     await fs.remove(path.join(accountsDir, `${accountId}.json`));

--- a/test/well-known-did-nostr.test.js
+++ b/test/well-known-did-nostr.test.js
@@ -332,81 +332,91 @@ describe('GET /.well-known/did/nostr/:pubkey (#407)', () => {
     const decoyPk = getPublicKey(generateSecretKey()); // unrelated key
     const decoyProfilePath = path.join(TEST_DATA_DIR, 'profile', 'card.jsonld');
     const decoyWebId = `${baseUrl}/profile/card.jsonld#decoy`;
-    let decoySnapshot = null;
-    try {
-      decoySnapshot = await fs.readFile(decoyProfilePath, 'utf8');
-    } catch (e) {
-      if (e.code !== 'ENOENT') throw e;
-      // didn't exist — nothing to restore
-    }
-    await fs.ensureDir(path.dirname(decoyProfilePath));
-    await fs.writeJson(decoyProfilePath, {
-      '@context': 'https://www.w3.org/ns/solid/v1',
-      '@id': decoyWebId,
-      verificationMethod: [{
-        id: `${decoyWebId.replace('#decoy', '')}#k`,
-        type: 'Multikey',
-        controller: decoyWebId,
-        publicKeyMultibase: fformMultikey(decoyPk),
-      }],
-      authentication: [`${decoyWebId.replace('#decoy', '')}#k`],
-    }, { spaces: 2 });
-
     const sk = generateSecretKey();
     const subPk = getPublicKey(sk);
     const subWebId = 'http://sub.example.test/profile/card.jsonld#me';
     const subProfilePath = path.join(TEST_DATA_DIR, 'sub', 'profile', 'card.jsonld');
     const VM_ID = 'http://sub.example.test/profile/card.jsonld#k';
-    await fs.ensureDir(path.dirname(subProfilePath));
-    await fs.writeJson(subProfilePath, {
-      '@context': 'https://www.w3.org/ns/solid/v1',
-      '@id': subWebId,
-      verificationMethod: [{
-        id: VM_ID,
-        type: 'Multikey',
-        controller: subWebId,
-        publicKeyMultibase: fformMultikey(subPk),
-      }],
-      authentication: [VM_ID],
-    }, { spaces: 2 });
-
     const accountsDir = path.join(TEST_DATA_DIR, '.idp', 'accounts');
     const indexPath = path.join(accountsDir, '_webid_index.json');
-    const idx = await fs.readJson(indexPath);
     const accountId = 'subdomain-pod-test-account';
-    idx[subWebId] = accountId;
-    await fs.writeJson(indexPath, idx, { spaces: 2 });
-    await fs.writeJson(path.join(accountsDir, `${accountId}.json`), {
-      id: accountId,
-      podName: 'sub',
-      webId: subWebId,
-      email: 'sub@example.test',
-    }, { spaces: 2 });
 
-    const r = await fetch(`${baseUrl}/.well-known/did/nostr/${subPk}.json`);
-    assert.strictEqual(r.status, 200, 'subdomain-mode pod must be findable');
-    const doc = await r.json();
-    assert.strictEqual(doc.id, `did:nostr:${subPk}`);
-    assert.strictEqual(doc.alsoKnownAs[0], subWebId);
-
-    // Cleanup: leave neither the decoy nor the subdomain
-    // fixture behind. Restore (or delete) the decoy file so
-    // any prior fixture state at that path is preserved.
-    if (decoySnapshot !== null) {
-      await fs.writeFile(decoyProfilePath, decoySnapshot, 'utf8');
-    } else {
-      await fs.remove(decoyProfilePath);
-    }
-    await fs.remove(subProfilePath);
-    // Also remove the parent `<TEST_DATA_DIR>/sub` dir if empty
-    // (won't be if other tests added siblings — that's fine).
+    // Snapshot any pre-existing file at the decoy path so a prior
+    // fixture (e.g. the "indexes root-level pods" test's profile
+    // at the same location) can be restored at cleanup. ENOENT
+    // means "didn't exist; remove on cleanup."
+    let decoySnapshot = null;
     try {
-      await fs.rmdir(path.dirname(subProfilePath));
-      await fs.rmdir(path.dirname(path.dirname(subProfilePath)));
-    } catch { /* not empty / already gone — fine */ }
-    delete idx[subWebId];
-    await fs.writeJson(indexPath, idx, { spaces: 2 });
-    await fs.remove(path.join(accountsDir, `${accountId}.json`));
+      decoySnapshot = await fs.readFile(decoyProfilePath, 'utf8');
+    } catch (e) {
+      if (e.code !== 'ENOENT') throw e;
+    }
+
+    // Mutate fixtures inside try; cleanup runs regardless of
+    // whether assertions throw, so a future regression doesn't
+    // leak filesystem state and turn the suite order-dependent.
+    try {
+      await fs.ensureDir(path.dirname(decoyProfilePath));
+      await fs.writeJson(decoyProfilePath, {
+        '@context': 'https://www.w3.org/ns/solid/v1',
+        '@id': decoyWebId,
+        verificationMethod: [{
+          id: `${decoyWebId.replace('#decoy', '')}#k`,
+          type: 'Multikey',
+          controller: decoyWebId,
+          publicKeyMultibase: fformMultikey(decoyPk),
+        }],
+        authentication: [`${decoyWebId.replace('#decoy', '')}#k`],
+      }, { spaces: 2 });
+
+      await fs.ensureDir(path.dirname(subProfilePath));
+      await fs.writeJson(subProfilePath, {
+        '@context': 'https://www.w3.org/ns/solid/v1',
+        '@id': subWebId,
+        verificationMethod: [{
+          id: VM_ID,
+          type: 'Multikey',
+          controller: subWebId,
+          publicKeyMultibase: fformMultikey(subPk),
+        }],
+        authentication: [VM_ID],
+      }, { spaces: 2 });
+
+      const idx = await fs.readJson(indexPath);
+      idx[subWebId] = accountId;
+      await fs.writeJson(indexPath, idx, { spaces: 2 });
+      await fs.writeJson(path.join(accountsDir, `${accountId}.json`), {
+        id: accountId,
+        podName: 'sub',
+        webId: subWebId,
+        email: 'sub@example.test',
+      }, { spaces: 2 });
+
+      const r = await fetch(`${baseUrl}/.well-known/did/nostr/${subPk}.json`);
+      assert.strictEqual(r.status, 200, 'subdomain-mode pod must be findable');
+      const doc = await r.json();
+      assert.strictEqual(doc.id, `did:nostr:${subPk}`);
+      assert.strictEqual(doc.alsoKnownAs[0], subWebId);
+    } finally {
+      // Restore decoy (or delete if it was created by this test).
+      if (decoySnapshot !== null) {
+        try { await fs.writeFile(decoyProfilePath, decoySnapshot, 'utf8'); }
+        catch { /* best effort */ }
+      } else {
+        try { await fs.remove(decoyProfilePath); } catch { /* best effort */ }
+      }
+      // Subdomain fixture file + empty parent dirs.
+      try { await fs.remove(subProfilePath); } catch { /* best effort */ }
+      try { await fs.rmdir(path.dirname(subProfilePath)); } catch { /* not empty / gone */ }
+      try { await fs.rmdir(path.dirname(path.dirname(subProfilePath))); } catch { /* not empty / gone */ }
+      // Index entry + account record.
+      try {
+        const idx = await fs.readJson(indexPath);
+        delete idx[subWebId];
+        await fs.writeJson(indexPath, idx, { spaces: 2 });
+      } catch { /* best effort */ }
+      try { await fs.remove(path.join(accountsDir, `${accountId}.json`)); } catch { /* best effort */ }
+    }
   });
 
   // No `it()` here — path containment is now exercised directly

--- a/test/well-known-did-nostr.test.js
+++ b/test/well-known-did-nostr.test.js
@@ -405,10 +405,13 @@ describe('GET /.well-known/did/nostr/:pubkey (#407)', () => {
       } else {
         try { await fs.remove(decoyProfilePath); } catch { /* best effort */ }
       }
-      // Subdomain fixture file + empty parent dirs.
+      // Subdomain fixture file + empty parent dirs. fs-extra's
+      // `remove` handles both files and (recursively) dirs and
+      // is a no-op on missing paths — replaces the deprecated
+      // node `fs.rmdir`.
       try { await fs.remove(subProfilePath); } catch { /* best effort */ }
-      try { await fs.rmdir(path.dirname(subProfilePath)); } catch { /* not empty / gone */ }
-      try { await fs.rmdir(path.dirname(path.dirname(subProfilePath))); } catch { /* not empty / gone */ }
+      try { await fs.remove(path.dirname(subProfilePath)); } catch { /* best effort */ }
+      try { await fs.remove(path.dirname(path.dirname(subProfilePath))); } catch { /* best effort */ }
       // Index entry + account record.
       try {
         const idx = await fs.readJson(indexPath);

--- a/test/well-known-did-nostr.test.js
+++ b/test/well-known-did-nostr.test.js
@@ -14,7 +14,11 @@ import fs from 'fs-extra';
 import { createServer as createNetServer } from 'net';
 import { generateSecretKey, getPublicKey } from '../src/nostr/event.js';
 import { createServer } from '../src/server.js';
-import { _resetIndexForTests, profilePathFromWebId } from '../src/idp/well-known-did-nostr.js';
+import {
+  _resetIndexForTests,
+  profilePathFromWebId,
+  profilePathCandidates,
+} from '../src/idp/well-known-did-nostr.js';
 import { extractNostrPubkeysFromProfile } from '../src/auth/nostr.js';
 
 const TEST_HOST = '127.0.0.1';
@@ -299,6 +303,63 @@ describe('GET /.well-known/did/nostr/:pubkey (#407)', () => {
     const doc = await r.json();
     assert.strictEqual(doc.id, `did:nostr:${rootPk}`);
     assert.strictEqual(doc.alsoKnownAs[0], rootWebId);
+  });
+
+  it('indexes subdomain-mode pods (#411): /<host-first-label>/profile/...', async () => {
+    // Subdomain layout: WebID host = `<podname>.<basedomain>` and
+    // the profile lives at `<DATA_ROOT>/<podname>/profile/card.jsonld`
+    // (NOT at `<DATA_ROOT>/profile/card.jsonld`). Pre-#411 the
+    // indexer derived the path from `webIdUrl.pathname` only,
+    // dropped the subdomain, and ENOENT-skipped every subdomain
+    // pod silently — so the entire `Sign in with Schnorr` zero-
+    // typing UX fell through to the typed-username fallback on
+    // every subdomain-mode deployment (e.g. solid.social).
+    //
+    // The test server is at 127.0.0.1:<port>; its hostname has
+    // only one label and so isn't a real subdomain test. Instead
+    // we simulate the layout: write a profile at
+    // <TEST_DATA_DIR>/sub/profile/card.jsonld (the on-disk shape
+    // a subdomain pod produces) and synthesize an account whose
+    // WebID host has `sub.` as its first label. Because the
+    // synthesized WebID points at a public domain, its DID-doc
+    // generation also confirms the path-derivation logic doesn't
+    // depend on the request's host.
+    const sk = generateSecretKey();
+    const subPk = getPublicKey(sk);
+    const subWebId = 'http://sub.example.test/profile/card.jsonld#me';
+    const subProfilePath = path.join(TEST_DATA_DIR, 'sub', 'profile', 'card.jsonld');
+    const VM_ID = 'http://sub.example.test/profile/card.jsonld#k';
+    await fs.ensureDir(path.dirname(subProfilePath));
+    await fs.writeJson(subProfilePath, {
+      '@context': 'https://www.w3.org/ns/solid/v1',
+      '@id': subWebId,
+      verificationMethod: [{
+        id: VM_ID,
+        type: 'Multikey',
+        controller: subWebId,
+        publicKeyMultibase: fformMultikey(subPk),
+      }],
+      authentication: [VM_ID],
+    }, { spaces: 2 });
+
+    const accountsDir = path.join(TEST_DATA_DIR, '.idp', 'accounts');
+    const indexPath = path.join(accountsDir, '_webid_index.json');
+    const idx = await fs.readJson(indexPath);
+    const accountId = 'subdomain-pod-test-account';
+    idx[subWebId] = accountId;
+    await fs.writeJson(indexPath, idx, { spaces: 2 });
+    await fs.writeJson(path.join(accountsDir, `${accountId}.json`), {
+      id: accountId,
+      podName: 'sub',
+      webId: subWebId,
+      email: 'sub@example.test',
+    }, { spaces: 2 });
+
+    const r = await fetch(`${baseUrl}/.well-known/did/nostr/${subPk}.json`);
+    assert.strictEqual(r.status, 200, 'subdomain-mode pod must be findable');
+    const doc = await r.json();
+    assert.strictEqual(doc.id, `did:nostr:${subPk}`);
+    assert.strictEqual(doc.alsoKnownAs[0], subWebId);
   });
 
   // No `it()` here — path containment is now exercised directly
@@ -626,6 +687,71 @@ describe('profilePathFromWebId — DATA_ROOT containment', () => {
         p === null || p.startsWith(DATA_ROOT + path.sep) || p === DATA_ROOT,
         `${evil} → ${p} escaped DATA_ROOT`,
       );
+    }
+  });
+});
+
+describe('profilePathCandidates — deployment-shape coverage (#411)', () => {
+  // The original `profilePathFromWebId` only emitted ONE candidate
+  // (`<dataRoot><pathname>`), which broke subdomain-mode pods on
+  // solid.social: account `b0b1707f-...` with WebID
+  // `https://test.solid.social/profile/card.jsonld#me` lives on disk
+  // at `<dataRoot>/test/profile/card.jsonld`, but the indexer was
+  // looking at `<dataRoot>/profile/card.jsonld` and ENOENT-ing.
+  //
+  // `profilePathCandidates` returns the full ordered list. Tests
+  // cover all three deployment shapes JSS supports.
+  const DATA_ROOT = '/srv/jss/data';
+
+  it('path-mode named pod: <dataRoot>/<pod>/profile/card.jsonld', () => {
+    const cands = profilePathCandidates(DATA_ROOT, 'https://example.com/alice/profile/card.jsonld#me');
+    assert.ok(cands.includes('/srv/jss/data/alice/profile/card.jsonld'),
+      `expected path-mode candidate; got ${cands.join(', ')}`);
+  });
+
+  it('root pod: <dataRoot>/profile/card.jsonld', () => {
+    const cands = profilePathCandidates(DATA_ROOT, 'https://example.com/profile/card.jsonld#me');
+    assert.ok(cands.includes('/srv/jss/data/profile/card.jsonld'),
+      `expected root-pod candidate; got ${cands.join(', ')}`);
+  });
+
+  it('subdomain-mode pod: emits <dataRoot>/<host-first-label>/profile/...', () => {
+    const cands = profilePathCandidates(DATA_ROOT, 'https://test.solid.social/profile/card.jsonld#me');
+    // BOTH should be there — the path-mode candidate (which won't
+    // exist on disk for a subdomain-mode pod) and the subdomain
+    // candidate. The caller fs.stats each in order.
+    assert.ok(cands.includes('/srv/jss/data/profile/card.jsonld'),
+      `expected path-mode candidate; got ${cands.join(', ')}`);
+    assert.ok(cands.includes('/srv/jss/data/test/profile/card.jsonld'),
+      `expected subdomain candidate; got ${cands.join(', ')}`);
+  });
+
+  it('does NOT emit a subdomain candidate for a single-label host', () => {
+    // `localhost` has only one label — there's no "host first label
+    // as pod dir" candidate to add (it would just duplicate the
+    // path-mode one).
+    const cands = profilePathCandidates(DATA_ROOT, 'http://localhost/profile/card.jsonld#me');
+    assert.deepStrictEqual(cands, ['/srv/jss/data/profile/card.jsonld']);
+  });
+
+  it('returns [] for an unparseable webId', () => {
+    assert.deepStrictEqual(profilePathCandidates(DATA_ROOT, 'not a url'), []);
+    assert.deepStrictEqual(profilePathCandidates(DATA_ROOT, null), []);
+  });
+
+  it('every candidate stays inside dataRootAbs', () => {
+    // The same containment invariant that profilePathFromWebId
+    // enforces — extended to ALL emitted candidates.
+    for (const w of [
+      'https://example.com/alice/profile/card.jsonld#me',
+      'https://alice.example.com/profile/card.jsonld#me',
+      'https://h/../../../etc/passwd',
+      'https://h.com/../../../etc/passwd',
+    ]) {
+      for (const c of profilePathCandidates(DATA_ROOT, w)) {
+        assert.ok(c === DATA_ROOT || c.startsWith(DATA_ROOT + path.sep),
+          `${w} → ${c} escaped DATA_ROOT`);
+      }
     }
   });
 });

--- a/test/well-known-did-nostr.test.js
+++ b/test/well-known-did-nostr.test.js
@@ -315,15 +315,30 @@ describe('GET /.well-known/did/nostr/:pubkey (#407)', () => {
     // typing UX fell through to the typed-username fallback on
     // every subdomain-mode deployment (e.g. solid.social).
     //
-    // The test server is at 127.0.0.1:<port>; its hostname has
-    // only one label and so isn't a real subdomain test. Instead
-    // we simulate the layout: write a profile at
-    // <TEST_DATA_DIR>/sub/profile/card.jsonld (the on-disk shape
-    // a subdomain pod produces) and synthesize an account whose
-    // WebID host has `sub.` as its first label. Because the
-    // synthesized WebID points at a public domain, its DID-doc
-    // generation also confirms the path-derivation logic doesn't
-    // depend on the request's host.
+    // This test ALSO exercises the "first candidate exists but
+    // belongs to a different account" path: we write a coexisting
+    // root-pod profile at `<TEST_DATA_DIR>/profile/card.jsonld`
+    // for an UNRELATED account (different webId, different VM).
+    // The subdomain account's path-mode candidate hits that file,
+    // fails the @id check, and the loop must fall through to the
+    // subdomain candidate. Self-contained — doesn't depend on
+    // earlier tests' fixtures or test-execution order.
+    const decoyPk = getPublicKey(generateSecretKey()); // unrelated key
+    const decoyProfilePath = path.join(TEST_DATA_DIR, 'profile', 'card.jsonld');
+    const decoyWebId = `${baseUrl}/profile/card.jsonld#decoy`;
+    await fs.ensureDir(path.dirname(decoyProfilePath));
+    await fs.writeJson(decoyProfilePath, {
+      '@context': 'https://www.w3.org/ns/solid/v1',
+      '@id': decoyWebId,
+      verificationMethod: [{
+        id: `${decoyWebId.replace('#decoy', '')}#k`,
+        type: 'Multikey',
+        controller: decoyWebId,
+        publicKeyMultibase: fformMultikey(decoyPk),
+      }],
+      authentication: [`${decoyWebId.replace('#decoy', '')}#k`],
+    }, { spaces: 2 });
+
     const sk = generateSecretKey();
     const subPk = getPublicKey(sk);
     const subWebId = 'http://sub.example.test/profile/card.jsonld#me';
@@ -360,6 +375,13 @@ describe('GET /.well-known/did/nostr/:pubkey (#407)', () => {
     const doc = await r.json();
     assert.strictEqual(doc.id, `did:nostr:${subPk}`);
     assert.strictEqual(doc.alsoKnownAs[0], subWebId);
+
+    // Cleanup: leave neither the decoy nor the index entry behind
+    // so the test isolates correctly even when re-run / reordered.
+    await fs.remove(decoyProfilePath);
+    delete idx[subWebId];
+    await fs.writeJson(indexPath, idx, { spaces: 2 });
+    await fs.remove(path.join(accountsDir, `${accountId}.json`));
   });
 
   // No `it()` here — path containment is now exercised directly
@@ -701,41 +723,49 @@ describe('profilePathCandidates — deployment-shape coverage (#411)', () => {
   //
   // `profilePathCandidates` returns the full ordered list. Tests
   // cover all three deployment shapes JSS supports.
-  const DATA_ROOT = '/srv/jss/data';
+  //
+  // DATA_ROOT is path.resolve()d so the assertions below build
+  // expected values via path.join — works on Windows (different
+  // separator/root) the same as on POSIX.
+  const DATA_ROOT = path.resolve('/srv/jss/data');
 
   it('path-mode named pod: <dataRoot>/<pod>/profile/card.jsonld', () => {
     const { paths } = profilePathCandidates(DATA_ROOT, 'https://example.com/alice/profile/card.jsonld#me');
-    assert.ok(paths.includes('/srv/jss/data/alice/profile/card.jsonld'),
-      `expected path-mode candidate; got ${paths.join(', ')}`);
+    const expected = path.join(DATA_ROOT, 'alice', 'profile', 'card.jsonld');
+    assert.ok(paths.includes(expected),
+      `expected ${expected}; got ${paths.join(', ')}`);
   });
 
   it('root pod: <dataRoot>/profile/card.jsonld', () => {
     const { paths } = profilePathCandidates(DATA_ROOT, 'https://example.com/profile/card.jsonld#me');
-    assert.ok(paths.includes('/srv/jss/data/profile/card.jsonld'),
-      `expected root-pod candidate; got ${paths.join(', ')}`);
+    const expected = path.join(DATA_ROOT, 'profile', 'card.jsonld');
+    assert.ok(paths.includes(expected),
+      `expected ${expected}; got ${paths.join(', ')}`);
   });
 
   it('subdomain-mode pod: emits <dataRoot>/<podName>/profile/... when host first label matches podName', () => {
     const { paths } = profilePathCandidates(DATA_ROOT, 'https://test.solid.social/profile/card.jsonld#me', 'test');
-    assert.ok(paths.includes('/srv/jss/data/profile/card.jsonld'),
-      `expected path-mode candidate; got ${paths.join(', ')}`);
-    assert.ok(paths.includes('/srv/jss/data/test/profile/card.jsonld'),
-      `expected subdomain candidate; got ${paths.join(', ')}`);
+    const pathMode = path.join(DATA_ROOT, 'profile', 'card.jsonld');
+    const subdomain = path.join(DATA_ROOT, 'test', 'profile', 'card.jsonld');
+    assert.ok(paths.includes(pathMode),
+      `expected path-mode candidate ${pathMode}; got ${paths.join(', ')}`);
+    assert.ok(paths.includes(subdomain),
+      `expected subdomain candidate ${subdomain}; got ${paths.join(', ')}`);
   });
 
   it('does NOT emit a subdomain candidate when podName is omitted', () => {
     const { paths } = profilePathCandidates(DATA_ROOT, 'https://test.solid.social/profile/card.jsonld#me');
-    assert.deepStrictEqual(paths, ['/srv/jss/data/profile/card.jsonld']);
+    assert.deepStrictEqual(paths, [path.join(DATA_ROOT, 'profile', 'card.jsonld')]);
   });
 
   it('does NOT emit a subdomain candidate when podName does not match the host first label', () => {
     const { paths } = profilePathCandidates(DATA_ROOT, 'https://example.com/profile/card.jsonld#me', 'me');
-    assert.deepStrictEqual(paths, ['/srv/jss/data/profile/card.jsonld']);
+    assert.deepStrictEqual(paths, [path.join(DATA_ROOT, 'profile', 'card.jsonld')]);
   });
 
   it('does NOT emit a subdomain candidate for a single-label host', () => {
     const { paths } = profilePathCandidates(DATA_ROOT, 'http://localhost/profile/card.jsonld#me', 'localhost');
-    assert.deepStrictEqual(paths, ['/srv/jss/data/profile/card.jsonld']);
+    assert.deepStrictEqual(paths, [path.join(DATA_ROOT, 'profile', 'card.jsonld')]);
   });
 
   it('returns empty paths for an unparseable webId', () => {


### PR DESCRIPTION
Closes #411.

The well-known did:nostr indexer was silently dropping every subdomain-mode pod. Surfaced during live testing of #408 on solid.social: account `b0b1707f-...` with WebID `https://test.solid.social/profile/card.jsonld#me` lives on disk at `<dataRoot>/test/profile/card.jsonld`, but the indexer was looking at `<dataRoot>/profile/card.jsonld` and ENOENT-ing.

## Root cause

`profilePathFromWebId` derived the on-disk path from `webIdUrl.pathname` alone, which works for path-mode named pods and root pods but loses the subdomain when host = `<podname>.<basedomain>`:

```
WebID:    https://alice.example.com/profile/card.jsonld#me
pathname: /profile/card.jsonld
derived:  <dataRoot>/profile/card.jsonld
actual:   <dataRoot>/alice/profile/card.jsonld     ← profile lives here
```

So every subdomain user on solid.social fell through to the typed-username fallback (#403/#405), defeating the zero-typing UX promise of #408.

## Fix

- New `profilePathCandidates(dataRoot, webId)` returns an ordered list of candidates: path-mode/root-pod first, then `<dataRoot>/<host-first-label>/<pathname>` if the host has ≥2 DNS labels. Containment-checked.
- `rebuildPubkeyIndex` now probes candidates and accepts the first whose `@id` matches `account.webId`. Multiple candidates can exist simultaneously (root pod + named pods coexisting), so committing to the first stat-able candidate was buggy — would pick someone else's profile, fail the @id check, skip without trying the next candidate.

## Test plan

- [x] 6 new unit tests on `profilePathCandidates` covering all three deployment shapes (path, root, subdomain) + edge cases (single-label host, unparseable webId, containment invariant)
- [x] 1 integration test that synthesizes a subdomain-mode pod alongside the existing root-pod test fixture — exercises the "first candidate exists but belongs to a different account" path that the original `findProfilePathOnDisk` got wrong
- [x] Full suite: 767 / 767 pass
- [ ] Manual on solid.social after deploy: subdomain pod's WebID resolvable via `/.well-known/did/nostr/<pubkey>.json`; "Sign in with Schnorr" works without typing a username