### PR TITLE
server: inject CORS headers on Fastify-internal errors (#376)

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,7 @@
 import Fastify from 'fastify';
 import rateLimit from '@fastify/rate-limit';
 import { readFile } from 'fs/promises';
+import { STATUS_CODES } from 'node:http';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { handleGet, handleHead, handlePut, handleDelete, handleOptions, handlePatch } from './handlers/resource.js';
@@ -177,19 +178,20 @@ export function createServer(options = {}) {
     // browser sees a CORS error (no Access-Control-Allow-*) instead
     // of the real status. #376.
     frameworkErrors: (err, request, reply) => {
-      const origin = request.headers?.origin;
-      if (origin) {
-        // getCorsHeaders sets Access-Control-Allow-Origin to the
-        // request's Origin (or `*` when absent). Allow-Methods /
-        // Headers / Expose-Headers / Credentials / Max-Age are the
-        // standard JSS set from src/ldp/headers.js, so this error
-        // path advertises the same surface as a happy-path response.
-        const cors = getCorsHeaders(origin);
-        for (const [k, v] of Object.entries(cors)) reply.header(k, v);
-      }
+      // ALWAYS apply CORS headers — matches the rest of the server's
+      // behavior (every successful response sets CORS via the global
+      // onRequest hook). getCorsHeaders defaults Allow-Origin to `*`
+      // when the request didn't send an Origin header.
+      const cors = getCorsHeaders(request.headers?.origin);
+      for (const [k, v] of Object.entries(cors)) reply.header(k, v);
       const statusCode = err.statusCode ?? 400;
       reply.code(statusCode).type('application/json').send({
-        error: err.name || 'Bad Request',
+        // Use the HTTP status text (e.g. "Bad Request" for 400)
+        // rather than err.name (which for FastifyError is the
+        // unhelpful string "FastifyError"). Matches Fastify's
+        // default error-body shape that pre-fix clients were
+        // parsing.
+        error: STATUS_CODES[statusCode] || 'Error',
         code: err.code,
         message: err.message,
         statusCode,

--- a/src/server.js
+++ b/src/server.js
@@ -169,6 +169,31 @@ export function createServer(options = {}) {
       }
       // Default Fastify behavior for other client errors
       socket.destroy(err);
+    },
+    // Catch Fastify-internal errors that fire BEFORE any user hook
+    // runs — notably FST_ERR_BAD_URL on malformed percent-encoding
+    // (`%g1`, truncated `%E0%`, invalid UTF-8). Without this, Fastify
+    // writes the 400 response directly via `res.writeHead` and the
+    // browser sees a CORS error (no Access-Control-Allow-*) instead
+    // of the real status. #376.
+    frameworkErrors: (err, request, reply) => {
+      const origin = request.headers?.origin;
+      if (origin) {
+        // getCorsHeaders sets Access-Control-Allow-Origin to the
+        // request's Origin (or `*` when absent). Allow-Methods /
+        // Headers / Expose-Headers / Credentials / Max-Age are the
+        // standard JSS set from src/ldp/headers.js, so this error
+        // path advertises the same surface as a happy-path response.
+        const cors = getCorsHeaders(origin);
+        for (const [k, v] of Object.entries(cors)) reply.header(k, v);
+      }
+      const statusCode = err.statusCode ?? 400;
+      reply.code(statusCode).type('application/json').send({
+        error: err.name || 'Bad Request',
+        code: err.code,
+        message: err.message,
+        statusCode,
+      });
     }
   };
 

--- a/test/error-handler.test.js
+++ b/test/error-handler.test.js
@@ -88,8 +88,10 @@ describe('registerErrorHandler (#312)', () => {
 // the 400 response with no Access-Control-Allow-* headers — browsers
 // surfaced the response as a CORS error instead of the real status.
 // The fix uses Fastify's `frameworkErrors` option in createServer
-// to attach the CORS header set whenever the bad request carried
-// an `Origin` header.
+// to attach the full CORS header set on EVERY framework-error
+// response (matching the rest of the server, where the global
+// onRequest hook sets CORS unconditionally). Allow-Origin mirrors
+// the request's `Origin` if present, otherwise defaults to `*`.
 describe('frameworkErrors injects CORS headers on FST_ERR_BAD_URL (#376)', () => {
   let server;
   let baseUrl;

--- a/test/error-handler.test.js
+++ b/test/error-handler.test.js
@@ -81,3 +81,73 @@ describe('registerErrorHandler (#312)', () => {
     assert.strictEqual(unhandled.length, 0, '4xx must not produce a 5xx stack log');
   });
 });
+
+// #376: Fastify-internal errors that fire BEFORE any user hook
+// runs (notably FST_ERR_BAD_URL on malformed percent-encoding)
+// previously bypassed every CORS-injecting handler in JSS, leaving
+// the 400 response with no Access-Control-Allow-* headers — browsers
+// surfaced the response as a CORS error instead of the real status.
+// The fix uses Fastify's `frameworkErrors` option in createServer
+// to attach the CORS header set whenever the bad request carried
+// an `Origin` header.
+describe('frameworkErrors injects CORS headers on FST_ERR_BAD_URL (#376)', () => {
+  let server;
+  let baseUrl;
+
+  before(async () => {
+    const { createServer } = await import('../src/server.js');
+    server = createServer({ logger: false, forceCloseConnections: true });
+    await server.listen({ port: 0, host: '127.0.0.1' });
+    const addr = server.server.address();
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  after(async () => {
+    await server.close();
+  });
+
+  it('returns 400 with full CORS headers for a malformed-percent URL + Origin', async () => {
+    // `%g1` is the canonical FST_ERR_BAD_URL trigger — `g` isn't a
+    // valid hex digit, so the percent-decode bails before any route
+    // handler is even resolved.
+    const r = await fetch(`${baseUrl}/foo%g1`, {
+      headers: { Origin: 'https://example.com' },
+    });
+    assert.strictEqual(r.status, 400);
+    // CORS headers are what was missing pre-fix. ACAO should mirror
+    // the request Origin (not `*`), since the request explicitly
+    // sent one — that's what getCorsHeaders does.
+    assert.strictEqual(r.headers.get('access-control-allow-origin'), 'https://example.com');
+    assert.match(r.headers.get('access-control-allow-methods') || '', /GET/);
+    assert.ok(r.headers.get('access-control-allow-headers'), 'ACAH must be set');
+    assert.ok(r.headers.get('access-control-expose-headers'), 'ACEH must be set');
+  });
+
+  it('also returns CORS headers for the same bad URL even without an Origin (ACAO defaults to *)', async () => {
+    // Non-browser clients without an Origin still get a JSON 400
+    // body — the CORS guard is "only set Allow-* when Origin was
+    // present" (browsers won't enforce CORS in this case anyway).
+    // Confirm the response is still well-shaped JSON and the status
+    // is correct.
+    const r = await fetch(`${baseUrl}/foo%g1`);
+    assert.strictEqual(r.status, 400);
+    const body = await r.json();
+    assert.strictEqual(body.code, 'FST_ERR_BAD_URL');
+    assert.strictEqual(body.statusCode, 400);
+  });
+
+  it('does NOT regress: a normal 404 still carries CORS via the wildcard handler', async () => {
+    // Belt-and-suspenders: the frameworkErrors hook shouldn't have
+    // displaced any existing CORS behavior on responses that go
+    // through the wildcard handler. Ask for a path that hits the
+    // LDP wildcard and 404s (no such resource), confirm CORS.
+    const r = await fetch(`${baseUrl}/nonexistent/deep/path`, {
+      headers: { Origin: 'https://example.com' },
+    });
+    // Could be 401 or 404 depending on auth defaults; in either case
+    // CORS must be present.
+    assert.ok([401, 404].includes(r.status), `expected 401 or 404, got ${r.status}`);
+    assert.ok(r.headers.get('access-control-allow-origin'),
+      'ACAO must be set on the normal-handler error path too');
+  });
+});

--- a/test/error-handler.test.js
+++ b/test/error-handler.test.js
@@ -121,17 +121,27 @@ describe('frameworkErrors injects CORS headers on FST_ERR_BAD_URL (#376)', () =>
     assert.match(r.headers.get('access-control-allow-methods') || '', /GET/);
     assert.ok(r.headers.get('access-control-allow-headers'), 'ACAH must be set');
     assert.ok(r.headers.get('access-control-expose-headers'), 'ACEH must be set');
+    // Body uses HTTP status text ("Bad Request"), not err.name
+    // ("FastifyError") — matches Fastify's default body shape so
+    // any pre-fix client parsing `error` keeps working.
+    const body = await r.json();
+    assert.strictEqual(body.error, 'Bad Request');
+    assert.strictEqual(body.code, 'FST_ERR_BAD_URL');
+    assert.strictEqual(body.statusCode, 400);
   });
 
-  it('also returns CORS headers for the same bad URL even without an Origin (ACAO defaults to *)', async () => {
-    // Non-browser clients without an Origin still get a JSON 400
-    // body — the CORS guard is "only set Allow-* when Origin was
-    // present" (browsers won't enforce CORS in this case anyway).
-    // Confirm the response is still well-shaped JSON and the status
-    // is correct.
+  it('returns CORS headers (ACAO=*) and well-shaped JSON for the same bad URL without an Origin', async () => {
+    // Non-browser clients without an Origin still receive the full
+    // CORS header set — consistent with the rest of the server,
+    // where the global onRequest hook always sets CORS. ACAO
+    // defaults to `*` when no Origin was sent (per getCorsHeaders).
     const r = await fetch(`${baseUrl}/foo%g1`);
     assert.strictEqual(r.status, 400);
+    assert.strictEqual(r.headers.get('access-control-allow-origin'), '*');
+    assert.match(r.headers.get('access-control-allow-methods') || '', /GET/);
+    assert.ok(r.headers.get('access-control-allow-headers'), 'ACAH must be set');
     const body = await r.json();
+    assert.strictEqual(body.error, 'Bad Request');
     assert.strictEqual(body.code, 'FST_ERR_BAD_URL');
     assert.strictEqual(body.statusCode, 400);
   });


### PR DESCRIPTION
Closes #376.

## Before

```bash
$ curl -i -H 'Origin: https://example.com' 'https://example.test/foo%g1'
HTTP/2 400
content-type: application/json
content-length: 116
# (no access-control-* headers)
{"error":"Bad Request","code":"FST_ERR_BAD_URL", ...}
```

Browser-side: surfaces as a generic CORS / network error instead of the real 400, masking the actual failure mode (malformed percent-encoding).

## After

```bash
$ curl -i -H 'Origin: https://example.com' 'https://example.test/foo%g1'
HTTP/2 400
access-control-allow-origin: https://example.com
access-control-allow-methods: GET, HEAD, POST, PUT, DELETE, PATCH, OPTIONS
access-control-allow-headers: Accept, Authorization, Content-Type, DPoP, ...
access-control-expose-headers: Accept-Patch, Accept-Post, ...
access-control-allow-credentials: true
access-control-max-age: 86400
content-type: application/json; charset=utf-8
{"error":"Bad Request","code":"FST_ERR_BAD_URL","message":"'/foo%g1' is not a valid url component","statusCode":400}
```

Browser sees the real 400 and the actual `FST_ERR_BAD_URL` reason. The `error` field uses the HTTP status text ("Bad Request") via `STATUS_CODES[statusCode]`, matching Fastify's default body shape so any pre-fix client that was parsing `error` keeps working.

For non-browser requests (no `Origin` header), CORS headers are still set with `Access-Control-Allow-Origin: *` — consistent with the rest of the server, where the global `onRequest` hook sets CORS unconditionally.

## Root cause

`FST_ERR_BAD_URL` is thrown by Fastify's URL parser BEFORE the request enters the normal handler chain. Direct probe confirmed neither `setErrorHandler` nor `onSend` hooks fire for this code path. Fastify writes the 400 directly via `res.writeHead()` / `res.end()` in `onBadUrl()` (`node_modules/fastify/fastify.js:752–771`) — bypassing every JSS CORS-injecting handler.

## Fix

Configure Fastify's `frameworkErrors` option in `createServer`. This is the explicit hook Fastify provides for framework-level errors (`FST_ERR_BAD_URL`, `FST_ERR_ASYNC_CONSTRAINT`). When set, Fastify routes through this function instead of the direct-write path, giving us a Reply object to attach headers to.

The handler:
- Always calls `getCorsHeaders(request.headers.origin)` and applies the full JSS CORS set — Allow-Origin mirrors the request Origin if present, falls back to `*` if absent
- Sends a JSON body with `error: STATUS_CODES[statusCode]` (HTTP status text, e.g. "Bad Request"), `code` (the Fastify error code, e.g. "FST_ERR_BAD_URL"), `message`, and `statusCode` — same shape as Fastify's default error body

## Test plan

Three new integration tests in `test/error-handler.test.js` against a live JSS server:

- [x] `%g1` with Origin → 400, ACAO mirrors Origin, full CORS set, body `error: "Bad Request"`
- [x] `%g1` without Origin → 400, ACAO=*, full CORS set, body `error: "Bad Request"`
- [x] Normal 404 path (no `FST_ERR`) → CORS still injected by the existing wildcard handler — confirms the new hook didn't displace existing behavior
- [x] Full suite: 777 → 780 pass

## Refs

- #371 — Git-Protocol CORS header
- #374 — `GIT_CORS_HEADERS` const + 4xx return paths (the PR that surfaced this issue)
- Fastify [`frameworkErrors` option](https://fastify.dev/docs/latest/Reference/Server/#frameworkerrors)
