### PR TITLE
Add LICENSING.md activating AGPL-3.0 + commercial dual-license

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,30 @@
+# Licensing
+
+JSS is distributed under the GNU Affero General Public License v3.0
+(AGPL-3.0) — see [LICENSE](./LICENSE) for the full text.
+
+The AGPL-3.0 is appropriate for most use cases, including
+network-deployed Solid servers (single-user, multi-user, agentic),
+community projects, research deployments, and commercial deployments
+compatible with AGPL terms (including §13 source-availability
+obligations on network-deployed modified versions, and §5(a)
+modification notice requirements).
+
+## Commercial licensing
+
+Commercial licensing is also available for organisations whose
+deployment requirements are incompatible with AGPL-3.0 — for example:
+
+- Organisations whose internal policies forbid AGPL substrate
+- Network-deployed services where source-availability obligations
+  (AGPL §13) cannot be satisfied
+- Embedded or OEM redistribution in proprietary products
+- Integration with proprietary stacks where copyleft contamination
+  is a concern
+
+Custom-licensed deployments are negotiable per-case. Terms typically
+include an annual or multi-year license fee, defined deployment scope
+(per server / per organisation / per use case), and a patent grant.
+
+To inquire about commercial licensing, contact
+`melvincarvalho@gmail.com` with subject prefix `[JSS LICENSING]`.

--- a/README.md
+++ b/README.md
@@ -144,4 +144,5 @@ npm test
 
 ## License
 
-AGPL-3.0-only
+Licensed under [AGPL-3.0](./LICENSE).
+Commercial licensing also available — see [LICENSING.md](./LICENSING.md).


### PR DESCRIPTION
## Summary

- Adds `LICENSING.md` documenting that JSS is dual-licensed: AGPL-3.0 (default) plus commercial licensing available per-case for organisations whose deployment requirements are incompatible with AGPL terms.
- Updates README's License section to reference the new `LICENSING.md`.

## Why

JSS is sole-copyright-held by the maintainer (original authorship plus future contributions assigned via CLA — see `CLA.md` / cla-assistant.io). This activates the public notice that commercial licensing is available, opening an institutional adoption path for organisations that cannot accept AGPL §13 source-availability obligations on network-deployed modified versions.

AGPL-3.0 remains the default license. Commercial licensing is offered per-case at maintainer discretion via the contact path documented in `LICENSING.md`. Nothing about existing AGPL adoption changes.

## Test plan
- [x] `LICENSING.md` renders correctly on GitHub
- [x] README License section links to `LICENSING.md`
- [x] No code changes; documentation only