### PR TITLE
feat: NIP-05 MVP — /.well-known/nostr.json on single-user provision (#446)

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -766,6 +766,7 @@ export function createServer(options = {}) {
     });
   }
 
+
   // LDP routes - using wildcard routing
   // Read operations - no rate limit (handled by bodyLimit)
   fastify.get('/*', handleGet);
@@ -1126,6 +1127,23 @@ export function createServer(options = {}) {
         throw new Error(
           'Failed to write owner key file at /private/privkey.jsonld'
         );
+      }
+
+      // NIP-05 mapping for the bare domain (#446). NIP-05 §3 reserves
+      // `_` as the "naked domain" identifier — a single-user pod IS
+      // the domain, so the owner's Nostr identity is just `<host>`
+      // with no `name@` prefix. The file is a plain JSON resource
+      // under the spec-mandated `.well-known/` namespace; jss already
+      // bypasses WAC for /.well-known/* and lets the LDP GET handler
+      // serve it as a static file. No new route needed.
+      await storage.createContainer('/.well-known/');
+      const nip05 = { names: { _: ownerKey.publicHex } };
+      const nip05Ok = await storage.write(
+        '/.well-known/nostr.json',
+        JSON.stringify(nip05, null, 2)
+      );
+      if (!nip05Ok) {
+        throw new Error('Failed to write /.well-known/nostr.json');
       }
     }
 

--- a/src/server.js
+++ b/src/server.js
@@ -1159,12 +1159,11 @@ export function createServer(options = {}) {
           'Failed to write owner key file at /private/privkey.jsonld'
         );
       }
-
     }
     // NIP-05 mapping is written outside this function (in the
     // single-user onReady block) so it covers both root pods and
     // named single-user pods (which take the createPodStructure
-    // path), not just the root case. See #447 review.
+    // path), not just the root case. See #446.
 
     // Generate profile (with the owner key's VM landed in
     // verificationMethod when --provision-keys is on). Written last —

--- a/src/server.js
+++ b/src/server.js
@@ -743,6 +743,14 @@ export function createServer(options = {}) {
     '/.well-known/did/nostr/',
     '/.well-known/did/nostr/:pubkeyAndExt',
     '/.well-known/did/nostr/*',
+    // /.well-known/nostr.json — NIP-05 mapping (#446). Same WAC-bypass
+    // concern as /.well-known/did/nostr/*: the global preHandler skips
+    // auth for /.well-known/* (the spec-mandated public namespace),
+    // so without 405 blocks the wildcard write handlers would let
+    // anyone PUT/DELETE/PATCH this file and hijack the pod's NIP-05
+    // identity. GET/HEAD reach the LDP layer normally and serve the
+    // file written by --provision-keys.
+    '/.well-known/nostr.json',
   ]) {
     fastify.put(pat, methodNotAllowed);
     fastify.post(pat, methodNotAllowed);
@@ -765,7 +773,6 @@ export function createServer(options = {}) {
       instance.head('/.well-known/did/nostr/:pubkeyAndExt', wellKnownDidNostr);
     });
   }
-
 
   // LDP routes - using wildcard routing
   // Read operations - no rate limit (handled by bodyLimit)
@@ -892,6 +899,30 @@ export function createServer(options = {}) {
             'Filesystem reads bypass WAC; use FDE / OS keyring / restrictive umask ' +
             'for any pod that matters. See docs/provision-keys.md.'
           );
