### PR TITLE
profile: declare Multikey/JsonWebKey class names in @context (#417)

### DIFF
--- a/src/webid/profile.js
+++ b/src/webid/profile.js
@@ -75,7 +75,19 @@ export function generateProfileJsonLd({ webId, name, podUri, issuer }) {
       'authentication':     { '@id': 'cid:authentication', '@type': '@id', '@container': '@set' },
       'assertionMethod':    { '@id': 'cid:assertionMethod', '@type': '@id', '@container': '@set' },
       'publicKeyJwk':       { '@id': 'cid:publicKeyJwk', '@type': '@json' },
-      'publicKeyMultibase': { '@id': 'cid:publicKeyMultibase' }
+      'publicKeyMultibase': { '@id': 'cid:publicKeyMultibase' },
+      // CID v1 verificationMethod *class* names (#417). Without these
+      // term mappings, an app PATCHing in a VM with `type: "Multikey"`
+      // (the spec-example shape) emits a bare relative-IRI `<Multikey>`
+      // when JSS conneg-converts the profile to Turtle — which then
+      // resolves against the document's base URL to a fictional class
+      // like `<pod>/profile/Multikey`. Mapping the class names here
+      // means the bare term `"Multikey"` in JSON-LD expands correctly
+      // (cid:Multikey → https://www.w3.org/ns/cid/v1#Multikey) for both
+      // JSON-LD processors AND our Turtle conneg layer. Naive JSON
+      // readers comparing `type === "Multikey"` continue to work.
+      'Multikey':           'cid:Multikey',
+      'JsonWebKey':         'cid:JsonWebKey'
     },
     '@id': webId,
     '@type': ['foaf:Person', 'schema:Person'],

--- a/test/webid.test.js
+++ b/test/webid.test.js
@@ -87,6 +87,30 @@ describe('WebID Profile', () => {
       assert.strictEqual(ctx.publicKeyJwk['@type'], '@json');
     });
 
+    it('declares CID v1 class names (Multikey, JsonWebKey) as flat aliases (#417)', async () => {
+      // Without these mappings, an app PATCHing in a VM with the
+      // spec-example shape `{type: "Multikey", ...}` produces a bare
+      // relative-IRI `<Multikey>` in the Turtle conneg output, which
+      // resolves to a fictional class on the pod's own host (e.g.
+      // `<pod>/profile/Multikey` instead of `cid:Multikey`).
+      //
+      // The flat-alias shape (`"Multikey": "cid:Multikey"`) makes
+      // bare-term emission work correctly through both JSON-LD
+      // expansion AND our Turtle conneg layer — and matches the
+      // "JSON-LD with flat context aliases" pattern consumers like
+      // LOSOS / LION rely on.
+      const res = await request(profilePath);
+      const jsonLd = await res.json();
+      const ctx = jsonLd['@context'];
+      for (const cls of ['Multikey', 'JsonWebKey']) {
+        const mapping = ctx[cls];
+        assert.ok(mapping, `@context must define class alias \`${cls}\``);
+        const id = typeof mapping === 'string' ? mapping : mapping['@id'];
+        assert.match(id, new RegExp(`^(cid:${cls}|https://www\\.w3\\.org/ns/cid/v1#${cls})$`),
+          `${cls} must map to the CID v1 namespace`);
+      }
+    });
+
     it('declares self-control via controller === @id (#386 Phase A)', async () => {
       const res = await request(profilePath);
       const jsonLd = await res.json();
@@ -214,6 +238,59 @@ describe('WebID Profile — Turtle conneg (#320)', () => {
 
   after(async () => {
     await stopTestServer();
+  });
+
+  it('Turtle conneg: generated profile @context expands bare Multikey/JsonWebKey terms (#417)', async () => {
+    // Combine the production profile generator's @context with a
+    // synthetic VM (the spec-example shape `{type: "Multikey", ...}`)
+    // and run it through the same conneg path the live profile
+    // would. Asserts: the bare-term type expands to the CID v1
+    // namespace, not to a relative IRI that resolves to a fake
+    // class on the pod's host.
+    const { generateProfile } = await import('../src/webid/profile.js');
+    const { fromJsonLd } = await import('../src/rdf/conneg.js');
+    const webId = 'https://example.test/profile/card.jsonld#me';
+    const profile = generateProfile({
+      webId,
+      name: 'mk-test',
+      podUri: 'https://example.test/',
+      issuer: 'https://example.test/',
+    });
+    // Inject a Multikey VM authored with the spec-example bare-term
+    // type — this is the shape the bug surfaces on.
+    const vmId = webId.replace('#me', '#nostr-key-1');
+    profile.verificationMethod = [{
+      id: vmId,
+      type: 'Multikey',
+      controller: webId,
+      publicKeyMultibase: 'fe70102de7ec0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab',
+    }];
+    profile.authentication = [vmId];
+
+    const { content: ttl } = await fromJsonLd(profile, 'text/turtle', 'https://example.test/', true);
+
+    // Pre-#417: would emit `a <Multikey>` (relative — resolves to
+    // `https://example.test/profile/Multikey`).
+    // After #417: the @context maps `Multikey -> cid:Multikey`, so
+    // the converter expands the bare term to the CID v1 IRI.
+    assert.ok(
+      ttl.includes('cid:Multikey') || ttl.includes('cid/v1#Multikey'),
+      `Turtle must emit a CID-namespaced Multikey class, got:\n${ttl}`,
+    );
+    assert.ok(
+      !/\ba\s+<Multikey>\s*[;.]/.test(ttl),
+      `Turtle must NOT emit bare <Multikey> (resolves to fictional class), got:\n${ttl}`,
+    );
+    // Don't regress #416: the VM block + publicKeyMultibase must
+    // still survive the conversion.
+    assert.ok(
+      ttl.includes('publicKeyMultibase') || ttl.includes('cid/v1#publicKeyMultibase'),
+      `Turtle must include cid:publicKeyMultibase, got:\n${ttl}`,
+    );
+    assert.ok(
+      ttl.includes('fe70102de7ec'),
+      `Turtle must include the publicKeyMultibase value, got:\n${ttl}`,
+    );
   });
 
   it('Turtle variant includes cid:service with lws:OpenIdProvider and serviceEndpoint', async () => {


### PR DESCRIPTION
Closes #417. Builds on #416 (Turtle converter accepts `id`/`type` aliases on nested objects).

## Problem

The server-default profile's `@context` mapped CID v1 predicates (`verificationMethod`, `controller`, `publicKeyMultibase`, etc.) but NOT the class names `Multikey` and `JsonWebKey`. An app PATCHing in a verificationMethod with the spec-example shape `{type: "Multikey", ...}` triggered:

```turtle
<.../#nostr-key-1> a <Multikey> ;
    cid:controller <.../#me> ;
    cid:publicKeyMultibase "fe701..." .
```

Per RFC 3986, `<Multikey>` resolves against the document base — yielding `<pod>/profile/Multikey`, a fictional class on the pod's own host. Same key on `alice.example.com` and `bob.example.com` emitted DIFFERENT class IRIs. VC validators / SPARQL queries against `cid:Multikey` missed every JSS-issued VM.

## Fix

Two flat aliases added to `@context` in `src/webid/profile.js`:

```js
"Multikey":   "cid:Multikey",
"JsonWebKey": "cid:JsonWebKey",
```

The flat-alias shape (vs. pre-prefixed CURIE in the payload) preserves three properties:

- **Naive JSON consumers** comparing `type === "Multikey"` keep working — payload shape unchanged
- **JSON-LD processors** expand via `@context` to the canonical `https://www.w3.org/ns/cid/v1#Multikey`
- **Turtle conneg** (post-#416) respects `@context` and emits `cid:Multikey` with the `cid:` prefix declared at the top — any Turtle parser resolves it to the canonical IRI

This matches the "JSON-LD with flat context aliases" pattern that consumers like [LOSOS / LION](https://losos.org/) rely on.

## Test plan

- [x] Unit: `@context` declares both `Multikey` and `JsonWebKey` as flat aliases mapping to the CID v1 namespace
- [x] Unit (Turtle conneg): combines the production profile generator's `@context` with a synthetic VM `{type: "Multikey", ...}` and asserts:
  - Turtle contains `cid:Multikey` (or full IRI form)
  - Turtle does NOT contain bare `<Multikey>` (would resolve to fictional `<pod>/profile/Multikey`)
  - `publicKeyMultibase` value still appears (#416 didn't regress)
- [x] Full suite: 772 → 774 pass

## Migration note

Existing profiles authored before this change still have the old `@context` without the class aliases. Their conneg-converted Turtle will continue to emit bare `<Multikey>` until the profile is re-emitted (e.g. via a profile-rewrite migration or simply a future PUT through this updated emitter). New pods + profiles created via JSS get the fix automatically.

For the live test pod on solid.social specifically, I'll patch its `@context` manually after this lands so its `/.well-known/did/nostr/...` and Turtle conneg paths produce clean class IRIs without waiting for a re-emit.