### PR TITLE
Add CODEOWNERS for reviewer routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# CODEOWNERS — paths that auto-request review from the listed owners.
+#
+# GitHub matches paths in order. The most specific match for a given
+# file wins. The catch-all `*` pattern at the top covers everything
+# else; the path-specific entries below document review responsibility
+# for security-sensitive surfaces explicitly.
+#
+# Format reference:
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default — all files
+*                       @melvincarvalho
+
+# Auth / security-sensitive paths
+/src/auth/              @melvincarvalho
+/src/idp/               @melvincarvalho
+/src/utils/ssrf.js      @melvincarvalho
+
+# CLI and release surface
+/bin/                   @melvincarvalho
+/package.json           @melvincarvalho
+/package-lock.json      @melvincarvalho
+
+# Legal / policy substrate
+/LICENSE                @melvincarvalho
+/CONTRIBUTING.md        @melvincarvalho
+/.github/               @melvincarvalho


### PR DESCRIPTION
Adds `.github/CODEOWNERS` to route GitHub's auto-review-request mechanism for paths that should always get explicit maintainer review.

## Categories

- **Default** (`*`) — all files
- **Auth / security** — `/src/auth/`, `/src/idp/`, `/src/utils/ssrf.js`
- **CLI / release surface** — `/bin/`, `/package.json`, `/package-lock.json`
- **Legal / policy substrate** — `/LICENSE`, `/CONTRIBUTING.md`, `/.github/`

All currently route to `@melvincarvalho`. The per-path breakdown documents review-responsibility intent rather than splitting reviewers — the structure is ready for co-maintainer expansion when J O'Hare onboards (security/release paths stay with the lead, broader code can split).

## Behaviour

CODEOWNERS by itself is *advisory* — it causes GitHub to auto-request review from the listed owners on PRs touching matching paths. Without a branch-protection rule requiring CODEOWNERS approval, it doesn't block merges. That's intentional for now; this PR is the path-mapping side of the work, and protection-rule enforcement can follow later when there's a second maintainer to enforce against.