+
+          // NIP-05 mapping for the bare domain (#446). Lives at the
+          // server root regardless of whether the pod is at / or
+          // /<name>/ — `.well-known/` is per-origin, not per-pod.
+          // This branch covers BOTH single-user shapes (root pod via
+          // createRootPodStructure, named pod via createPodStructure)
+          // because the file is logically server-level identity, not
+          // pod-internal data. Multi-user aggregation is the next
+          // slice of #445. WAC bypass on /.well-known/* is balanced
+          // by the 405 method-not-allowed guards registered earlier
+          // so an attacker can't PUT-overwrite this mapping.
+          await storage.createContainer('/.well-known/');
+          const nip05Ok = await storage.write(
+            '/.well-known/nostr.json',
+            JSON.stringify({ names: { _: creation.ownerKey.publicHex } }, null, 2)
+          );
+          if (!nip05Ok) {
+            fastify.log.warn(
+              'Failed to write /.well-known/nostr.json — pod is provisioned ' +
+              'but NIP-05 verification will not resolve to this server.'
+            );
+          } else {
+            fastify.log.info(`NIP-05 mapping at ${baseUrl}/.well-known/nostr.json`);
+          }
         }
       }
 
@@ -1129,23 +1160,11 @@ export function createServer(options = {}) {
         );
       }
 
-      // NIP-05 mapping for the bare domain (#446). NIP-05 §3 reserves
-      // `_` as the "naked domain" identifier — a single-user pod IS
-      // the domain, so the owner's Nostr identity is just `<host>`
-      // with no `name@` prefix. The file is a plain JSON resource
-      // under the spec-mandated `.well-known/` namespace; jss already
-      // bypasses WAC for /.well-known/* and lets the LDP GET handler
-      // serve it as a static file. No new route needed.
-      await storage.createContainer('/.well-known/');
-      const nip05 = { names: { _: ownerKey.publicHex } };
-      const nip05Ok = await storage.write(
-        '/.well-known/nostr.json',
-        JSON.stringify(nip05, null, 2)
-      );
-      if (!nip05Ok) {
-        throw new Error('Failed to write /.well-known/nostr.json');
-      }
     }
+    // NIP-05 mapping is written outside this function (in the
+    // single-user onReady block) so it covers both root pods and
+    // named single-user pods (which take the createPodStructure
+    // path), not just the root case. See #447 review.
 
     // Generate profile (with the owner key's VM landed in
     // verificationMethod when --provision-keys is on). Written last —

