### PR TITLE
feat: Phase 2 — wire owner key into WebID profile + did:nostr controller (#443)

### DIFF
--- a/src/handlers/container.js
+++ b/src/handlers/container.js
@@ -190,8 +190,24 @@ export async function createPodStructure(name, webId, podUri, issuer, defaultQuo
   await storage.createContainer(`${podPath}settings/`);
   await storage.createContainer(`${podPath}profile/`);
 
-  // Generate and write WebID profile at /profile/card.jsonld
-  const profile = generateProfile({ webId, name, podUri, issuer });
+  // Optional: provision a Schnorr secp256k1 owner key. The keypair is
+  // generated up-front so the public side can be injected into the
+  // WebID profile's verificationMethod array before the profile is
+  // written. Phase 2 of #437 (#443) — see src/keys/provision.js for
+  // the design notes. The on-disk secret file is written last so a
+  // failure during ACL setup doesn't leave a key without protection.
+  // Strict `=== true` (not just truthy) so a misconfigured caller
+  // passing `'true'` / `1` / etc. doesn't silently activate; matches
+  // handleCreatePod's HTTP-side check on the body field.
+  const ownerKey = options.provisionKeys === true
+    ? provisionOwnerKey({ webId })
+    : null;
+
+  // Generate and write WebID profile at /profile/card.jsonld. When
+  // an owner key was provisioned, its VM lands in the profile so the
+  // existing LWS-CID verifier (src/auth/lws-cid.js) can authenticate
+  // JWTs signed with the matching secret.
+  const profile = generateProfile({ webId, name, podUri, issuer, ownerVm: ownerKey?.vm });
   await storage.write(`${podPath}profile/card.jsonld`, serialize(profile));
 
   // Generate and write preferences
@@ -248,18 +264,14 @@ export async function createPodStructure(name, webId, podUri, issuer, defaultQuo
     await initializeQuota(name, defaultQuota);
   }
 
-  // Optional: provision a Schnorr secp256k1 owner key in /private/.
-  // Phase 1 of #437. See src/keys/provision.js for the design notes.
+  // Owner-key file is written last (after the rest of the pod
+  // structure exists) so a failure during ACL setup doesn't leave a
+  // secret on disk without proper protection. The keypair itself was
+  // generated up-front for profile injection; this step persists it.
   // Throw on write failure so the caller's cleanup path runs and the
   // pod isn't left with a phantom `ownerKey` in the response that
   // doesn't correspond to any on-disk file.
-  //
-  // Strict `=== true` (not just truthy) so a misconfigured caller
-  // passing `'true'` / `1` / etc. doesn't silently activate. Matches
-  // handleCreatePod's HTTP-side check on the body field.
-  let ownerKey;
-  if (options.provisionKeys === true) {
-    ownerKey = provisionOwnerKey({ controllerWebId: webId });
+  if (ownerKey) {
     const ok = await storage.write(
       `${podPath}private/privkey.jsonld`,
       JSON.stringify(ownerKey.document, null, 2),
@@ -272,7 +284,11 @@ export async function createPodStructure(name, webId, podUri, issuer, defaultQuo
     }
   }
 
-  return { podPath, podUri, ownerKey };
+  // Spread `ownerKey` only when set so the field is genuinely absent
+  // (not `null`) on the no-provisioning path — matches the existing
+  // test expectation that `result.ownerKey === undefined` when the
+  // flag was omitted.
+  return { podPath, podUri, ...(ownerKey && { ownerKey }) };
 }
 
 /**

--- a/src/handlers/container.js
+++ b/src/handlers/container.js
@@ -191,11 +191,14 @@ export async function createPodStructure(name, webId, podUri, issuer, defaultQuo
   await storage.createContainer(`${podPath}profile/`);
 
   // Optional: provision a Schnorr secp256k1 owner key. The keypair is
-  // generated up-front so the public side can be injected into the
-  // WebID profile's verificationMethod array before the profile is
-  // written. Phase 2 of #437 (#443) — see src/keys/provision.js for
-  // the design notes. The on-disk secret file is written last so a
-  // failure during ACL setup doesn't leave a key without protection.
+  // generated in memory up-front so its VM can be injected into the
+  // WebID profile, then persisted to /private/privkey.jsonld *before*
+  // the profile is written. This ordering matters: the WebID
+  // profile advertises the VM, so a crash between profile and privkey
+  // would leave the WebID permanently advertising an authentication
+  // method whose secret was never persisted (#444 review). Writing
+  // privkey first means the worst-case crash leaves an orphan secret
+  // file (easy to delete) rather than an orphan VM in a public profile.
   // Strict `=== true` (not just truthy) so a misconfigured caller
   // passing `'true'` / `1` / etc. doesn't silently activate; matches
   // handleCreatePod's HTTP-side check on the body field.
@@ -203,10 +206,24 @@ export async function createPodStructure(name, webId, podUri, issuer, defaultQuo
     ? provisionOwnerKey({ webId })
     : null;
 
+  if (ownerKey) {
+    const ok = await storage.write(
+      `${podPath}private/privkey.jsonld`,
+      JSON.stringify(ownerKey.document, null, 2),
+      { mode: 0o600 }
+    );
+    if (!ok) {
+      throw new Error(
+        `Failed to write owner key file at ${podPath}private/privkey.jsonld`
+      );
+    }
+  }
+
   // Generate and write WebID profile at /profile/card.jsonld. When
   // an owner key was provisioned, its VM lands in the profile so the
   // existing LWS-CID verifier (src/auth/lws-cid.js) can authenticate
-  // JWTs signed with the matching secret.
+  // JWTs signed with the matching secret. The privkey file already
+  // exists on disk at this point — see ordering rationale above.
   const profile = generateProfile({ webId, name, podUri, issuer, ownerVm: ownerKey?.vm });
   await storage.write(`${podPath}profile/card.jsonld`, serialize(profile));
 
@@ -264,25 +281,8 @@ export async function createPodStructure(name, webId, podUri, issuer, defaultQuo
     await initializeQuota(name, defaultQuota);
   }
 
-  // Owner-key file is written last (after the rest of the pod
-  // structure exists) so a failure during ACL setup doesn't leave a
-  // secret on disk without proper protection. The keypair itself was
-  // generated up-front for profile injection; this step persists it.
-  // Throw on write failure so the caller's cleanup path runs and the
-  // pod isn't left with a phantom `ownerKey` in the response that
-  // doesn't correspond to any on-disk file.
-  if (ownerKey) {
-    const ok = await storage.write(
-      `${podPath}private/privkey.jsonld`,
-      JSON.stringify(ownerKey.document, null, 2),
-      { mode: 0o600 }
-    );
-    if (!ok) {
-      throw new Error(
-        `Failed to write owner key file at ${podPath}private/privkey.jsonld`
-      );
-    }
-  }
+  // (privkey was written above, before the profile, to avoid
+  // orphan-VM-on-crash. Nothing more to do here.)
 
   // Spread `ownerKey` only when set so the field is genuinely absent
   // (not `null`) on the no-provisioning path — matches the existing

--- a/src/handlers/container.js
+++ b/src/handlers/container.js
@@ -192,40 +192,18 @@ export async function createPodStructure(name, webId, podUri, issuer, defaultQuo
 
   // Optional: provision a Schnorr secp256k1 owner key. The keypair is
   // generated in memory up-front so its VM can be injected into the
-  // WebID profile, then persisted to /private/privkey.jsonld *before*
-  // the profile is written. This ordering matters: the WebID
-  // profile advertises the VM, so a crash between profile and privkey
-  // would leave the WebID permanently advertising an authentication
-  // method whose secret was never persisted (#444 review). Writing
-  // privkey first means the worst-case crash leaves an orphan secret
-  // file (easy to delete) rather than an orphan VM in a public profile.
-  // Strict `=== true` (not just truthy) so a misconfigured caller
-  // passing `'true'` / `1` / etc. doesn't silently activate; matches
-  // handleCreatePod's HTTP-side check on the body field.
+  // WebID profile that gets written last. The on-disk persistence of
+  // the secret is deferred to *after* the ACL tree is in place — see
+  // the ordering block further below. Strict `=== true` (not just
+  // truthy) so a misconfigured caller passing `'true'` / `1` / etc.
+  // doesn't silently activate; matches handleCreatePod's HTTP-side
+  // check on the body field.
   const ownerKey = options.provisionKeys === true
     ? provisionOwnerKey({ webId })
     : null;
 
-  if (ownerKey) {
-    const ok = await storage.write(
-      `${podPath}private/privkey.jsonld`,
-      JSON.stringify(ownerKey.document, null, 2),
-      { mode: 0o600 }
-    );
-    if (!ok) {
-      throw new Error(
-        `Failed to write owner key file at ${podPath}private/privkey.jsonld`
-      );
-    }
-  }
-
-  // Generate and write WebID profile at /profile/card.jsonld. When
-  // an owner key was provisioned, its VM lands in the profile so the
-  // existing LWS-CID verifier (src/auth/lws-cid.js) can authenticate
-  // JWTs signed with the matching secret. The privkey file already
-  // exists on disk at this point — see ordering rationale above.
-  const profile = generateProfile({ webId, name, podUri, issuer, ownerVm: ownerKey?.vm });
-  await storage.write(`${podPath}profile/card.jsonld`, serialize(profile));
+  // Profile is written last (see the ACL/privkey block below). Skip
+  // the write here; we'll do it after privkey lands on disk.
 
   // Generate and write preferences
   const prefs = generatePreferences({ webId, podUri });
@@ -281,8 +259,43 @@ export async function createPodStructure(name, webId, podUri, issuer, defaultQuo
     await initializeQuota(name, defaultQuota);
   }
 
-  // (privkey was written above, before the profile, to avoid
-  // orphan-VM-on-crash. Nothing more to do here.)
+  // Owner-key persistence + profile write (when --provision-keys is on).
+  // Order is load-bearing for two distinct concerns (#444 review):
+  //
+  //   1. WAC vacuum: write privkey *after* the ACL tree is in place so
+  //      the secret file is born under owner-only WAC. Without this,
+  //      there's a window where the file exists but no /private/.acl
+  //      protects it; jss's deny-by-default since #f43ecdf would
+  //      mitigate to 401, but defence-in-depth beats relying on a
+  //      security default holding.
+  //
+  //   2. Orphan-VM: write privkey *before* the profile so a crash
+  //      between the two leaves an orphan secret file (easy to delete)
+  //      rather than an orphan VM in a published WebID profile that
+  //      forever advertises an authentication method whose secret was
+  //      never persisted.
+  //
+  // Combined: ACLs (above) → privkey (here) → profile (next).
+  if (ownerKey) {
+    const ok = await storage.write(
+      `${podPath}private/privkey.jsonld`,
+      JSON.stringify(ownerKey.document, null, 2),
+      { mode: 0o600 }
+    );
+    if (!ok) {
+      throw new Error(
+        `Failed to write owner key file at ${podPath}private/privkey.jsonld`
+      );
+    }
+  }
+
+  // Generate and write WebID profile at /profile/card.jsonld. When an
+  // owner key was provisioned, its VM lands in the profile so the
+  // existing LWS-CID verifier (src/auth/lws-cid.js) can authenticate
+  // JWTs signed with the matching secret. Profile is intentionally
+  // written last — see ordering rationale above.
+  const profile = generateProfile({ webId, name, podUri, issuer, ownerVm: ownerKey?.vm });
+  await storage.write(`${podPath}profile/card.jsonld`, serialize(profile));
 
   // Spread `ownerKey` only when set so the field is genuinely absent
   // (not `null`) on the no-provisioning path — matches the existing

--- a/src/keys/provision.js
+++ b/src/keys/provision.js
@@ -20,7 +20,7 @@
  *     surface area or a new dependency.
  */
 
-import { schnorr } from '@noble/curves/secp256k1';
+import { schnorr, secp256k1 } from '@noble/curves/secp256k1';
 
 /**
  * Multicodec varints (lower-hex). The CCG / W3C CID v1.0 Multikey
@@ -43,12 +43,34 @@ const EVEN_Y_PARITY_HEX = '02';
 /**
  * Generate a fresh secp256k1 keypair suitable for Schnorr signing.
  *
+ * The secret is normalized so that `G * secret` has *even* y (BIP-340
+ * convention). Without normalization, ECDSA signatures made with the
+ * raw secret would verify against the natural y of the public point —
+ * even half the time, odd half the time — while the corresponding JWK
+ * we publish in the WebID profile is always derived from the even-y
+ * x-only Schnorr pubkey. The two would disagree on ~50% of generated
+ * secrets, breaking Phase 2's LWS-CID round-trip non-deterministically.
+ *
+ * Normalizing once at generation time means a single secret-on-disk
+ * works under both Schnorr (Nostr) and ECDSA (LWS-CID JWT) without
+ * parity gymnastics in either signing path.
+ *
  * @returns {{ secretHex: string, publicHex: string }}
- *   `secretHex` — 32-byte secret scalar, lower-hex.
+ *   `secretHex` — 32-byte secret scalar, lower-hex, normalized so the
+ *     corresponding public point has even y.
  *   `publicHex` — 32-byte x-only Schnorr pubkey, lower-hex (BIP-340).
  */
 export function generateOwnerKeypair() {
-  const secretBytes = schnorr.utils.randomPrivateKey();
+  let secretBytes = schnorr.utils.randomPrivateKey();
+  // Compressed SEC1 starts with 02 (even y) or 03 (odd y).
+  const compressed = secp256k1.getPublicKey(secretBytes, /*compressed=*/true);
+  if (compressed[0] === 0x03) {
+    // Negate the secret (mod n) so the resulting point flips to even y.
+    const n = secp256k1.CURVE.n;
+    const original = BigInt('0x' + bytesToHex(secretBytes));
+    const negated = (n - original) % n;
+    secretBytes = hexToBytes(negated.toString(16).padStart(64, '0'));
+  }
   const publicBytes = schnorr.getPublicKey(secretBytes);
   return {
     secretHex: bytesToHex(secretBytes),
@@ -76,46 +98,169 @@ export function secretKeyMultibase(secretHex) {
 }
 
 /**
+ * Compute the canonical did:nostr identifier for a Schnorr secp256k1
+ * pubkey. Lower-hex form (matches the rest of jss — see
+ * src/idp/well-known-did-nostr.js's resolveDidNostrLocally(pubkeyHex)
+ * and src/auth/did-nostr.js's `did:nostr:${pubkey.toLowerCase()}`).
+ * Phase 2 of #437 (#443) flips the Multikey document's `controller`
+ * field to this form now that jss's resolver round-trips it.
+ *
+ * @param {string} publicHex - 32-byte x-only Schnorr pubkey hex.
+ * @returns {string} `did:nostr:<lower-hex pubkey>`.
+ */
+export function didNostrFromPublicHex(publicHex) {
+  if (!/^[0-9a-f]{64}$/.test(publicHex)) {
+    throw new Error('didNostrFromPublicHex: expected 64-char lower-hex pubkey');
+  }
+  return `did:nostr:${publicHex}`;
+}
+
+/**
  * Build the W3C CID v1.0 Multikey JSON-LD document for a fresh pod
- * owner key. The `controller` is the pod owner's WebID — Phase 1
- * keeps the document self-consistent at every phase (Phase 2 will
- * swap in a `did:nostr:` controller once the resolver lands).
+ * owner key.
+ *
+ * Phase 2 default controller: `did:nostr:<hex>`. The previous Phase 1
+ * shape used the pod owner's WebID — both are valid CID v1.0
+ * controllers, but did:nostr lets the keypair self-identify via jss's
+ * existing resolver. Callers can still pass an explicit `controller`
+ * (the legacy WebID form is what existing test fixtures use).
  *
  * @param {object} args
- * @param {string} args.controllerWebId - Absolute owner WebID URI.
  * @param {string} args.publicHex - 32-byte x-only Schnorr pubkey hex.
  * @param {string} args.secretHex - 32-byte secret scalar hex.
+ * @param {string} [args.controller] - Override the controller field.
+ *   Defaults to `did:nostr:<publicHex>` (Phase 2 of #437 / #443).
  * @returns {object} JSON-LD Multikey document, ready for `JSON.stringify`.
  */
-export function buildOwnerKeyDocument({ controllerWebId, publicHex, secretHex }) {
-  if (typeof controllerWebId !== 'string' || !controllerWebId) {
-    throw new Error('buildOwnerKeyDocument: controllerWebId required');
+export function buildOwnerKeyDocument({ publicHex, secretHex, controller }) {
+  const ctrl = controller ?? didNostrFromPublicHex(publicHex);
+  if (typeof ctrl !== 'string' || !ctrl) {
+    throw new Error('buildOwnerKeyDocument: controller required');
   }
   return {
     '@context': 'https://www.w3.org/ns/cid/v1',
     type: 'Multikey',
-    controller: controllerWebId,
+    controller: ctrl,
     publicKeyMultibase: publicKeyMultibase(publicHex),
     secretKeyMultibase: secretKeyMultibase(secretHex)
   };
 }
 
 /**
- * One-shot helper: generate a fresh keypair and produce both the
- * Multikey document and the raw key material (for log lines / CLI
- * output that wants to display the pubkey).
+ * Compute the BIP-340 even-y JWK (kty=EC, crv=secp256k1) for an
+ * x-only Schnorr pubkey hex. Phase 2 needs this for the VM that
+ * lands in the WebID profile — the LWS-CID verifier currently reads
+ * `publicKeyJwk` only (Multikey-only VMs aren't yet handled there
+ * per `src/auth/lws-cid.js`'s docstring), so the VM ships both
+ * `publicKeyMultibase` (CID v1.0 conformance) and `publicKeyJwk`
+ * (LWS-CID compat).
+ *
+ * The y coordinate is computed against the canonical even-y point at
+ * `x` — same convention `src/auth/nostr-keys.js`'s
+ * `pubkeyFromValidatedJwk` checks against on the verifier side, so
+ * the VM we mint round-trips through the existing extractor without
+ * being rejected as "wrong y".
+ *
+ * @param {string} publicHex - 32-byte x-only Schnorr pubkey hex.
+ * @returns {{ kty: 'EC', crv: 'secp256k1', x: string, y: string }}
+ */
+export function publicKeyJwkFromHex(publicHex) {
+  if (!/^[0-9a-f]{64}$/.test(publicHex)) {
+    throw new Error('publicKeyJwkFromHex: expected 64-char lower-hex pubkey');
+  }
+  // Compressed SEC1 with parity 02 = the canonical even-y point at x.
+  const point = secp256k1.ProjectivePoint.fromHex('02' + publicHex);
+  const yHex = point.toAffine().y.toString(16).padStart(64, '0');
+  return {
+    kty: 'EC',
+    crv: 'secp256k1',
+    x: hexToBase64Url(publicHex),
+    y: hexToBase64Url(yHex)
+  };
+}
+
+/**
+ * Build the verificationMethod entry for the seeded WebID profile.
+ *
+ * The VM wires the Phase 1 keypair into the existing LWS-CID auth
+ * loop: an agent signs a JWT with the on-disk secret + `kid` set to
+ * this VM's `id`, the verifier (already merged in `src/auth/lws-cid.js`)
+ * fetches the WebID profile, finds this VM, decodes the JWK, verifies
+ * the signature, and returns the WebID as the authenticated identity.
+ *
+ * Both forms are emitted: `publicKeyMultibase` for CID v1.0 readers
+ * (and round-trip with `decodeFFormSecp256k1` in `src/auth/nostr-keys.js`),
+ * `publicKeyJwk` for the LWS-CID verifier and any tool that prefers JOSE.
+ *
+ * @param {object} args
+ * @param {string} args.webId - Pod owner's WebID; used to derive both
+ *   the `controller` and the document URL the VM `id` sits in.
+ * @param {string} args.publicHex - 32-byte x-only Schnorr pubkey hex.
+ * @param {string} [args.fragment='owner-key'] - Fragment id for the VM;
+ *   appended to the WebID document URL to form `vm.id`.
+ * @returns {object} JSON-LD verificationMethod entry.
+ */
+export function buildOwnerVerificationMethod({ webId, publicHex, fragment = 'owner-key' }) {
+  if (typeof webId !== 'string' || !webId) {
+    throw new Error('buildOwnerVerificationMethod: webId required');
+  }
+  const docUrl = webId.split('#')[0];
+  return {
+    '@id': `${docUrl}#${fragment}`,
+    '@type': 'Multikey',
+    controller: webId,
+    publicKeyMultibase: publicKeyMultibase(publicHex),
+    publicKeyJwk: publicKeyJwkFromHex(publicHex)
+  };
+}
+
+/**
+ * One-shot helper: generate a fresh keypair and produce the Multikey
+ * document, the verificationMethod entry for the WebID profile, and
+ * the raw key material (for log lines / CLI output that wants to
+ * display the pubkey).
  *
  * The returned `secretHex` should be considered sensitive and not
- * logged; the public `multibase` IS safe to print.
+ * logged; the public `publicMultibase` IS safe to print.
+ *
+ * @param {object} args
+ * @param {string} args.webId - Pod owner's WebID. Used as the
+ *   `controller` of the VM and to derive the VM's `@id` fragment.
+ *   The Multikey document's `controller` is the `did:nostr:<hex>`
+ *   form by default (Phase 2 of #437 / #443).
+ * @param {string} [args.controller] - Override the Multikey
+ *   document's controller. Defaults to `did:nostr:<publicHex>`.
+ * @returns {{
+ *   document: object,
+ *   vm: object,
+ *   publicHex: string,
+ *   secretHex: string,
+ *   publicMultibase: string,
+ *   didNostr: string
+ * }}
  */
-export function provisionOwnerKey({ controllerWebId }) {
+export function provisionOwnerKey({ webId, controller, controllerWebId }) {
+  // Backward-compat: callers from Phase 1 passed `controllerWebId` and
+  // expected it to land in both the document's `controller` field and
+  // (implicitly) the VM controller. Map it to the new shape.
+  const effectiveWebId = webId ?? controllerWebId;
+  if (typeof effectiveWebId !== 'string' || !effectiveWebId) {
+    throw new Error('provisionOwnerKey: webId required');
+  }
   const { publicHex, secretHex } = generateOwnerKeypair();
-  const document = buildOwnerKeyDocument({ controllerWebId, publicHex, secretHex });
-  return {
-    document,
+  const document = buildOwnerKeyDocument({
     publicHex,
     secretHex,
-    publicMultibase: document.publicKeyMultibase
+    controller: controller ?? (controllerWebId ?? didNostrFromPublicHex(publicHex))
+  });
+  const vm = buildOwnerVerificationMethod({ webId: effectiveWebId, publicHex });
+  return {
+    document,
+    vm,
+    publicHex,
+    secretHex,
+    publicMultibase: document.publicKeyMultibase,
+    didNostr: didNostrFromPublicHex(publicHex)
   };
 }
 
@@ -154,4 +299,17 @@ function bytesToHex(bytes) {
     s += bytes[i].toString(16).padStart(2, '0');
   }
   return s;
+}
+
+function hexToBase64Url(hex) {
+  if (!/^[0-9a-f]+$/i.test(hex) || hex.length % 2 !== 0) {
+    throw new Error('hexToBase64Url: expected even-length hex');
+  }
+  return Buffer.from(hex, 'hex').toString('base64url');
+}
+
+function hexToBytes(hex) {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  return out;
 }

--- a/src/keys/provision.js
+++ b/src/keys/provision.js
@@ -249,10 +249,14 @@ export function provisionOwnerKey({ webId, documentController }) {
     throw new Error('provisionOwnerKey: webId required');
   }
   const { publicHex, secretHex } = generateOwnerKeypair();
+  // Pass `documentController` through verbatim — buildOwnerKeyDocument
+  // already defaults to `did:nostr:<publicHex>` when none is given, so
+  // duplicating the fallback here would just create two sources of
+  // truth for the default controller.
   const document = buildOwnerKeyDocument({
     publicHex,
     secretHex,
-    controller: documentController ?? didNostrFromPublicHex(publicHex)
+    controller: documentController
   });
   const vm = buildOwnerVerificationMethod({ webId, publicHex });
   return {

--- a/src/keys/provision.js
+++ b/src/keys/provision.js
@@ -230,6 +230,15 @@ export function buildOwnerVerificationMethod({ webId, publicHex, fragment = 'own
  * because it created surprising precedence interactions with the new
  * `documentController` and asymmetric document/VM controllers.
  *
+ * **Two controllers, on purpose.** `vm.controller` lives inside the
+ * WebID profile and always tracks `webId` — it identifies who in
+ * WebID-land can present this VM (the pod owner). `document.controller`
+ * lives in /private/privkey.jsonld and identifies the key in its own
+ * right (default did:nostr, overridable). They're decoupled by design;
+ * `documentController` does NOT propagate to the VM. If a caller wants
+ * both to point at, say, a custom DID, they should construct the VM
+ * separately via `buildOwnerVerificationMethod` and merge.
+ *
  * @param {object} args
  * @param {string} args.webId - Pod owner's WebID. Used as the VM
  *   controller and to derive the VM's `@id` fragment.
@@ -314,6 +323,14 @@ function hexToBase64Url(hex) {
 }
 
 function hexToBytes(hex) {
+  // Validate up front — without this, `parseInt('zz', 16)` returns
+  // NaN and silently writes 0 into the byte slot. Today the only
+  // caller passes freshly-generated 32-byte hex, but the helper is
+  // shared infrastructure: every sibling helper (`publicKeyJwkFromHex`,
+  // `didNostrFromPublicHex`, `hexToBase64Url`) validates the same way.
+  if (typeof hex !== 'string' || !/^[0-9a-fA-F]+$/.test(hex) || hex.length % 2 !== 0) {
+    throw new Error('hexToBytes: expected even-length hex');
+  }
   const out = new Uint8Array(hex.length / 2);
   for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
   return out;

--- a/src/keys/provision.js
+++ b/src/keys/provision.js
@@ -223,12 +223,17 @@ export function buildOwnerVerificationMethod({ webId, publicHex, fragment = 'own
  * The returned `secretHex` should be considered sensitive and not
  * logged; the public `publicMultibase` IS safe to print.
  *
+ * Single canonical input shape — `webId` for VM controller + VM `@id`
+ * derivation, `documentController` to override the Multikey document's
+ * controller (defaults to `did:nostr:<publicHex>` per Phase 2 of #437).
+ * The previous `controllerWebId` legacy alias was removed in #443
+ * because it created surprising precedence interactions with the new
+ * `documentController` and asymmetric document/VM controllers.
+ *
  * @param {object} args
- * @param {string} args.webId - Pod owner's WebID. Used as the
- *   `controller` of the VM and to derive the VM's `@id` fragment.
- *   The Multikey document's `controller` is the `did:nostr:<hex>`
- *   form by default (Phase 2 of #437 / #443).
- * @param {string} [args.controller] - Override the Multikey
+ * @param {string} args.webId - Pod owner's WebID. Used as the VM
+ *   controller and to derive the VM's `@id` fragment.
+ * @param {string} [args.documentController] - Override the Multikey
  *   document's controller. Defaults to `did:nostr:<publicHex>`.
  * @returns {{
  *   document: object,
@@ -239,21 +244,17 @@ export function buildOwnerVerificationMethod({ webId, publicHex, fragment = 'own
  *   didNostr: string
  * }}
  */
-export function provisionOwnerKey({ webId, controller, controllerWebId }) {
-  // Backward-compat: callers from Phase 1 passed `controllerWebId` and
-  // expected it to land in both the document's `controller` field and
-  // (implicitly) the VM controller. Map it to the new shape.
-  const effectiveWebId = webId ?? controllerWebId;
-  if (typeof effectiveWebId !== 'string' || !effectiveWebId) {
+export function provisionOwnerKey({ webId, documentController }) {
+  if (typeof webId !== 'string' || !webId) {
     throw new Error('provisionOwnerKey: webId required');
   }
   const { publicHex, secretHex } = generateOwnerKeypair();
   const document = buildOwnerKeyDocument({
     publicHex,
     secretHex,
-    controller: controller ?? (controllerWebId ?? didNostrFromPublicHex(publicHex))
+    controller: documentController ?? didNostrFromPublicHex(publicHex)
   });
-  const vm = buildOwnerVerificationMethod({ webId: effectiveWebId, publicHex });
+  const vm = buildOwnerVerificationMethod({ webId, publicHex });
   return {
     document,
     vm,

--- a/src/server.js
+++ b/src/server.js
@@ -1045,17 +1045,35 @@ export function createServer(options = {}) {
     await storage.createContainer('/settings/');
     await storage.createContainer('/profile/');
 
-    // Generate the owner key up-front (when --provision-keys is set)
-    // so its public side can be injected into the WebID profile's
-    // verificationMethod array before the profile is written. Phase 2
-    // of #437 (#443). The on-disk secret file is written last, after
-    // the rest of the structure exists.
+    // Generate the owner key in memory up-front (when --provision-keys
+    // is set), persist it to /private/privkey.jsonld *before* the
+    // WebID profile is written. The profile advertises the VM, so a
+    // crash between profile and privkey would leave the WebID
+    // permanently advertising an authentication method whose secret
+    // never persisted (#444 review). Writing privkey first means the
+    // worst-case crash leaves an orphan secret file (easy to delete)
+    // rather than an orphan VM in a public profile.
     const ownerKey = provisionKeysEnabled
       ? provisionOwnerKey({ webId })
       : null;
 
+    if (ownerKey) {
+      const ok = await storage.write(
+        '/private/privkey.jsonld',
+        JSON.stringify(ownerKey.document, null, 2),
+        { mode: 0o600 }
+      );
+      if (!ok) {
+        throw new Error(
+          'Failed to write owner key file at /private/privkey.jsonld'
+        );
+      }
+    }
+
     // Generate profile (with the owner key's VM landed in
-    // verificationMethod when --provision-keys is on).
+    // verificationMethod when --provision-keys is on). The privkey
+    // file already exists on disk at this point — see ordering
+    // rationale above.
     const profile = generateProfile({ webId, name: displayName, podUri, issuer, ownerVm: ownerKey?.vm });
     await storage.write('/profile/card.jsonld', serialize(profile));
 
@@ -1100,22 +1118,8 @@ export function createServer(options = {}) {
     const profileAcl = generatePublicFolderAcl('./', owner('profile/'));
     await storage.write('/profile/.acl', serializeAcl(profileAcl));
 
-    // Owner-key file is written last. The keypair itself was generated
-    // up-front for profile injection; this step persists it. Throw on
-    // write failure so single-user startup fails loud rather than
-    // logging "Provisioned …" against a missing on-disk file.
-    if (ownerKey) {
-      const ok = await storage.write(
-        '/private/privkey.jsonld',
-        JSON.stringify(ownerKey.document, null, 2),
-        { mode: 0o600 }
-      );
-      if (!ok) {
-        throw new Error(
-          'Failed to write owner key file at /private/privkey.jsonld'
-        );
-      }
-    }
+    // (privkey was written above, before the profile, to avoid
+    // orphan-VM-on-crash. Nothing more to do here.)
 
     // Note: Quota not initialized for root-level pods (no user directory).
     // Spread `ownerKey` only when set so the field is genuinely absent

--- a/src/server.js
+++ b/src/server.js
@@ -1046,36 +1046,15 @@ export function createServer(options = {}) {
     await storage.createContainer('/profile/');
 
     // Generate the owner key in memory up-front (when --provision-keys
-    // is set), persist it to /private/privkey.jsonld *before* the
-    // WebID profile is written. The profile advertises the VM, so a
-    // crash between profile and privkey would leave the WebID
-    // permanently advertising an authentication method whose secret
-    // never persisted (#444 review). Writing privkey first means the
-    // worst-case crash leaves an orphan secret file (easy to delete)
-    // rather than an orphan VM in a public profile.
+    // is set) so its VM can be injected into the WebID profile that
+    // gets written last. On-disk persistence of the secret happens
+    // *after* the ACL tree is in place — see the ordering block
+    // further below.
     const ownerKey = provisionKeysEnabled
       ? provisionOwnerKey({ webId })
       : null;
 
-    if (ownerKey) {
-      const ok = await storage.write(
-        '/private/privkey.jsonld',
-        JSON.stringify(ownerKey.document, null, 2),
-        { mode: 0o600 }
-      );
-      if (!ok) {
-        throw new Error(
-          'Failed to write owner key file at /private/privkey.jsonld'
-        );
-      }
-    }
-
-    // Generate profile (with the owner key's VM landed in
-    // verificationMethod when --provision-keys is on). The privkey
-    // file already exists on disk at this point — see ordering
-    // rationale above.
-    const profile = generateProfile({ webId, name: displayName, podUri, issuer, ownerVm: ownerKey?.vm });
-    await storage.write('/profile/card.jsonld', serialize(profile));
+    // Profile is written last (see the ACL/privkey block below).
 
     // Preferences and type indexes
     const prefs = generatePreferences({ webId, podUri });
@@ -1118,8 +1097,43 @@ export function createServer(options = {}) {
     const profileAcl = generatePublicFolderAcl('./', owner('profile/'));
     await storage.write('/profile/.acl', serializeAcl(profileAcl));
 
-    // (privkey was written above, before the profile, to avoid
-    // orphan-VM-on-crash. Nothing more to do here.)
+    // Owner-key persistence + profile write (when --provision-keys is
+    // on). Order is load-bearing for two distinct concerns
+    // (#444 review):
+    //
+    //   1. WAC vacuum: write privkey *after* the ACL tree is in place
+    //      so the secret file is born under owner-only WAC. Without
+    //      this, there's a window where the file exists but no
+    //      /private/.acl protects it; deny-by-default since #f43ecdf
+    //      would mitigate to 401, but defence-in-depth beats relying
+    //      on a security default holding. The single-user root pod is
+    //      especially exposed since the URL is the server origin.
+    //
+    //   2. Orphan-VM: write privkey *before* the profile so a crash
+    //      between the two leaves an orphan secret file (easy to
+    //      delete) rather than an orphan VM in a published WebID
+    //      profile that forever advertises an authentication method
+    //      whose secret was never persisted.
+    //
+    // Combined: ACLs (above) → privkey (here) → profile (next).
+    if (ownerKey) {
+      const ok = await storage.write(
+        '/private/privkey.jsonld',
+        JSON.stringify(ownerKey.document, null, 2),
+        { mode: 0o600 }
+      );
+      if (!ok) {
+        throw new Error(
+          'Failed to write owner key file at /private/privkey.jsonld'
+        );
+      }
+    }
+
+    // Generate profile (with the owner key's VM landed in
+    // verificationMethod when --provision-keys is on). Written last —
+    // see ordering rationale above.
+    const profile = generateProfile({ webId, name: displayName, podUri, issuer, ownerVm: ownerKey?.vm });
+    await storage.write('/profile/card.jsonld', serialize(profile));
 
     // Note: Quota not initialized for root-level pods (no user directory).
     // Spread `ownerKey` only when set so the field is genuinely absent

--- a/src/server.js
+++ b/src/server.js
@@ -1045,8 +1045,18 @@ export function createServer(options = {}) {
     await storage.createContainer('/settings/');
     await storage.createContainer('/profile/');
 
-    // Generate profile
-    const profile = generateProfile({ webId, name: displayName, podUri, issuer });
+    // Generate the owner key up-front (when --provision-keys is set)
+    // so its public side can be injected into the WebID profile's
+    // verificationMethod array before the profile is written. Phase 2
+    // of #437 (#443). The on-disk secret file is written last, after
+    // the rest of the structure exists.
+    const ownerKey = provisionKeysEnabled
+      ? provisionOwnerKey({ webId })
+      : null;
+
+    // Generate profile (with the owner key's VM landed in
+    // verificationMethod when --provision-keys is on).
+    const profile = generateProfile({ webId, name: displayName, podUri, issuer, ownerVm: ownerKey?.vm });
     await storage.write('/profile/card.jsonld', serialize(profile));
 
     // Preferences and type indexes
@@ -1090,13 +1100,11 @@ export function createServer(options = {}) {
     const profileAcl = generatePublicFolderAcl('./', owner('profile/'));
     await storage.write('/profile/.acl', serializeAcl(profileAcl));
 
-    // Optional: provision a Schnorr secp256k1 owner key in /private/.
-    // Phase 1 of #437. See src/keys/provision.js for the design notes.
-    // Throw on write failure so single-user startup fails loud rather
-    // than logging "Provisioned …" against a missing on-disk file.
-    let ownerKey;
-    if (provisionKeysEnabled) {
-      ownerKey = provisionOwnerKey({ controllerWebId: webId });
+    // Owner-key file is written last. The keypair itself was generated
+    // up-front for profile injection; this step persists it. Throw on
+    // write failure so single-user startup fails loud rather than
+    // logging "Provisioned …" against a missing on-disk file.
+    if (ownerKey) {
       const ok = await storage.write(
         '/private/privkey.jsonld',
         JSON.stringify(ownerKey.document, null, 2),
@@ -1109,8 +1117,10 @@ export function createServer(options = {}) {
       }
     }
 
-    // Note: Quota not initialized for root-level pods (no user directory)
-    return { ownerKey };
+    // Note: Quota not initialized for root-level pods (no user directory).
+    // Spread `ownerKey` only when set so the field is genuinely absent
+    // (not `null`) on the no-provisioning path.
+    return { ...(ownerKey && { ownerKey }) };
   }
 
   // Start file watcher for live reload (watches filesystem for external changes)

--- a/src/webid/profile.js
+++ b/src/webid/profile.js
@@ -16,25 +16,29 @@ const CID = 'https://www.w3.org/ns/cid/v1#';
 const LWS = 'https://www.w3.org/ns/lws#';
 
 /**
- * Generate JSON-LD data for a WebID profile
+ * Generate JSON-LD data for a WebID profile.
+ *
  * @param {object} options
  * @param {string} options.webId - Full WebID URI (e.g., https://example.com/alice/profile/card#me)
  * @param {string} options.name - Display name
  * @param {string} options.podUri - Pod root URI (e.g., https://example.com/alice/)
  * @param {string} options.issuer - OIDC issuer URI
+ * @param {object} [options.ownerVm] - Optional verificationMethod
+ *   entry for an owner-held key (Phase 2 of #437 / #443). Build via
+ *   `src/keys/provision.js#buildOwnerVerificationMethod`.
+ *
+ *   **Fresh-pod-only when `ownerVm` is set.** The helper unconditionally
+ *   overwrites `verificationMethod`, `authentication`, and
+ *   `assertionMethod` with single-element arrays referencing this VM.
+ *   That's correct for the only current caller (fresh pod creation,
+ *   nothing to overwrite), but a future "rotate-keys" / re-provisioning
+ *   command using this helper to regenerate an existing profile would
+ *   silently drop any VMs / proof-purpose references the operator
+ *   added by hand. Either pass the existing profile through a merge
+ *   step before calling this, or treat the helper as fresh-pod-only.
+ *   See #444 review.
+ *
  * @returns {object} JSON-LD profile data
- */
-/**
- * NOTE on `ownerVm`: when provided, this helper unconditionally
- * overwrites `verificationMethod`, `authentication`, and
- * `assertionMethod` with single-element arrays. That's correct for
- * the only current caller (fresh-pod creation, where there's nothing
- * to overwrite), but if a future "rotate-keys" / re-provisioning
- * command ever calls this helper to regenerate an existing profile,
- * it will silently drop any VMs / proof-purpose references the
- * operator added by hand. Either pass the existing profile through
- * a merge step before calling this, or treat this helper as
- * fresh-pod-only. See #444 review.
  */
 export function generateProfileJsonLd({ webId, name, podUri, issuer, ownerVm = null }) {
   const pod = podUri.endsWith('/') ? podUri : podUri + '/';

--- a/src/webid/profile.js
+++ b/src/webid/profile.js
@@ -24,7 +24,7 @@ const LWS = 'https://www.w3.org/ns/lws#';
  * @param {string} options.issuer - OIDC issuer URI
  * @returns {object} JSON-LD profile data
  */
-export function generateProfileJsonLd({ webId, name, podUri, issuer }) {
+export function generateProfileJsonLd({ webId, name, podUri, issuer, ownerVm = null }) {
   const pod = podUri.endsWith('/') ? podUri : podUri + '/';
   // Document URL is the WebID without its fragment; service entries use
   // fragment ids resolved against it.
@@ -114,7 +114,24 @@ export function generateProfileJsonLd({ webId, name, podUri, issuer }) {
         '@type': 'lws:OpenIdProvider',
         'serviceEndpoint': issuer
       }
-    ]
+    ],
+    // Optional: a verificationMethod for an owner-held key, populated
+    // when the pod was created with `--provision-keys` (Phase 2 of
+    // #437 / #443). The VM lands the public side of the owner key
+    // into the profile so the existing LWS-CID verifier in
+    // src/auth/lws-cid.js can authenticate JWTs signed with the
+    // matching secret. Both `publicKeyMultibase` (CID v1.0
+    // conformance) and `publicKeyJwk` (LWS-CID compat) are emitted by
+    // src/keys/provision.js's buildOwnerVerificationMethod helper.
+    //
+    // The VM is also referenced from `authentication` and
+    // `assertionMethod` so the same key counts as an authentication
+    // factor without an app needing to PATCH those arrays separately.
+    ...(ownerVm && {
+      verificationMethod: [ownerVm],
+      authentication: [ownerVm['@id']],
+      assertionMethod: [ownerVm['@id']]
+    })
   };
 }
 
@@ -131,10 +148,15 @@ export function generateProfileJsonLd({ webId, name, podUri, issuer }) {
  * @param {string} options.name - Display name
  * @param {string} options.podUri - Pod root URI
  * @param {string} options.issuer - OIDC issuer URI
+ * @param {object} [options.ownerVm] - Optional verificationMethod entry
+ *   for an owner-held key (Phase 2 of #437 / #443). When set, lands
+ *   the VM in `verificationMethod` and references it from
+ *   `authentication` + `assertionMethod`. Build via
+ *   `src/keys/provision.js#buildOwnerVerificationMethod`.
  * @returns {object} JSON-LD profile document
  */
-export function generateProfile({ webId, name, podUri, issuer }) {
-  return generateProfileJsonLd({ webId, name, podUri, issuer });
+export function generateProfile({ webId, name, podUri, issuer, ownerVm = null }) {
+  return generateProfileJsonLd({ webId, name, podUri, issuer, ownerVm });
 }
 
 /**

--- a/src/webid/profile.js
+++ b/src/webid/profile.js
@@ -24,6 +24,18 @@ const LWS = 'https://www.w3.org/ns/lws#';
  * @param {string} options.issuer - OIDC issuer URI
  * @returns {object} JSON-LD profile data
  */
+/**
+ * NOTE on `ownerVm`: when provided, this helper unconditionally
+ * overwrites `verificationMethod`, `authentication`, and
+ * `assertionMethod` with single-element arrays. That's correct for
+ * the only current caller (fresh-pod creation, where there's nothing
+ * to overwrite), but if a future "rotate-keys" / re-provisioning
+ * command ever calls this helper to regenerate an existing profile,
+ * it will silently drop any VMs / proof-purpose references the
+ * operator added by hand. Either pass the existing profile through
+ * a merge step before calling this, or treat this helper as
+ * fresh-pod-only. See #444 review.
+ */
 export function generateProfileJsonLd({ webId, name, podUri, issuer, ownerVm = null }) {
   const pod = podUri.endsWith('/') ? podUri : podUri + '/';
   // Document URL is the WebID without its fragment; service entries use

--- a/test/keys-provision-integration.test.js
+++ b/test/keys-provision-integration.test.js
@@ -71,8 +71,11 @@ describe('POST /.pods — provisionKeys: true (Phase 1 of #437)', () => {
     const doc = JSON.parse(await fs.readFile(filePath, 'utf8'));
     assert.strictEqual(doc['@context'], 'https://www.w3.org/ns/cid/v1');
     assert.strictEqual(doc.type, 'Multikey');
-    assert.strictEqual(doc.controller, body.webId,
-      'Phase 1 controller is the pod owner WebID (did:nostr lands in Phase 2)');
+    // Phase 2 of #437 (#443): controller is now did:nostr:<hex>,
+    // computed from the freshly-minted publicHex. Round-trips through
+    // jss's existing did:nostr resolver.
+    assert.match(doc.controller, /^did:nostr:[0-9a-f]{64}$/,
+      'Phase 2 controller is did:nostr:<hex>');
     assert.match(doc.publicKeyMultibase, /^fe70102[0-9a-f]{64}$/);
     assert.match(doc.secretKeyMultibase, /^f8126[0-9a-f]{64}$/);
     // Round-trip the public side through jss's existing decoder.
@@ -237,7 +240,22 @@ describe('createPodStructure — provisionKeys option (direct call)', () => {
     assert.match(result.ownerKey.publicHex, /^[0-9a-f]{64}$/);
     assert.match(result.ownerKey.secretHex, /^[0-9a-f]{64}$/);
     assert.strictEqual(result.ownerKey.publicMultibase, result.ownerKey.document.publicKeyMultibase);
-    assert.strictEqual(result.ownerKey.document.controller, webId);
+    // Phase 2 default controller — did:nostr:<hex>.
+    assert.strictEqual(
+      result.ownerKey.document.controller,
+      `did:nostr:${result.ownerKey.publicHex}`
+    );
+    // Phase 2 surfaces the VM and the did:nostr identifier alongside
+    // the document for callers that want to display the public side.
+    assert.strictEqual(result.ownerKey.vm.controller, webId);
+    assert.strictEqual(
+      result.ownerKey.vm['@id'],
+      `${podUri}profile/card.jsonld#owner-key`
+    );
+    assert.strictEqual(
+      result.ownerKey.didNostr,
+      `did:nostr:${result.ownerKey.publicHex}`
+    );
   });
 
   it('returns no ownerKey when the option is omitted', async () => {

--- a/test/keys-provision-lws-cid.test.js
+++ b/test/keys-provision-lws-cid.test.js
@@ -160,7 +160,11 @@ describe('Phase 2: LWS-CID round-trip with provisioned owner key (#443)', () => 
     const result = await verifyLwsCidAuth(makeRequest(token));
     assert.strictEqual(result.webId, null,
       'mismatched secret must not authenticate');
-    assert.match(result.error || '', /signature/i,
-      'error should mention signature failure');
+    // Match the specific verifier error prefix, not just any string
+    // containing "signature" — JWS-related errors (expired, malformed,
+    // bad nbf, etc.) also mention "signature" but for the wrong
+    // reasons. We want to prove the signature *check* did real work.
+    assert.match(result.error || '', /signature verification failed/,
+      'error should be the signature-verification path, not some other JWT failure');
   });
 });

--- a/test/keys-provision-lws-cid.test.js
+++ b/test/keys-provision-lws-cid.test.js
@@ -1,0 +1,166 @@
+/**
+ * End-to-end: a JWT signed with the on-disk Phase 1 owner secret,
+ * with `kid` pointing at the Phase 2 verificationMethod that lands
+ * in the seeded WebID profile, authenticates as the pod owner via
+ * the existing LWS-CID verifier (src/auth/lws-cid.js).
+ *
+ * This is the single test that proves Phase 2 of #437 (#443) closes
+ * the loop: keypair on disk → public side in profile → JWT signed
+ * with the secret → verifier accepts → WebID returned.
+ *
+ * Builds the JWT inline (signing primitives from @noble/curves are
+ * already a jss dep). Stubs global.fetch so the verifier's profile
+ * GET is served from an in-memory profile produced by the actual
+ * generateProfile helper — no test fixtures, no second source of
+ * truth for the profile shape.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { sha256 } from '@noble/hashes/sha2';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { provisionOwnerKey } from '../src/keys/provision.js';
+import { generateProfile } from '../src/webid/profile.js';
+import { verifyLwsCidAuth, _clearProfileCacheForTests } from '../src/auth/lws-cid.js';
+
+const POD_ORIGIN = 'https://alice.example';
+const POD_URI = `${POD_ORIGIN}/`;
+const WEBID = `${POD_URI}profile/card.jsonld#me`;
+const DOC_URL = `${POD_URI}profile/card.jsonld`;
+const ISSUER = `${POD_ORIGIN}/`;
+
+function b64u(bytes) {
+  return Buffer.from(bytes).toString('base64')
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function makeEs256kJwt({ secretHex, header, payload }) {
+  const h64 = b64u(Buffer.from(JSON.stringify(header)));
+  const p64 = b64u(Buffer.from(JSON.stringify(payload)));
+  const signingInput = Buffer.from(`${h64}.${p64}`, 'utf8');
+  const msgHash = sha256(signingInput);
+  const sig = secp256k1.sign(msgHash, hexToBytes(secretHex));
+  return `${h64}.${p64}.${b64u(sig.toCompactRawBytes())}`;
+}
+
+function hexToBytes(hex) {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
+
+function makeRequest(token, { host = 'alice.example', proto = 'https' } = {}) {
+  return {
+    headers: { authorization: `Bearer ${token}`, host },
+    protocol: proto
+  };
+}
+
+describe('Phase 2: LWS-CID round-trip with provisioned owner key (#443)', () => {
+  let realFetch;
+  let servedProfile = null;
+
+  before(() => {
+    realFetch = global.fetch;
+    global.fetch = async (url) => {
+      const u = String(url);
+      if (u === DOC_URL && servedProfile) {
+        return new Response(JSON.stringify(servedProfile), {
+          status: 200,
+          headers: { 'content-type': 'application/ld+json' }
+        });
+      }
+      return new Response('not found', { status: 404 });
+    };
+  });
+
+  after(() => {
+    global.fetch = realFetch;
+  });
+
+  beforeEach(() => {
+    servedProfile = null;
+    _clearProfileCacheForTests();
+  });
+
+  it('verifies a JWT signed with the on-disk secret against the seeded profile', async () => {
+    // 1. Provision an owner key (same call site as createPodStructure /
+    //    createRootPodStructure use during pod creation).
+    const owner = provisionOwnerKey({ webId: WEBID });
+
+    // 2. Build the seeded WebID profile with the owner VM injected
+    //    (same call as createPodStructure makes after #443).
+    servedProfile = generateProfile({
+      webId: WEBID,
+      name: 'me',
+      podUri: POD_URI,
+      issuer: ISSUER,
+      ownerVm: owner.vm
+    });
+
+    // Sanity: the profile should carry the VM and reference it from
+    // authentication / assertionMethod (the last two are what lets the
+    // VM count as an auth factor without a separate PATCH).
+    assert.strictEqual(servedProfile.verificationMethod.length, 1);
+    assert.strictEqual(servedProfile.verificationMethod[0]['@id'], owner.vm['@id']);
+    assert.deepStrictEqual(servedProfile.authentication, [owner.vm['@id']]);
+    assert.deepStrictEqual(servedProfile.assertionMethod, [owner.vm['@id']]);
+
+    // 3. Sign an LWS-CID JWT with the on-disk secret. `kid` points at
+    //    the VM's `@id` — that's how the verifier locates the public
+    //    key in the profile.
+    const now = Math.floor(Date.now() / 1000);
+    const token = makeEs256kJwt({
+      secretHex: owner.secretHex,
+      header: { alg: 'ES256K', typ: 'JWT', kid: owner.vm['@id'] },
+      payload: {
+        iss: WEBID,
+        sub: WEBID,
+        aud: POD_ORIGIN,
+        client_id: WEBID,
+        iat: now,
+        exp: now + 60
+      }
+    });
+
+    // 4. Verify via the existing LWS-CID verifier (no changes to
+    //    src/auth/lws-cid.js — Phase 2 only landed the profile wire).
+    const result = await verifyLwsCidAuth(makeRequest(token));
+    assert.strictEqual(result.error, null,
+      `LWS-CID verification should succeed; got error: ${result.error}`);
+    assert.strictEqual(result.webId, WEBID,
+      'verifier should return the pod owner WebID as the authenticated identity');
+  });
+
+  it('rejects a JWT signed with a different secret (sanity)', async () => {
+    // Provision the real owner key and seed the profile with its VM,
+    // but sign the JWT with an UNRELATED secret. The verifier should
+    // refuse — proves the signature check is doing real work, not
+    // just rubber-stamping anything addressed to the right kid.
+    const owner = provisionOwnerKey({ webId: WEBID });
+    servedProfile = generateProfile({
+      webId: WEBID,
+      name: 'me',
+      podUri: POD_URI,
+      issuer: ISSUER,
+      ownerVm: owner.vm
+    });
+
+    const wrongSecret = provisionOwnerKey({ webId: WEBID }).secretHex;
+    const now = Math.floor(Date.now() / 1000);
+    const token = makeEs256kJwt({
+      secretHex: wrongSecret,
+      header: { alg: 'ES256K', typ: 'JWT', kid: owner.vm['@id'] },
+      payload: {
+        iss: WEBID, sub: WEBID, aud: POD_ORIGIN, client_id: WEBID,
+        iat: now, exp: now + 60
+      }
+    });
+
+    const result = await verifyLwsCidAuth(makeRequest(token));
+    assert.strictEqual(result.webId, null,
+      'mismatched secret must not authenticate');
+    assert.match(result.error || '', /signature/i,
+      'error should mention signature failure');
+  });
+});

--- a/test/keys-provision.test.js
+++ b/test/keys-provision.test.js
@@ -4,7 +4,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { schnorr } from '@noble/curves/secp256k1';
+import { schnorr, secp256k1 } from '@noble/curves/secp256k1';
 import {
   generateOwnerKeypair,
   publicKeyMultibase,
@@ -38,6 +38,21 @@ describe('generateOwnerKeypair', () => {
     const b = generateOwnerKeypair();
     assert.notStrictEqual(a.publicHex, b.publicHex);
     assert.notStrictEqual(a.secretHex, b.secretHex);
+  });
+
+  it('always normalizes the secret so G*secret has even y (BIP-340)', () => {
+    // Without normalization, ECDSA signatures made with the raw secret
+    // would verify against the natural y of G*secret — even/odd ~50/50
+    // — while the JWK we publish in the WebID profile is derived from
+    // the even-y x-only Schnorr pubkey. Phase 2's LWS-CID round-trip
+    // would flake non-deterministically. Generate many keypairs and
+    // assert every secret's natural public point is even-y.
+    for (let i = 0; i < 64; i++) {
+      const { secretHex } = generateOwnerKeypair();
+      const compressed = secp256k1.getPublicKey(hexToBytes(secretHex), /*compressed=*/true);
+      assert.strictEqual(compressed[0], 0x02,
+        `secret #${i} produced odd-y point; normalization is broken`);
+    }
   });
 });
 
@@ -91,11 +106,27 @@ describe('buildOwnerKeyDocument', () => {
     assert.strictEqual(doc.type, 'Multikey');
   });
 
-  it('uses the WebID as controller in Phase 1 (not did:nostr)', () => {
-    // Phase 1 keeps the document self-consistent. did:nostr controllers
-    // require the Phase 2 resolver to be useful; until then a CID
-    // consumer would dereference an unresolvable URI.
-    const doc = buildOwnerKeyDocument(args);
+  it('defaults the controller to did:nostr:<hex> in Phase 2', () => {
+    // Phase 2 of #437 (#443) flipped the default controller to
+    // `did:nostr:<publicHex>` now that jss's resolver round-trips
+    // it. Phase 1 had used the WebID; the swap was anticipated in
+    // the Phase 1 design log and ships here.
+    const doc = buildOwnerKeyDocument({
+      publicHex: args.publicHex,
+      secretHex: args.secretHex
+    });
+    assert.strictEqual(doc.controller, `did:nostr:${args.publicHex}`);
+  });
+
+  it('accepts an explicit controller override (Phase 1 backward-compat)', () => {
+    // Tests / fixtures that need the legacy WebID-controller shape can
+    // pass `controller` explicitly. Phase 1-style call sites and any
+    // future caller wanting a non-default controller stay supported.
+    const doc = buildOwnerKeyDocument({
+      publicHex: args.publicHex,
+      secretHex: args.secretHex,
+      controller: args.controllerWebId
+    });
     assert.strictEqual(doc.controller, args.controllerWebId);
     assert.doesNotMatch(doc.controller, /^did:nostr:/);
   });
@@ -115,20 +146,60 @@ describe('buildOwnerKeyDocument', () => {
     assert.strictEqual(doc.nostr, undefined);
   });
 
-  it('rejects a missing or empty controller WebID', () => {
-    assert.throws(() => buildOwnerKeyDocument({ ...args, controllerWebId: '' }), /controllerWebId required/);
-    assert.throws(() => buildOwnerKeyDocument({ ...args, controllerWebId: undefined }), /controllerWebId required/);
+  it('rejects an explicit empty controller override', () => {
+    // The default did:nostr controller is computed from publicHex, so
+    // missing inputs are caught upstream (see publicKeyMultibase
+    // validation tests). When a caller *explicitly* passes an empty
+    // string, that's a misconfiguration we surface loudly.
+    assert.throws(
+      () => buildOwnerKeyDocument({
+        publicHex: args.publicHex,
+        secretHex: args.secretHex,
+        controller: ''
+      }),
+      /controller required/
+    );
   });
 });
 
 describe('provisionOwnerKey', () => {
+  const webId = 'https://alice.example/profile/card.jsonld#me';
+
   it('returns the document together with raw key material for CLI display', () => {
-    const out = provisionOwnerKey({ controllerWebId: 'https://alice.example/profile/card.jsonld#me' });
+    const out = provisionOwnerKey({ webId });
     assert.match(out.publicHex, /^[0-9a-f]{64}$/);
     assert.match(out.secretHex, /^[0-9a-f]{64}$/);
     assert.strictEqual(out.publicMultibase, out.document.publicKeyMultibase);
     assert.strictEqual(out.document.type, 'Multikey');
-    assert.strictEqual(out.document.controller, 'https://alice.example/profile/card.jsonld#me');
+    // Phase 2 of #437 (#443): controller defaults to did:nostr:<hex>.
+    assert.strictEqual(out.document.controller, `did:nostr:${out.publicHex}`);
+    assert.strictEqual(out.didNostr, `did:nostr:${out.publicHex}`);
+  });
+
+  it('returns a verificationMethod entry suitable for the WebID profile', () => {
+    // Phase 2 wires the public side into the profile's
+    // verificationMethod array so the existing LWS-CID verifier
+    // (src/auth/lws-cid.js) can authenticate JWTs signed with the
+    // matching secret. Both Multikey and JWK forms ship — Multikey
+    // for CID v1.0 conformance, JWK for LWS-CID compat.
+    const out = provisionOwnerKey({ webId });
+    assert.strictEqual(out.vm['@type'], 'Multikey');
+    assert.strictEqual(out.vm.controller, webId);
+    assert.strictEqual(out.vm['@id'], 'https://alice.example/profile/card.jsonld#owner-key');
+    assert.strictEqual(out.vm.publicKeyMultibase, out.publicMultibase);
+    assert.strictEqual(out.vm.publicKeyJwk.kty, 'EC');
+    assert.strictEqual(out.vm.publicKeyJwk.crv, 'secp256k1');
+    assert.match(out.vm.publicKeyJwk.x, /^[A-Za-z0-9_-]+$/);
+    assert.match(out.vm.publicKeyJwk.y, /^[A-Za-z0-9_-]+$/);
+  });
+
+  it('still accepts the legacy controllerWebId arg (Phase 1 callers)', () => {
+    // Phase 1 callers passed controllerWebId; honour it so an old
+    // call site doesn't silently break and so test fixtures targeting
+    // the WebID-controller shape stay terse.
+    const out = provisionOwnerKey({ controllerWebId: webId });
+    assert.strictEqual(out.document.controller, webId);
+    assert.strictEqual(out.vm.controller, webId);
   });
 });
 

--- a/test/keys-provision.test.js
+++ b/test/keys-provision.test.js
@@ -193,13 +193,14 @@ describe('provisionOwnerKey', () => {
     assert.match(out.vm.publicKeyJwk.y, /^[A-Za-z0-9_-]+$/);
   });
 
-  it('still accepts the legacy controllerWebId arg (Phase 1 callers)', () => {
-    // Phase 1 callers passed controllerWebId; honour it so an old
-    // call site doesn't silently break and so test fixtures targeting
-    // the WebID-controller shape stay terse.
-    const out = provisionOwnerKey({ controllerWebId: webId });
+  it('honours an explicit documentController override', () => {
+    // The legacy controllerWebId alias was removed in #443 review —
+    // the canonical way to pin the document controller to a WebID
+    // (or any other URI) is documentController.
+    const out = provisionOwnerKey({ webId, documentController: webId });
     assert.strictEqual(out.document.controller, webId);
-    assert.strictEqual(out.vm.controller, webId);
+    assert.strictEqual(out.vm.controller, webId,
+      'VM controller still uses webId regardless of documentController');
   });
 });
 

--- a/test/keys-provision.test.js
+++ b/test/keys-provision.test.js
@@ -118,10 +118,11 @@ describe('buildOwnerKeyDocument', () => {
     assert.strictEqual(doc.controller, `did:nostr:${args.publicHex}`);
   });
 
-  it('accepts an explicit controller override (Phase 1 backward-compat)', () => {
-    // Tests / fixtures that need the legacy WebID-controller shape can
-    // pass `controller` explicitly. Phase 1-style call sites and any
-    // future caller wanting a non-default controller stay supported.
+  it('accepts an explicit controller override (e.g. WebID, urn:, custom DID method)', () => {
+    // The forward-looking knob — operators or future callers that
+    // want to pin the document's controller to something other than
+    // did:nostr (a WebID, a urn:, a custom DID method) pass
+    // `controller` explicitly. Defaults still fire when omitted.
     const doc = buildOwnerKeyDocument({
       publicHex: args.publicHex,
       secretHex: args.secretHex,
@@ -195,12 +196,26 @@ describe('provisionOwnerKey', () => {
 
   it('honours an explicit documentController override', () => {
     // The legacy controllerWebId alias was removed in #443 review —
-    // the canonical way to pin the document controller to a WebID
-    // (or any other URI) is documentController.
+    // the canonical way to pin the document controller is
+    // documentController.
     const out = provisionOwnerKey({ webId, documentController: webId });
     assert.strictEqual(out.document.controller, webId);
     assert.strictEqual(out.vm.controller, webId,
       'VM controller still uses webId regardless of documentController');
+  });
+
+  it('keeps document.controller and vm.controller decoupled by design', () => {
+    // Asymmetric on purpose: vm.controller lives inside the WebID
+    // profile and identifies who in WebID-land can present this VM
+    // (always the pod owner = webId). document.controller lives in
+    // /private/privkey.jsonld and identifies the key in its own right
+    // (defaults to did:nostr, can be overridden to any custom DID
+    // method or URI). The two are distinct semantically; the JSDoc
+    // on provisionOwnerKey spells this out.
+    const out = provisionOwnerKey({ webId, documentController: 'urn:example:custom' });
+    assert.strictEqual(out.document.controller, 'urn:example:custom');
+    assert.strictEqual(out.vm.controller, webId,
+      'vm.controller intentionally tracks webId, not documentController');
   });
 });
 


### PR DESCRIPTION
## Summary

Closes the LWS-CID auth loop with the Phase 1 keypair. Three small wires:

1. **Inject the Phase 1 public key into the seeded WebID profile.** `provisionOwnerKey()` now also returns a `verificationMethod` entry (Multikey + JWK forms). `createPodStructure` / `createRootPodStructure` pass it to `generateProfile` so the existing LWS-CID verifier in `src/auth/lws-cid.js` can authenticate JWTs signed with the on-disk secret. Same VM `id` is referenced from `authentication` and `assertionMethod` so the key counts as an auth factor without an app having to PATCH those arrays.
2. **Flip the Multikey controller** in `/private/privkey.jsonld` from the WebID to `did:nostr:<hex>` (resolves locally via the existing `resolveDidNostrLocally` / `resolveDidNostrToWebId`). Phase 1's design log explicitly anticipated this swap; Phase 2 ships it.
3. **Normalize the secret to BIP-340 even-y form** at generation time. Without this, ECDSA sigs from the raw secret would verify against the natural y of `G*secret` (even/odd ~50/50), while the JWK we publish is derived from the even-y x-only Schnorr pubkey — Phase 2's round-trip would flake non-deterministically. Normalizing once means one secret works under both Schnorr (Nostr) and ECDSA (LWS-CID JWT) with no parity gymnastics.

No new dependencies. No changes to `src/auth/lws-cid.js`, `src/auth/did-nostr.js`, or the profile generator's `@context`. Two wires + controller flip + parity fix.

## Tests

`npm test` — **854/854 passing**.

- Unit (`test/keys-provision.test.js`): did:nostr controller default + explicit override (Phase 1 backward-compat), VM shape (Multikey + JWK), legacy `controllerWebId` arg still honoured, secret normalization stress (64 iterations).
- Integration (`test/keys-provision-integration.test.js`): direct `createPodStructure` call returns the new `ownerKey` shape (`vm` + `didNostr`).
- **End-to-end round-trip** (new file `test/keys-provision-lws-cid.test.js`): provision a key → generate a profile with the VM → sign an LWS-CID JWT with the on-disk secret → call `verifyLwsCidAuth` → returns the pod owner WebID. Plus a negative case (mismatched secret rejects with signature-verification error). This is **the** test that proves Phase 2 closes the loop.

## What's already in tree (didn't need building)

| Capability | Where |
|---|---|
| LWS-CID JWT verifier | `src/auth/lws-cid.js` |
| `did:nostr:` resolver + local well-known DID-doc | `src/auth/did-nostr.js`, `src/idp/well-known-did-nostr.js` |
| WebID profile generator with CID v1.0 `verificationMethod` slot | `src/webid/profile.js` |
| Pubkey extractor from a VM (handles Multikey + JWK with BIP-340 even-y check) | `src/auth/nostr-keys.js` |
| Phase 1 keypair generator + Multikey serializer | `src/keys/provision.js` |

## Test plan
- [x] `npm test` — 854/854 locally
- [x] End-to-end LWS-CID round-trip (positive + negative) covered by a dedicated test file
- [x] Backward-compat: legacy `controllerWebId` arg + explicit controller override still honoured
- [x] Parity-normalization stress (64 iterations all even-y)

## Out of scope (Phase 3+)
- `--key-passphrase` / scrypt+aesgcm wrap (Phase 3)
- BIP-39 seed phrase derivation (Phase 3)
- Hardware wallets / KMS / encrypted-at-rest (Phase 4)

Closes #443. Phase 2 of #437.
