### PR TITLE
feat: default landing page + ACL at server root (#433, supersedes #303)

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -28,6 +28,7 @@ import { webrtcPlugin } from './webrtc/index.js';
 import { tunnelPlugin } from './tunnel/index.js';
 import { terminalPlugin } from './terminal/index.js';
 import { registerErrorHandler } from './utils/error-handler.js';
+import { seedServerRoot } from './ui/server-root.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -761,6 +762,48 @@ export function createServer(options = {}) {
   fastify.head('/', handleHead);
   fastify.options('/', handleOptions);
   fastify.post('/', writeRateLimit, handlePost);
+
+  // Server-root landing page: seed /index.html and a public-read /.acl
+  // on first start (skip-if-exists, so operator-provided files are
+  // preserved). See #433 / #276. Skipped in read-only deployments so
+  // startup never mutates DATA_ROOT.
+  if (!options.readOnly) {
+    fastify.addHook('onReady', async () => {
+      // A missing or unreadable package.json (some production bundles
+      // omit it) shouldn't block seeding; fall back to "unknown".
+      let version = 'unknown';
+      try {
+        const pkg = await readFile(join(__dirname, '..', 'package.json'), 'utf8');
+        ({ version } = JSON.parse(pkg));
+      } catch (err) {
+        fastify.log.warn({ err }, 'Failed to read package.json version; seeding server root with version=unknown');
+      }
+
+      try {
+        await seedServerRoot({
+          version,
+          singleUser,
+          idp: idpEnabled,
+          singleUserName,
+          enabled: {
+            idp: idpEnabled,
+            nostr: nostrEnabled,
+            webrtc: webrtcEnabled,
+            activitypub: activitypubEnabled,
+            git: gitEnabled,
+            pay: payEnabled,
+            notifications: notificationsEnabled,
+            mashlib: mashlibEnabled,
+            mongo: mongoEnabled,
+            tunnel: tunnelEnabled,
+            terminal: terminalEnabled
+          }
+        });
+      } catch (err) {
+        fastify.log.warn({ err }, 'Failed to seed server root');
+      }
+    });
+  }
 
   // Single-user mode: create pod on startup if it doesn't exist
   if (singleUser) {

--- a/src/ui/server-root.html
+++ b/src/ui/server-root.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{title}}</title>
+  <meta name="description" content="A personal data server powered by JSS">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: Georgia, 'Times New Roman', serif;
+      background: #fafaf8;
+      color: #2c2c2c;
+      line-height: 1.7;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+    }
+    .container { max-width: 560px; width: 100%; }
+    h1 { font-size: 2.2rem; font-weight: 400; margin-bottom: 0.25rem; }
+    .subtitle { color: #666; font-size: 1.05rem; margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid #ddd; }
+    p { margin-bottom: 1.25rem; }
+    .actions { display: flex; gap: 0.75rem; margin: 1.5rem 0 2rem; flex-wrap: wrap; }
+    .btn {
+      display: inline-block;
+      padding: 0.6rem 1.2rem;
+      border-radius: 4px;
+      text-decoration: none;
+      font-family: Georgia, serif;
+      font-size: 0.95rem;
+      border: 1px solid transparent;
+      cursor: pointer;
+      transition: all 0.1s;
+    }
+    .btn-primary { background: #7c3aed; color: #fff; }
+    .btn-primary:hover { background: #6025c0; }
+    .btn-secondary { background: #fff; color: #2c2c2c; border-color: #ccc; }
+    .btn-secondary:hover { background: #f0efeb; }
+    .info { background: #f5f4f0; border-radius: 4px; padding: 1rem; font-size: 0.85rem; color: #666; margin-top: 1.5rem; }
+    .info .row { display: flex; justify-content: space-between; padding: 0.2rem 0; }
+    .info .label { color: #999; }
+    .info code { font-family: 'SFMono-Regular', Consolas, monospace; font-size: 0.9em; color: #555; }
+    footer { margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #ddd; color: #999; font-size: 0.8rem; text-align: center; }
+    footer a { color: #888; }
+    .features { font-size: 0.85rem; color: #666; margin-top: 0.5rem; }
+    .features span { display: inline-block; background: #eee; padding: 0.15rem 0.5rem; border-radius: 3px; margin-right: 0.3rem; margin-bottom: 0.3rem; font-family: 'SFMono-Regular', Consolas, monospace; font-size: 0.8rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>{{heading}}</h1>
+    <div class="subtitle">{{subtitle}}</div>
+    <p>{{description}}</p>
+
+    {{actions}}
+
+    <div class="info">
+      <div class="row"><span class="label">Version</span><code>{{version}}</code></div>
+      <div class="row"><span class="label">Mode</span><code>{{mode}}</code></div>
+      <div class="features">{{features}}</div>
+    </div>
+
+    <footer>
+      Powered by <a href="https://jss.live">JSS</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/src/ui/server-root.js
+++ b/src/ui/server-root.js
@@ -79,20 +79,28 @@ export function renderServerRoot(ctx = {}) {
     ? 'This server hosts a personal data pod. Apps come to the data rather than the other way around.'
     : 'This server hosts personal data pods on the web. Each pod is a space you own, with your own identity and access control.';
 
-  // Replacements use the function form, not the string form: a string
-  // replacement interprets `$&`, `$1`, etc. as substitution patterns,
-  // which would corrupt any interpolated value containing a `$` (e.g.
-  // a single-user name). The function form skips that interpretation
-  // entirely. See #433.
-  return tpl
-    .replace(/{{title}}/g, () => heading)
-    .replace(/{{heading}}/g, () => heading)
-    .replace(/{{subtitle}}/g, () => subtitle)
-    .replace(/{{description}}/g, () => description)
-    .replace(/{{actions}}/g, () => renderActions({ singleUser, idp }))
-    .replace(/{{version}}/g, () => escape(version))
-    .replace(/{{mode}}/g, () => mode)
-    .replace(/{{features}}/g, () => features);
+  // Single-pass token substitution. Sequential .replace() calls would
+  // re-scan already-substituted values, so a `singleUserName` of e.g.
+  // `{{actions}}` would land inside `subtitle`, then get expanded by
+  // the later `.replace(/{{actions}}/g, …)` — letting a pod owner
+  // inject other template fragments via their name. With a single
+  // pass over the original template, each {{token}} is matched once
+  // and replaced with its value; `$` inside any value is also harmless
+  // because the function form of replace skips substitution patterns.
+  // See #433 review thread.
+  const values = {
+    title: heading,
+    heading,
+    subtitle,
+    description,
+    actions: renderActions({ singleUser, idp }),
+    version: escape(version),
+    mode,
+    features
+  };
+  return tpl.replace(/{{(\w+)}}/g, (match, key) =>
+    Object.prototype.hasOwnProperty.call(values, key) ? values[key] : match
+  );
 }
 
 function escape(s = '') {

--- a/src/ui/server-root.js
+++ b/src/ui/server-root.js
@@ -137,18 +137,27 @@ export async function seedServerRoot(ctx = {}) {
 
   // Seed /.acl if one doesn't already exist. Public read on the container
   // itself — so GET / serves the landing page. Independent of index.html.
+  //
+  // Use './' (relative to the .acl's own URL) rather than '/' (the
+  // origin root). The two coincide when JSS is mounted at the origin
+  // root, but only the relative form survives reverse-proxy mounts at
+  // a path prefix (e.g. https://example/jss/). This matches the
+  // pattern used by createPodStructure / createRootPodStructure since
+  // #428 / #430.
+  //
   // (createRootPodStructure in single-user mode writes its own ACL and
   // runs in a later hook, which will overwrite this if needed.)
   if (!(await storage.exists('/.acl'))) {
-    const ok = await storage.write('/.acl', serializeAcl(generatePublicReadAcl('/')));
+    const ok = await storage.write('/.acl', serializeAcl(generatePublicReadAcl('./')));
     if (ok) seededAcl = true;
   }
 
   // Dedicated ACL for the landing page itself — public read. The container
   // ACL above has no acl:default (we don't want to implicitly publish all
   // children), so /index.html needs its own rule when fetched directly.
+  // Same relative-form rationale as above.
   if (!(await storage.exists('/index.html.acl'))) {
-    const ok = await storage.write('/index.html.acl', serializeAcl(generatePublicReadAcl('/index.html')));
+    const ok = await storage.write('/index.html.acl', serializeAcl(generatePublicReadAcl('./index.html')));
     if (ok) seededPageAcl = true;
   }
 

--- a/src/ui/server-root.js
+++ b/src/ui/server-root.js
@@ -1,0 +1,156 @@
+/**
+ * Server-root landing page.
+ *
+ * Renders src/ui/server-root.html with runtime values, and seeds
+ * DATA_ROOT/index.html + DATA_ROOT/.acl on first start (skip-if-exists,
+ * so operator customisation is preserved).
+ *
+ * See issue #276.
+ */
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import * as storage from '../storage/filesystem.js';
+import { generatePublicReadAcl, serializeAcl } from '../wac/parser.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEMPLATE_PATH = join(__dirname, 'server-root.html');
+
+/**
+ * Collect the list of enabled features for display on the landing page.
+ */
+function listFeatures(options = {}) {
+  const f = [];
+  if (options.idp) f.push('idp');
+  if (options.nostr) f.push('nostr');
+  if (options.webrtc) f.push('webrtc');
+  if (options.activitypub) f.push('activitypub');
+  if (options.git) f.push('git');
+  if (options.pay) f.push('payments');
+  if (options.notifications) f.push('notifications');
+  if (options.mashlib) f.push('mashlib');
+  if (options.mongo) f.push('mongo');
+  if (options.tunnel) f.push('tunnel');
+  if (options.terminal) f.push('terminal');
+  return f;
+}
+
+/**
+ * Build an HTML snippet of action buttons based on server mode.
+ */
+function renderActions({ singleUser, idp }) {
+  const buttons = [];
+  if (!singleUser && idp) {
+    buttons.push('<a href="/idp/register" class="btn btn-primary">Create a pod</a>');
+    buttons.push('<a href="/idp" class="btn btn-secondary">Sign in</a>');
+  } else if (singleUser && idp) {
+    buttons.push('<a href="/idp" class="btn btn-primary">Sign in</a>');
+  }
+  buttons.push('<a href="https://javascriptsolidserver.github.io/docs/" class="btn btn-secondary">Docs</a>');
+  return `<div class="actions">${buttons.join('\n      ')}</div>`;
+}
+
+/**
+ * Render the landing page as an HTML string.
+ *
+ * @param {object} ctx
+ * @param {string} ctx.version - JSS version
+ * @param {boolean} [ctx.singleUser]
+ * @param {boolean} [ctx.idp]
+ * @param {string} [ctx.singleUserName]
+ * @param {object} [ctx.enabled] - Map of feature flags
+ * @returns {string} HTML
+ */
+export function renderServerRoot(ctx = {}) {
+  const { version = 'unknown', singleUser = false, idp = false, singleUserName, enabled = {} } = ctx;
+
+  const tpl = readFileSync(TEMPLATE_PATH, 'utf8');
+  const mode = singleUser ? 'single-user' : 'multi-user';
+  const features = listFeatures(enabled)
+    .map(f => `<span>${f}</span>`)
+    .join(' ');
+
+  const heading = 'JSS';
+  const subtitle = singleUser
+    ? `Personal pod${singleUserName && singleUserName !== '/' ? ` for ${escape(singleUserName)}` : ''}`
+    : 'A personal data server';
+  const description = singleUser
+    ? 'This server hosts a personal data pod. Apps come to the data rather than the other way around.'
+    : 'This server hosts personal data pods on the web. Each pod is a space you own, with your own identity and access control.';
+
+  // Replacements use the function form, not the string form: a string
+  // replacement interprets `$&`, `$1`, etc. as substitution patterns,
+  // which would corrupt any interpolated value containing a `$` (e.g.
+  // a single-user name). The function form skips that interpretation
+  // entirely. See #433.
+  return tpl
+    .replace(/{{title}}/g, () => heading)
+    .replace(/{{heading}}/g, () => heading)
+    .replace(/{{subtitle}}/g, () => subtitle)
+    .replace(/{{description}}/g, () => description)
+    .replace(/{{actions}}/g, () => renderActions({ singleUser, idp }))
+    .replace(/{{version}}/g, () => escape(version))
+    .replace(/{{mode}}/g, () => mode)
+    .replace(/{{features}}/g, () => features);
+}
+
+function escape(s = '') {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+
+/**
+ * Seed DATA_ROOT/index.html, DATA_ROOT/.acl and DATA_ROOT/index.html.acl
+ * if they don't already exist. Operator's own files are never overwritten.
+ *
+ * Default ACL: public read. No write access — the operator edits
+ * /index.html on disk, not via the web.
+ *
+ * If the HTML write fails (permissions, full disk, read-only DATA_ROOT),
+ * ACL seeding is aborted to avoid leaving the server with a public-read
+ * root ACL and no index page.
+ *
+ * @param {object} ctx - Same context passed to renderServerRoot
+ * @returns {Promise<{seededHtml: boolean, seededAcl: boolean, seededPageAcl: boolean}>}
+ */
+export async function seedServerRoot(ctx = {}) {
+  let seededHtml = false;
+  let seededAcl = false;
+  let seededPageAcl = false;
+
+  // Seed /index.html if operator hasn't written one.
+  if (!(await storage.exists('/index.html'))) {
+    const html = renderServerRoot(ctx);
+    const ok = await storage.write('/index.html', html);
+    if (!ok) {
+      // Don't proceed with ACLs if the page itself failed to write —
+      // leaves us in a consistent unchanged state.
+      return { seededHtml: false, seededAcl: false, seededPageAcl: false };
+    }
+    seededHtml = true;
+  }
+
+  // Seed /.acl if one doesn't already exist. Public read on the container
+  // itself — so GET / serves the landing page. Independent of index.html.
+  // (createRootPodStructure in single-user mode writes its own ACL and
+  // runs in a later hook, which will overwrite this if needed.)
+  if (!(await storage.exists('/.acl'))) {
+    const ok = await storage.write('/.acl', serializeAcl(generatePublicReadAcl('/')));
+    if (ok) seededAcl = true;
+  }
+
+  // Dedicated ACL for the landing page itself — public read. The container
+  // ACL above has no acl:default (we don't want to implicitly publish all
+  // children), so /index.html needs its own rule when fetched directly.
+  if (!(await storage.exists('/index.html.acl'))) {
+    const ok = await storage.write('/index.html.acl', serializeAcl(generatePublicReadAcl('/index.html')));
+    if (ok) seededPageAcl = true;
+  }
+
+  return { seededHtml, seededAcl, seededPageAcl };
+}

--- a/test/server-root.test.js
+++ b/test/server-root.test.js
@@ -30,6 +30,24 @@ describe('Server-root landing page', () => {
     const res = await request('/index.html');
     assertStatus(res, 200);
   });
+
+  // Portability regression: the seeded ACLs must use './' (resolved
+  // against the .acl's own URL) rather than '/' (the origin root).
+  // The two coincide when JSS sits at the origin root, so a request
+  // smoke-test would pass either way; only direct inspection of the
+  // serialized accessTo catches a regression to the absolute form.
+  // Without this, JSS mounted under a reverse-proxy path prefix would
+  // see the seeded ACL match the origin root rather than the prefix.
+  it('seeded ACLs use relative resourceUrl ("./" / "./index.html"), not absolute paths', async () => {
+    const rootAcl = JSON.parse(await fs.readFile('./data/.acl', 'utf8'));
+    const pageAcl = JSON.parse(await fs.readFile('./data/index.html.acl', 'utf8'));
+    const rootAccessTo = rootAcl['@graph'][0]['acl:accessTo']['@id'];
+    const pageAccessTo = pageAcl['@graph'][0]['acl:accessTo']['@id'];
+    assert.strictEqual(rootAccessTo, './',
+      `Expected /.acl accessTo to be relative './', got '${rootAccessTo}'`);
+    assert.strictEqual(pageAccessTo, './index.html',
+      `Expected /index.html.acl accessTo to be relative './index.html', got '${pageAccessTo}'`);
+  });
 });
 
 // Operator's existing /index.html is preserved — dedicated server + data dir.

--- a/test/server-root.test.js
+++ b/test/server-root.test.js
@@ -1,0 +1,152 @@
+/**
+ * Server-root landing page seed (#276).
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs-extra';
+import { createServer } from '../src/server.js';
+import { renderServerRoot } from '../src/ui/server-root.js';
+import { startTestServer, stopTestServer, request, assertStatus } from './helpers.js';
+
+describe('Server-root landing page', () => {
+  before(async () => {
+    await startTestServer();
+  });
+
+  after(async () => {
+    await stopTestServer();
+  });
+
+  it('seeds /index.html so GET / serves HTML', async () => {
+    const res = await request('/', { headers: { Accept: 'text/html' } });
+    assertStatus(res, 200);
+    const body = await res.text();
+    assert.match(body, /<title>JSS<\/title>/);
+    assert.match(body, /A personal data server/);
+  });
+
+  it('landing page is publicly readable (no auth required)', async () => {
+    const res = await request('/index.html');
+    assertStatus(res, 200);
+  });
+});
+
+// Operator's existing /index.html is preserved — dedicated server + data dir.
+describe('Server-root landing — operator override', () => {
+  let server;
+  let baseUrl;
+  let savedDataRoot;
+  const DATA_DIR = './test-data-server-root-override';
+  const CUSTOM_HTML = '<!doctype html><html><body>my custom page</body></html>';
+
+  before(async () => {
+    // Capture process.env.DATA_ROOT — createServer mutates it when options.root
+    // is provided. Restore in after() to avoid cross-test interference with
+    // suites that rely on the default ./data dir.
+    savedDataRoot = process.env.DATA_ROOT;
+
+    await fs.remove(DATA_DIR);
+    await fs.ensureDir(DATA_DIR);
+    await fs.writeFile(`${DATA_DIR}/index.html`, CUSTOM_HTML);
+
+    server = createServer({
+      logger: false,
+      root: DATA_DIR,
+      forceCloseConnections: true,
+    });
+    await server.listen({ port: 0, host: '127.0.0.1' });
+    baseUrl = `http://127.0.0.1:${server.server.address().port}`;
+  });
+
+  after(async () => {
+    await server.close();
+    await fs.remove(DATA_DIR);
+    if (savedDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = savedDataRoot;
+  });
+
+  it('does not overwrite operator-provided /index.html', async () => {
+    const current = await fs.readFile(`${DATA_DIR}/index.html`, 'utf8');
+    assert.strictEqual(current, CUSTOM_HTML);
+  });
+
+  it('GET / serves operator custom page', async () => {
+    const res = await fetch(`${baseUrl}/`, { headers: { Accept: 'text/html' } });
+    assert.strictEqual(res.status, 200);
+    const body = await res.text();
+    assert.match(body, /my custom page/);
+  });
+});
+
+describe('renderServerRoot — mode-specific output', () => {
+  it('multi-user + IDP shows Create a pod + Sign in', () => {
+    const html = renderServerRoot({ version: '1.0.0', singleUser: false, idp: true });
+    assert.match(html, /Create a pod/);
+    assert.match(html, /href="\/idp\/register"/);
+    assert.match(html, /href="\/idp"/);
+    assert.match(html, /Sign in/);
+  });
+
+  it('single-user + IDP shows Sign in only (no Create a pod)', () => {
+    const html = renderServerRoot({ version: '1.0.0', singleUser: true, idp: true, singleUserName: 'alice' });
+    assert.doesNotMatch(html, /Create a pod/);
+    assert.match(html, /Sign in/);
+  });
+
+  it('multi-user without IDP shows only the Docs link', () => {
+    const html = renderServerRoot({ version: '1.0.0', singleUser: false, idp: false });
+    assert.doesNotMatch(html, /Create a pod/);
+    assert.doesNotMatch(html, /Sign in/);
+    assert.match(html, /Docs/);
+  });
+
+  it('single-user subtitle includes the pod name when provided', () => {
+    const html = renderServerRoot({ version: '1.0.0', singleUser: true, idp: false, singleUserName: 'alice' });
+    assert.match(html, /Personal pod for alice/);
+  });
+
+  it('lists enabled features', () => {
+    const html = renderServerRoot({
+      version: '1.0.0',
+      singleUser: false,
+      idp: true,
+      enabled: { idp: true, nostr: true, webrtc: true, terminal: true }
+    });
+    assert.match(html, /<span>idp<\/span>/);
+    assert.match(html, /<span>nostr<\/span>/);
+    assert.match(html, /<span>webrtc<\/span>/);
+    assert.match(html, /<span>terminal<\/span>/);
+  });
+
+  it('interpolates version', () => {
+    const html = renderServerRoot({ version: '9.9.9' });
+    assert.match(html, /<code>9\.9\.9<\/code>/);
+  });
+
+  it('escapes version to prevent injection', () => {
+    const html = renderServerRoot({ version: '<script>alert(1)</script>' });
+    assert.doesNotMatch(html, /<script>alert\(1\)<\/script>/);
+    assert.match(html, /&lt;script&gt;/);
+  });
+
+  // Regression for the `$&` substitution gotcha (#433): a string used as
+  // the second argument of String.prototype.replace interprets `$&`,
+  // `$1`, etc. as substitution patterns. Interpolated values can contain
+  // `$` (notably a singleUserName), so the renderer uses the function
+  // form of replace instead. Asserting the literal `$&` survives the
+  // round-trip would mean it survived as plain text.
+  it('preserves $-patterns in singleUserName instead of treating them as replacement specials', () => {
+    const html = renderServerRoot({
+      version: '1.0.0',
+      singleUser: true,
+      idp: false,
+      singleUserName: 'foo$&bar'
+    });
+    // The HTML escape converts `&` to `&amp;`; the rest must stay verbatim,
+    // not be replaced by the matched template token.
+    assert.match(html, /Personal pod for foo\$&amp;bar/,
+      'singleUserName containing "$&" should land as-is, not trigger String.replace substitution');
+    assert.doesNotMatch(html, /\{\{subtitle\}\}/, 'subtitle token should be fully consumed');
+  });
+});

--- a/test/server-root.test.js
+++ b/test/server-root.test.js
@@ -148,6 +148,28 @@ describe('renderServerRoot — mode-specific output', () => {
     assert.match(html, /&lt;script&gt;/);
   });
 
+  // Regression for token re-scanning (#433 review thread): if the
+  // renderer ran a chain of sequential .replace() calls, a value
+  // containing a literal `{{actions}}` would land inside the subtitle
+  // and then get expanded by the later `.replace(/{{actions}}/g, ...)`,
+  // letting any pod owner inject other template fragments via their
+  // singleUserName. The single-pass substitution prevents that.
+  it('does not re-scan substituted values for further template tokens', () => {
+    const html = renderServerRoot({
+      version: '1.0.0',
+      singleUser: true,
+      idp: false,
+      // The HTML escape only touches & < > " — { } pass through, so the
+      // token would land in the output verbatim if the substitution were
+      // multi-pass.
+      singleUserName: 'evil{{actions}}name'
+    });
+    assert.match(html, /Personal pod for evil\{\{actions\}\}name/,
+      'singleUserName containing a template token should appear as plain text, not be re-templated');
+    // Sanity: the real {{actions}} slot is still resolved (Docs link is always present).
+    assert.match(html, /href="https:\/\/javascriptsolidserver\.github\.io\/docs/);
+  });
+
   // Regression for the `$&` substitution gotcha (#433): a string used as
   // the second argument of String.prototype.replace interprets `$&`,
   // `$1`, etc. as substitution patterns. Interpolated values can contain


### PR DESCRIPTION
## Summary
- Seed `DATA_ROOT/index.html` + `DATA_ROOT/.acl` + `DATA_ROOT/index.html.acl` on first start with a minimal landing page and public-read ACLs. Skip-if-exists — operator files are preserved.
- Landing page adapts to server mode (multi-user + IDP / single-user + IDP / no-IDP) and lists enabled features.
- Skipped entirely in read-only mode so startup never mutates DATA_ROOT.
- Closes #433. Phase 3 of #427. **Supersedes #303** (open since April 23, `mergeable: CONFLICTING`).

## Why this lands now

PR #303 stalled because the original design had to coexist with `createRootPodStructure` writing absolute-URI ACLs. Now that #428 (Phase 1) and #430 (Phase 2) made the generators emit relative `accessTo`/`default`/`agent`, the seeded `/.acl` is portable by construction — no design tension, no special-casing.

## Carried over from PR #303

This branch picks up the design + the entire Copilot review thread that went unaddressed on the original branch:

- `generatePublicReadAcl` reuse (no inline ACL JSON)
- skip seeding in read-only deployments
- check `storage.write` returns; abort ACL seeding if the HTML write fails (so we never end up with a public-read root ACL but no index page)
- real IDP routes (`/idp/register`, `/idp` — not the non-existent `/.account/new` and `/idp/auth`)
- full error logging (with stack)
- terminal feature flag
- resilient `package.json` read with `version="unknown"` fallback
- restore `process.env.DATA_ROOT` after the operator-override test

## Additional fix (one Copilot nit that was flagged but never landed)

`String.prototype.replace` with a string interprets `$&`, `$1`, etc. as substitution patterns. Interpolated values can transitively contain `$` characters (notably `singleUserName`), so any pod owner with a `$` in their name would have produced corrupted HTML. All template substitutions now use the function form (`replace(/{{key}}/g, () => value)`). Regression test asserts a `singleUserName` of `foo$&bar` survives intact.

## Tests

- 12 new tests in `test/server-root.test.js`:
  - 2 server-root integration tests (seeded HTML on `GET /`, public-read on direct `/index.html` fetch)
  - 2 operator-override tests (pre-write a custom `/index.html`, assert it isn't overwritten and `GET /` serves it)
  - 7 mode-specific renderer tests (multi-user + IDP buttons, single-user-only Sign-in, no-IDP Docs-only, single-user subtitle, feature listing, version interpolation, version XSS escape)
  - 1 regression for the `$&` substitution gotcha
- 811/811 existing tests pass.

## Test plan
- [x] `npm test` — 811/811 passing locally
- [x] Phase 3 tests cover seed + operator-override + mode-aware rendering + `$&` regression

## Out of scope
- `--admin-webid` / web-edit access for the landing page — future iteration.
- Cross-host owner write — Phase 4 of #427, separate design issue.

Closes #433. Closes #303 (superseded).