--- a/test/well-known-nostr-json.test.js
+++ b/test/well-known-nostr-json.test.js
@@ -118,15 +118,15 @@ describe('NIP-05 MVP — single-user without a provisioned key', () => {
 });
 
 describe('NIP-05 MVP — multi-user mode', () => {
-  let server;
+  let server, baseUrl;
   let savedDataRoot;
 
   before(async () => {
     savedDataRoot = process.env.DATA_ROOT;
-    // No singleUser → multi-user. createRootPodStructure isn't called;
-    // each pod's createPodStructure is, but the MVP only writes the
-    // NIP-05 file in single-user mode.
-    ({ server } = await startServer({}));
+    // No singleUser → multi-user. The MVP only writes the NIP-05
+    // file in single-user mode; aggregation across multi-user pods
+    // is the next slice of #445.
+    ({ server, baseUrl } = await startServer({}));
   });
 
   after(async () => {
@@ -135,10 +135,34 @@ describe('NIP-05 MVP — multi-user mode', () => {
     else process.env.DATA_ROOT = savedDataRoot;
   });
 
-  it('does not write a server-level NIP-05 file (aggregation is the next slice)', async () => {
+  it('still does not write a server-level NIP-05 file when a pod is provisioned with keys', async () => {
+    // Actually exercise the code path that *could* have written the
+    // file — provision a multi-user pod with provisionKeys: true via
+    // POST /.pods. The pod's own /<name>/private/privkey.jsonld
+    // lands as expected, but the server-level /.well-known/nostr.json
+    // must remain absent because this is multi-user mode.
+    const res = await fetch(`${baseUrl}/.pods`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'alice', provisionKeys: true })
+    });
+    assert.strictEqual(res.status, 201, 'pod creation must succeed');
+    const body = await res.json();
+    assert.ok(body.ownerKey, 'pod-level owner key must still be provisioned');
+
+    // The pod's own privkey IS on disk — sanity check the multi-user
+    // provisioning path still ran.
+    assert.strictEqual(
+      await fs.pathExists(`${DATA_DIR}/alice/private/privkey.jsonld`),
+      true,
+      'multi-user pod provisioning still writes the pod-internal privkey'
+    );
+
+    // …but no server-level NIP-05 file.
     assert.strictEqual(
       await fs.pathExists(`${DATA_DIR}/.well-known/nostr.json`),
-      false
+      false,
+      'multi-user mode must not write a server-level NIP-05 mapping'
     );
   });
 });

--- a/test/well-known-nostr-json.test.js
+++ b/test/well-known-nostr-json.test.js
@@ -1,0 +1,144 @@
+/**
+ * NIP-05 MVP — /.well-known/nostr.json on single-user pods (#446).
+ *
+ * Implementation is a static file written during pod creation, not
+ * a server-side handler. JSS already exposes /.well-known/* as a
+ * public namespace (WAC bypass + dotfile allow-list); the LDP GET
+ * handler serves the file like any other resource.
+ *
+ * Acceptance:
+ *   - single-user + --provision-keys → 200 { names: { _: <hex> } }
+ *     served at /.well-known/nostr.json, publicly readable, with
+ *     CORS open for browser-based NIP-05 verifiers.
+ *   - single-user without --provision-keys → no file written.
+ *   - multi-user → no file written (next slice of #445 aggregates).
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs-extra';
+import { createServer } from '../src/server.js';
+
+const DATA_DIR = './test-data-nip05';
+
+async function startServer(options = {}) {
+  await fs.remove(DATA_DIR);
+  await fs.ensureDir(DATA_DIR);
+  const server = createServer({
+    logger: false,
+    forceCloseConnections: true,
+    root: DATA_DIR,
+    ...options
+  });
+  await server.listen({ port: 0, host: '127.0.0.1' });
+  const baseUrl = `http://127.0.0.1:${server.server.address().port}`;
+  return { server, baseUrl };
+}
+
+async function stopServer(server) {
+  await server.close();
+  await fs.remove(DATA_DIR);
+}
+
+describe('NIP-05 MVP — single-user with provisioned key', () => {
+  let server, baseUrl;
+  let savedDataRoot;
+
+  before(async () => {
+    savedDataRoot = process.env.DATA_ROOT;
+    ({ server, baseUrl } = await startServer({
+      singleUser: true,
+      provisionKeys: true
+    }));
+  });
+
+  after(async () => {
+    await stopServer(server);
+    if (savedDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = savedDataRoot;
+  });
+
+  it('writes the NIP-05 mapping with the reserved `_` name', async () => {
+    const onDisk = JSON.parse(
+      await fs.readFile(`${DATA_DIR}/.well-known/nostr.json`, 'utf8')
+    );
+    assert.deepStrictEqual(Object.keys(onDisk.names), ['_'],
+      'MVP emits exactly one mapping (the `_` reserved name)');
+    assert.match(onDisk.names._, /^[0-9a-f]{64}$/,
+      'the `_` mapping must be a 32-byte hex pubkey');
+  });
+
+  it('serves the mapping over HTTP without auth (NIP-05 verifiers are unauth)', async () => {
+    const res = await fetch(`${baseUrl}/.well-known/nostr.json`);
+    assert.strictEqual(res.status, 200);
+    const body = await res.json();
+    assert.match(body.names._, /^[0-9a-f]{64}$/);
+  });
+
+  it('matches the same pubkey landed in the WebID profile VM', async () => {
+    // Cross-check: the NIP-05 pubkey and the profile's
+    // verificationMethod publicKeyMultibase should describe the
+    // same key. If they ever diverge, an LWS-CID verifier would
+    // accept the profile's VM but a NIP-05 verifier would attest
+    // to a different identity for the same domain.
+    const onDisk = JSON.parse(
+      await fs.readFile(`${DATA_DIR}/.well-known/nostr.json`, 'utf8')
+    );
+    const profile = JSON.parse(
+      await fs.readFile(`${DATA_DIR}/profile/card.jsonld`, 'utf8')
+    );
+    const vm = profile.verificationMethod[0];
+    assert.ok(vm.publicKeyMultibase.includes(onDisk.names._),
+      'NIP-05 pubkey hex must appear in the profile VM publicKeyMultibase');
+  });
+});
+
+describe('NIP-05 MVP — single-user without a provisioned key', () => {
+  let server;
+  let savedDataRoot;
+
+  before(async () => {
+    savedDataRoot = process.env.DATA_ROOT;
+    ({ server } = await startServer({ singleUser: true }));
+  });
+
+  after(async () => {
+    await stopServer(server);
+    if (savedDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = savedDataRoot;
+  });
+
+  it('does not create the file (nothing to publish)', async () => {
+    assert.strictEqual(
+      await fs.pathExists(`${DATA_DIR}/.well-known/nostr.json`),
+      false,
+      'no key → no NIP-05 mapping → no file'
+    );
+  });
+});
+
+describe('NIP-05 MVP — multi-user mode', () => {
+  let server;
+  let savedDataRoot;
+
+  before(async () => {
+    savedDataRoot = process.env.DATA_ROOT;
+    // No singleUser → multi-user. createRootPodStructure isn't called;
+    // each pod's createPodStructure is, but the MVP only writes the
+    // NIP-05 file in single-user mode.
+    ({ server } = await startServer({}));
+  });
+
+  after(async () => {
+    await stopServer(server);
+    if (savedDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = savedDataRoot;
+  });
+
+  it('does not write a server-level NIP-05 file (aggregation is the next slice)', async () => {
+    assert.strictEqual(
+      await fs.pathExists(`${DATA_DIR}/.well-known/nostr.json`),
+      false
+    );
+  });
+});

--- a/test/well-known-nostr-json.test.js
+++ b/test/well-known-nostr-json.test.js
@@ -19,15 +19,17 @@ import assert from 'node:assert';
 import fs from 'fs-extra';
 import { createServer } from '../src/server.js';
 
-const DATA_DIR = './test-data-nip05';
-
-async function startServer(options = {}) {
-  await fs.remove(DATA_DIR);
-  await fs.ensureDir(DATA_DIR);
+// Per-describe DATA_DIR suffixes so the three suites in this file
+// don't collide if --test-concurrency is ever raised above 1.
+// Currently 1 per the npm test script, but the latent risk was
+// flagged in the #447 review.
+async function startServer(dataDir, options = {}) {
+  await fs.remove(dataDir);
+  await fs.ensureDir(dataDir);
   const server = createServer({
     logger: false,
     forceCloseConnections: true,
-    root: DATA_DIR,
+    root: dataDir,
     ...options
   });
   await server.listen({ port: 0, host: '127.0.0.1' });
@@ -35,25 +37,26 @@ async function startServer(options = {}) {
   return { server, baseUrl };
 }
 
-async function stopServer(server) {
+async function stopServer(server, dataDir) {
   await server.close();
-  await fs.remove(DATA_DIR);
+  await fs.remove(dataDir);
 }
 
 describe('NIP-05 MVP — single-user with provisioned key', () => {
+  const DATA_DIR = './test-data-nip05-with-key';
   let server, baseUrl;
   let savedDataRoot;
 
   before(async () => {
     savedDataRoot = process.env.DATA_ROOT;
-    ({ server, baseUrl } = await startServer({
+    ({ server, baseUrl } = await startServer(DATA_DIR, {
       singleUser: true,
       provisionKeys: true
     }));
   });
 
   after(async () => {
-    await stopServer(server);
+    await stopServer(server, DATA_DIR);
     if (savedDataRoot === undefined) delete process.env.DATA_ROOT;
     else process.env.DATA_ROOT = savedDataRoot;
   });
@@ -94,16 +97,17 @@ describe('NIP-05 MVP — single-user with provisioned key', () => {
 });
 
 describe('NIP-05 MVP — single-user without a provisioned key', () => {
+  const DATA_DIR = './test-data-nip05-no-key';
   let server;
   let savedDataRoot;
 
   before(async () => {
     savedDataRoot = process.env.DATA_ROOT;
-    ({ server } = await startServer({ singleUser: true }));
+    ({ server } = await startServer(DATA_DIR, { singleUser: true }));
   });
 
   after(async () => {
-    await stopServer(server);
+    await stopServer(server, DATA_DIR);
     if (savedDataRoot === undefined) delete process.env.DATA_ROOT;
     else process.env.DATA_ROOT = savedDataRoot;
   });
@@ -118,6 +122,7 @@ describe('NIP-05 MVP — single-user without a provisioned key', () => {
 });
 
 describe('NIP-05 MVP — multi-user mode', () => {
+  const DATA_DIR = './test-data-nip05-multiuser';
   let server, baseUrl;
   let savedDataRoot;
 
@@ -126,11 +131,11 @@ describe('NIP-05 MVP — multi-user mode', () => {
     // No singleUser → multi-user. The MVP only writes the NIP-05
     // file in single-user mode; aggregation across multi-user pods
     // is the next slice of #445.
-    ({ server, baseUrl } = await startServer({}));
+    ({ server, baseUrl } = await startServer(DATA_DIR, {}));
   });
 
   after(async () => {
-    await stopServer(server);
+    await stopServer(server, DATA_DIR);
     if (savedDataRoot === undefined) delete process.env.DATA_ROOT;
     else process.env.DATA_ROOT = savedDataRoot;
   });


### PR DESCRIPTION
## Summary

NIP-05 MVP for single-user pods. Auto-publish `/.well-known/nostr.json` mapping the bare domain to the provisioned owner pubkey, so other Nostr clients can verify the pod's owner identity.

**No new route, no new module.** NIP-05 is a static JSON file at a well-known path. JSS already:
- allows `.well-known` through the dotfile filter
- bypasses WAC for `/.well-known/*` (it's the spec-mandated public namespace)
- serves files under the data dir via the LDP `GET /*` handler

So this is purely a file write in `createRootPodStructure` (single-user only for the MVP) alongside the privkey + profile writes. Same ordering as the other provisioning files: ACLs → privkey → NIP-05 → profile.

## What lands

For `jss start --single-user --provision-keys`:

```
GET /.well-known/nostr.json

{
  "names": {
    "_": "<provisioned pubkey hex>"
  }
}
```

NIP-05 §3 reserves `_` as the "naked domain" identifier — the user IS the domain, no `name@` prefix. For a single-user pod where the pod IS the server, that's the natural identifier. The pod owner's Nostr ID becomes `<host>`, verifiable in any NIP-05-aware client.

The file is publicly readable since `.well-known/` is the spec-mandated public namespace — JSS already short-circuits WAC for `/.well-known/*` at the request-handler layer (the same bypass that lets `.well-known/openid-configuration` and `.well-known/did/nostr/*` be reachable without auth). Operator-written `.acl` files don't apply here because the bypass runs *before* WAC enforcement; this is intentional (NIP-05 verifiers are unauthenticated by spec). Operators who want a different mapping should overwrite the file content; lockdown via WAC isn't meaningful for this resource.

## Out of scope (next slices of #445)

- Multi-user aggregation (path mode → one shared file; subdomain mode → per-subdomain).
- `?name=` query filter (NIP-05 §3).
- `relays` field auto-populated from `--nostr`.
- `nip46` remote signer.
- Per-pod opt-out / custom names.

## Tests

`npm test` — 860/860 passing locally (one pre-existing flake in `nostr-cid-vm.test.js` tracked as #438, unrelated to this change).

- File written with the correct shape on `--single-user --provision-keys`
- Served over HTTP without auth (NIP-05 verifiers are unauth)
- **Cross-check**: the NIP-05 pubkey matches the profile VM's `publicKeyMultibase` — same key in both places, no chance of identity drift
- Without `--provision-keys`: no file written
- Multi-user mode: no file written (aggregation is the next slice)

## Test plan
- [x] `npm test` — 860/860 + the known #438 flake
- [x] File-on-disk + HTTP-fetch + cross-check against profile VM all covered

Closes #446. MVP of #445.