### PR TITLE
fix: flip Get started CTA to /first-run (#440)

### DIFF
--- a/src/ui/server-root.html
+++ b/src/ui/server-root.html
@@ -62,7 +62,7 @@
     <p class="explainer">This is a Solid pod server. Solid is an open standard for personal data — your data lives in pods you own, and apps connect to it.</p>
 
     <div class="actions">
-      <a href="https://jss.live/docs/getting-started/introduction" class="btn btn-primary">Get started →</a>
+      <a href="https://jss.live/docs/getting-started/first-run" class="btn btn-primary">Get started →</a>
       <!-- IdP links are written page-relative (no leading slash) so they
            resolve against document base, surviving reverse-proxy mounts
            at a path prefix (e.g. https://example/jss/). Origin-root

--- a/test/server-root.test.js
+++ b/test/server-root.test.js
@@ -132,12 +132,12 @@ describe('renderServerRoot', () => {
     assert.doesNotMatch(html, /class="info"/);
   });
 
-  it('always emits the Get started button pointing at the docs introduction', () => {
+  it('always emits the Get started button pointing at the docs First Run page', () => {
     const html = renderServerRoot({ version: '1.0.0' });
-    // The canonical URL is the introduction page, not the category.
-    // Docusaurus 3 doesn't auto-generate a category index page, so
-    // /docs/getting-started/ would 404. Link to the real document.
-    assert.match(html, /href="https:\/\/jss\.live\/docs\/getting-started\/introduction"/);
+    // First Run is the friendly "you just installed it, now what?"
+    // walkthrough — better destination for a first-time installer than
+    // the encyclopedic Introduction page. See #440.
+    assert.match(html, /href="https:\/\/jss\.live\/docs\/getting-started\/first-run"/);
     assert.match(html, /Get started/);
   });
 


### PR DESCRIPTION
## Summary
Flip the seeded landing's primary CTA from `/docs/getting-started/introduction` to `/docs/getting-started/first-run`. The new First Run page (merged in [JavaScriptSolidServer/docs#14](https://github.com/JavaScriptSolidServer/docs/pull/14)) is the friendly "you just installed it, now what?" walkthrough — better destination for a first-time installer than the encyclopedic Introduction page.

## Test plan
- [x] `npm test` — server-root tests pass with the updated assertion
- [x] Anchor href in template + test assertion both updated to `/first-run`

Closes #440.