### PR TITLE
auth: did:nostr resolver prefers local index before external (#423)

### DIFF
--- a/src/auth/did-nostr.js
+++ b/src/auth/did-nostr.js
@@ -2,9 +2,12 @@
  * DID:nostr Resolution
  *
  * Resolves did:nostr:<pubkey> to a Solid WebID by:
- * 1. Fetching DID document from nostr.social
- * 2. Extracting alsoKnownAs WebID
- * 3. Verifying bidirectional link (WebID links back to did:nostr)
+ * 1. Trying the in-process local well-known index first (the pod is
+ *    its own authoritative resolver for its accounts — no HTTP)
+ * 2. Falling back to the configured external resolver:
+ *    a. Fetching the DID document
+ *    b. Extracting alsoKnownAs WebID
+ *    c. Verifying bidirectional link (WebID links back to did:nostr)
  */
 
 import { validateExternalUrl } from '../utils/ssrf.js';
@@ -168,12 +171,21 @@ export async function fetchWithRedirectGuard(initialUrl, {
 }
 
 /**
- * Resolve did:nostr pubkey to WebID via DID document.
+ * Resolve did:nostr pubkey to WebID.
  *
- * Local users are resolved by `resolveDidNostrLocally` in the auth
- * caller (well-known-did-nostr.js exports an in-process function) —
- * this resolver is the cross-pod fallback that fetches an external
- * DID doc, so all fetches run through the SSRF guard.
+ * Tries the in-process local well-known index first (the pod is its
+ * own authoritative resolver for its accounts — no HTTP fetch, no
+ * external dependency, no SSRF surface). Falls back to the configured
+ * external resolver (`nostr.social` by default) only for cross-pod
+ * pubkeys that no local account claims.
+ *
+ * This local-first ordering is also enforced in the `verifyNostrAuth`
+ * resolver chain (src/auth/nostr.js). Duplicating it inside the
+ * resolver itself is defense-in-depth: callers from other code paths
+ * (and any future caller that forgets to consult the local index)
+ * still get the cheap, reliable answer for the dominant SSO case
+ * — user signing in to their own pod — even when the external
+ * resolver is unavailable (network down, SSL cert expired, etc.).
  *
  * @param {string} pubkey - 64-char hex Nostr pubkey
  * @param {string} [resolverUrl] - DID resolver base URL (without the
@@ -192,6 +204,24 @@ export async function resolveDidNostrToWebId(pubkey, resolverUrl = DEFAULT_DID_R
     return null;
   }
   pubkey = pubkey.toLowerCase();
+
+  // Local-first: consult the in-process well-known index before any
+  // HTTP fetch. The index is built from local WebID profiles whose
+  // `verificationMethod` declares this Nostr pubkey AND is referenced
+  // from `authentication` (see src/idp/well-known-did-nostr.js) — so
+  // the binding is already verified by construction and we skip the
+  // backlink round-trip required for external answers.
+  //
+  // Dynamic import keeps the IdP module optional: pods built/run
+  // without the IdP layer don't pull it in. Any import or lookup
+  // error falls through to the external resolver.
+  try {
+    const { resolveDidNostrLocally } = await import('../idp/well-known-did-nostr.js');
+    const localWebId = await resolveDidNostrLocally(pubkey);
+    if (localWebId) return localWebId;
+  } catch {
+    // IdP module unavailable or local lookup threw — fall through.
+  }
 
   // Cache key includes the resolver URL because different resolvers
   // can legitimately disagree about the same pubkey (one might have


### PR DESCRIPTION
## Summary

When the requesting Nostr pubkey belongs to a local account, resolve to its WebID via the in-process well-known index instead of round-tripping through the configured external resolver.

Closes #423.

## Why

The dominant SSO case is a user signing into their own pod. With the previous ordering inside `resolveDidNostrToWebId`, that case always reached the configured external resolver (`https://nostr.social/.well-known/did/nostr/<pubkey>` by default). When the external host is unreachable — network outage, expired SSL certificate, etc. — auth fails entirely even though the pod has the authoritative DID document for the user in memory.

Real-world incident that motivated this: `nostr.social`'s SSL certificate expired, causing `fetch()` to fail with `SSRF protection`/`fetch failed` and the user's own write requests to come back 401 because the agent couldn't be resolved to a WebID.

## What

In `src/auth/did-nostr.js`, `resolveDidNostrToWebId` now consults the local well-known index first (via dynamic import of `resolveDidNostrLocally` from `src/idp/well-known-did-nostr.js`) before any HTTP fetch. Falls back to the external resolver only when no local account claims the pubkey, so cross-pod identities still work.

The local binding is already verified by construction — the indexer only admits VMs declared in `verificationMethod` AND referenced from `authentication` of a local profile — so the backlink-verification round-trip the external path requires is also skipped on the local path.

## Defense-in-depth

`verifyNostrAuth` (src/auth/nostr.js) already calls `resolveDidNostrLocally` ahead of `resolveDidNostrToWebId` in its resolver chain. Duplicating the local-first preference inside the resolver itself protects callers from other code paths (and any future caller that forgets the chain ordering) without behavioural cost.

Dynamic import keeps the IdP module optional: pods built/run without IdP don't pull it in, and any import or lookup error falls through to the external resolver.

## Test plan

- [x] All 27 existing `test/did-nostr.test.js` cases pass
- [x] All 100 cases across `test/well-known-did-nostr.test.js`, `test/nostr-event.test.js`, `test/nostr-cid-vm.test.js` pass
- [ ] Manual: deploy to `solid.social` and verify the user's write-after-NIP-98-SSO flow returns the correct WebID without hitting the external resolver. Confirmed locally via `curl` against the pod's own `.well-known/did/nostr/<pubkey>` returning the correct DID document with `alsoKnownAs` pointing at the WebID granted Write in the test ACL.