### PR TITLE
feat: GET /idp/account/export — self-service pod data download (#353)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "microfed": "^0.0.14",
         "n3": "^1.26.0",
         "oidc-provider": "^9.6.0",
-        "sql.js": "^1.13.0"
+        "sql.js": "^1.13.0",
+        "tar-stream": "^3.2.0"
       },
       "bin": {
         "jss": "bin/jss.js"
@@ -608,6 +609,111 @@
         "fastq": "^1.17.1"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1015,6 +1121,15 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/fast-content-type-parse": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-1.1.0.tgz",
@@ -1029,6 +1144,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
     },
     "node_modules/fast-json-stringify": {
       "version": "5.16.1",
@@ -2250,6 +2371,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -2298,6 +2430,36 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/thread-stream": {
@@ -2961,6 +3123,60 @@
         "fastq": "^1.17.1"
       }
     },
+    "b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "requires": {}
+    },
+    "bare-events": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
+      "requires": {}
+    },
+    "bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "requires": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      }
+    },
+    "bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ=="
+    },
+    "bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "requires": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "requires": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      }
+    },
+    "bare-url": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+      "requires": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -3209,6 +3425,14 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
+    "events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "requires": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "fast-content-type-parse": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-1.1.0.tgz",
@@ -3223,6 +3447,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
     "fast-json-stringify": {
       "version": "5.16.1",
@@ -4041,6 +4270,16 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
     },
+    "streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "requires": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -4076,6 +4315,33 @@
       "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
+      }
+    },
+    "tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "requires": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "requires": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "requires": {
+        "b4a": "^1.6.4"
       }
     },
     "thread-stream": {

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "benchmark": "node benchmark.js"
   },
   "dependencies": {
-    "@noble/curves": "^1.2.0",
-    "@noble/hashes": "^1.3.2",
     "@fastify/middie": "^8.3.3",
     "@fastify/rate-limit": "^9.1.0",
     "@fastify/websocket": "^8.3.1",
+    "@noble/curves": "^1.2.0",
+    "@noble/hashes": "^1.3.2",
     "@simplewebauthn/server": "^13.2.2",
     "bcryptjs": "^3.0.3",
     "commander": "^14.0.2",
@@ -38,7 +38,8 @@
     "microfed": "^0.0.14",
     "n3": "^1.26.0",
     "oidc-provider": "^9.6.0",
-    "sql.js": "^1.13.0"
+    "sql.js": "^1.13.0",
+    "tar-stream": "^3.2.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/src/idp/export.js
+++ b/src/idp/export.js
@@ -1,0 +1,229 @@
+/**
+ * GET /idp/account/export — self-service pod data download (#353).
+ *
+ * The export side of the user-rights trio (#351 password change,
+ * #352 account delete, this). Authenticated owner downloads a
+ * streamed tar.gz of their pod tree + a manifest. End users walk
+ * away with what they own without operator help and without
+ * shell access.
+ *
+ * Per the Credible Exit framing (#448), the archive intentionally
+ * INCLUDES `/private/privkey.jsonld` when the pod was provisioned
+ * with `--provision-keys`. The user's secret IS theirs and must
+ * leave with them — refusing would make L4+ identity migration
+ * impossible. The endpoint is owner-authenticated; the secret
+ * never leaves the WAC perimeter to anyone but the owner.
+ *
+ * Streaming pipeline: tar.pack → zlib.createGzip → reply. Memory
+ * stays constant regardless of pod size; a multi-GB pod doesn't
+ * OOM the server.
+ *
+ * Failure modes:
+ *   401 — unauthenticated
+ *   403 — multi-user: no account for the caller's WebID
+ *   404 — pod directory unexpectedly missing (shouldn't happen for
+ *         an account with a valid WebID, but caught defensively)
+ *
+ * Out of scope: re-import, cross-server pod migration, periodic
+ * scheduled backups, partial / per-resource selection. See #353.
+ */
+
+import path from 'path';
+import fs from 'fs';
+import { promises as fsp } from 'fs';
+import zlib from 'zlib';
+import tar from 'tar-stream';
+import { getWebIdFromRequestAsync } from '../auth/token.js';
+import { findByWebId } from './accounts.js';
+
+/**
+ * @param {object} request - Fastify request
+ * @param {object} reply - Fastify reply
+ * @param {object} options
+ * @param {boolean} [options.singleUser]
+ * @param {string|null} [options.singleUserName] - null for root pod,
+ *   string for /<name>/ pod
+ * @param {string} [options.jssVersion] - written into the manifest
+ *   for forensic / "what server made this" purposes
+ */
+export async function handleExportAccount(request, reply, options = {}) {
+  // 1. Authenticate caller. Same path as DELETE /idp/account etc.;
+  // works with bearer tokens, LWS-CID JWTs, etc. — anything
+  // getWebIdFromRequestAsync resolves to a WebID.
+  const { webId, error: authError } = await getWebIdFromRequestAsync(request);
+  if (!webId) {
+    return reply.code(401).send({
+      error: 'invalid_token',
+      error_description: authError || 'Authentication required',
+    });
+  }
+
+  // 2. Resolve the pod tree on disk + the manifest data.
+  const dataRoot = process.env.DATA_ROOT || './data';
+  let podDir;
+  let accountRecord = null;
+  let manifest;
+
+  if (options.singleUser) {
+    // Single-user: pod is at `/` (root pod) or `/<name>/` based on
+    // singleUserName. There's at most one IDP account; if it exists
+    // include it, else emit a single-user manifest with no account.
+    const isRootPod = !options.singleUserName;
+    podDir = isRootPod
+      ? dataRoot
+      : path.join(dataRoot, options.singleUserName);
+
+    accountRecord = await findByWebId(webId);   // may be null in --no-idp mode
+    manifest = {
+      webId,
+      mode: 'single-user',
+      podName: isRootPod ? null : options.singleUserName,
+      exportedAt: new Date().toISOString(),
+      jssVersion: options.jssVersion ?? 'unknown',
+    };
+  } else {
+    // Multi-user: caller's WebID must resolve to an account record
+    // on this server. Same 403 shape as DELETE /idp/account uses
+    // when an authenticated WebID has no local account.
+    accountRecord = await findByWebId(webId);
+    if (!accountRecord) {
+      return reply.code(403).send({
+        error: 'forbidden',
+        error_description: 'No account found for authenticated WebID',
+      });
+    }
+    const podName = accountRecord.podName || accountRecord.username;
+    podDir = path.join(dataRoot, podName);
+    manifest = {
+      webId: accountRecord.webId,
+      username: accountRecord.username,
+      email: accountRecord.email,
+      podName,
+      mode: 'multi-user',
+      createdAt: accountRecord.createdAt,
+      exportedAt: new Date().toISOString(),
+      jssVersion: options.jssVersion ?? 'unknown',
+    };
+  }
+
+  // Defensive: the pod dir should exist for any legitimate caller.
+  // 404 lets the client distinguish "auth was fine, but there's
+  // nothing on disk" from a true server error.
+  try {
+    const st = await fsp.stat(podDir);
+    if (!st.isDirectory()) throw new Error('not a directory');
+  } catch {
+    return reply.code(404).send({
+      error: 'not_found',
+      error_description: `No pod directory at ${podDir}`,
+    });
+  }
+
+  // 3. Set headers and start streaming.
+  const slug = sanitizeSlug(webId);
+  const isoDate = manifest.exportedAt.replace(/[:.]/g, '-');
+  const filename = `jss-export-${slug}-${isoDate}.tar.gz`;
+
+  reply
+    .type('application/x-tar+gzip')
+    .header('Content-Disposition', `attachment; filename="${filename}"`)
+    .header('Cache-Control', 'no-store');
+
+  const pack = tar.pack();
+  const gzip = zlib.createGzip();
+  pack.pipe(gzip);
+
+  // Pump in the background; entries are added asynchronously below.
+  const streamingPromise = packExport({
+    pack,
+    podDir,
+    manifest,
+    accountRecord,
+  }).catch((err) => {
+    // Once headers + body bytes are out, the only thing we can do is
+    // destroy the stream and let Fastify surface the connection drop.
+    request.log?.error({ err }, 'pod export failed mid-stream');
+    pack.destroy(err);
+  });
+
+  // Don't await streamingPromise here — Fastify will close the
+  // response when `gzip` ends. We do attach the catch above so an
+  // error during traversal is logged instead of being swallowed.
+  void streamingPromise;
+
+  return reply.send(gzip);
+}
+
+async function packExport({ pack, podDir, manifest, accountRecord }) {
+  // Manifest first so consumers can read the shape before deciding
+  // whether to keep streaming the (potentially large) pod tree.
+  await addEntry(pack, 'jss-export/manifest.json',
+    Buffer.from(JSON.stringify(manifest, null, 2), 'utf8'));
+
+  // Account record minus passwordHash. Single-user mode without an
+  // IDP account skips this (no record to include).
+  if (accountRecord) {
+    const { passwordHash: _omit, ...safeAccount } = accountRecord;
+    await addEntry(pack, 'jss-export/account.json',
+      Buffer.from(JSON.stringify(safeAccount, null, 2), 'utf8'));
+  }
+
+  // Pod tree. Walk the directory, stream each file in turn. Symlinks
+  // are followed (we want the file content, not the link metadata).
+  await walkAndPack(pack, podDir, 'jss-export/pod');
+
+  pack.finalize();
+}
+
+/**
+ * Recursively pack `dir` into `pack` under the tar prefix `tarBase`.
+ */
+async function walkAndPack(pack, dir, tarBase) {
+  const entries = await fsp.readdir(dir, { withFileTypes: true });
+  for (const dirent of entries) {
+    const fullPath = path.join(dir, dirent.name);
+    const tarPath = `${tarBase}/${dirent.name}`;
+    if (dirent.isDirectory()) {
+      await walkAndPack(pack, fullPath, tarPath);
+    } else if (dirent.isFile()) {
+      const stat = await fsp.stat(fullPath);
+      // Stream the file into the entry — keeps memory constant
+      // even for large media files in a pod.
+      await new Promise((resolve, reject) => {
+        const entry = pack.entry(
+          { name: tarPath, size: stat.size, mode: stat.mode & 0o777 },
+          (err) => err ? reject(err) : resolve(),
+        );
+        fs.createReadStream(fullPath).pipe(entry);
+      });
+    }
+    // Symlinks, sockets, etc. are intentionally skipped — they're
+    // out of scope for "downloadable pod data" and would complicate
+    // restore semantics without serving a real use case.
+  }
+}
+
+/**
+ * Add a single in-memory entry to the tar pack. Promisified wrapper
+ * around `pack.entry({...}, callback)` so the caller can await.
+ */
+function addEntry(pack, name, content) {
+  return new Promise((resolve, reject) => {
+    pack.entry({ name, size: content.length }, content, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+/**
+ * Squash a WebID into something safe for a download filename.
+ * Just enough to be useful as a hint; doesn't need to round-trip.
+ */
+function sanitizeSlug(webId) {
+  return webId
+    .replace(/^https?:\/\//, '')
+    .replace(/[#?].*$/, '')
+    .replace(/[^A-Za-z0-9._-]+/g, '_')
+    .slice(0, 80) || 'pod';
+}

--- a/src/idp/export.js
+++ b/src/idp/export.js
@@ -149,11 +149,18 @@ export async function handleExportAccount(request, reply, options = {}) {
           'Authenticated WebID does not match the single-user account',
       });
     }
+    // manifest.podName mirrors the IDP account's podName (the OIDC
+    // short name) for parity with the multi-user branch — both
+    // branches now read podName from accountRecord, so a downstream
+    // importer keying on manifest.podName or account.json.podName
+    // gets the same answer regardless of server mode. Filesystem
+    // layout (root-pod vs /<name>/ pod) is conveyed by `mode` +
+    // the seeded podName ('me' for root-pod, singleUserName otherwise).
     manifest = {
       webId: accountRecord.webId,
       username: accountRecord.username,
       email: accountRecord.email,
-      podName: isRootPod ? null : options.singleUserName,
+      podName: accountRecord.podName,
       mode: 'single-user',
       createdAt: accountRecord.createdAt,
       exportedAt: new Date().toISOString(),
@@ -225,7 +232,13 @@ export async function handleExportAccount(request, reply, options = {}) {
   // error signal. We log on the server side and destroy the
   // pipeline so the client at least sees an aborted transfer rather
   // than a corrupt but seemingly-complete archive.
+  // Idempotent: invoked from pack.error, gzip.error, AND
+  // streamingPromise.catch. Destroying a stream re-emits 'error',
+  // which would re-enter this handler and produce duplicate log
+  // lines for one underlying failure. The destroyed-flag short-
+  // circuits all subsequent calls so a single failure logs once.
   const onStreamError = (err) => {
+    if (gzip.destroyed || pack.destroyed) return;
     request.log.error({ err }, 'pod export stream error');
     pack.destroy(err);
     gzip.destroy(err);
@@ -269,16 +282,16 @@ async function packExport({ pack, podDir, manifest, accountRecord, excludeAtRoot
   await addEntry(pack, 'jss-export/manifest.json',
     Buffer.from(JSON.stringify(manifest, null, 2), 'utf8'));
 
-  // Account record — allowlisted fields only. Single-user without
-  // an IDP account skips this (no record to include).
-  if (accountRecord) {
-    const safeAccount = {};
-    for (const key of ACCOUNT_EXPORT_FIELDS) {
-      if (accountRecord[key] !== undefined) safeAccount[key] = accountRecord[key];
-    }
-    await addEntry(pack, 'jss-export/account.json',
-      Buffer.from(JSON.stringify(safeAccount, null, 2), 'utf8'));
+  // Account record — allowlisted fields only. Both branches in
+  // handleExportAccount now refuse with 403 when accountRecord is
+  // null, so by the time we get here the record is always defined
+  // and account.json is always emitted.
+  const safeAccount = {};
+  for (const key of ACCOUNT_EXPORT_FIELDS) {
+    if (accountRecord[key] !== undefined) safeAccount[key] = accountRecord[key];
   }
+  await addEntry(pack, 'jss-export/account.json',
+    Buffer.from(JSON.stringify(safeAccount, null, 2), 'utf8'));
 
   // Pod tree. The first-level filter (`excludeAtRoot`) is what
   // prevents single-user-root-pod mode from leaking .idp/.

--- a/src/idp/export.js
+++ b/src/idp/export.js
@@ -90,6 +90,15 @@ const ROOT_POD_EXCLUDE = new Set(['.idp', '.private']);
  * Adding a new field here requires a security review. Passkey
  * credentials are intentionally NOT included — they're device-
  * bound and not portable to a fresh server.
+ *
+ * !!! TOP-LEVEL ONLY. The allowlist gates only at the first level
+ * of the account record. If a future field is itself an
+ * object/array (e.g. `oidcClientConfig: { secret: ... }`,
+ * `metadata: { recoveryAnswers: [...] }`, etc.), allowlisting the
+ * top-level key alone exports the entire nested structure
+ * including any secrets. Nested structures need their own scrubbing
+ * before being added here, OR they should be projected into a flat
+ * shape that excludes the secret-bearing fields.
  */
 const ACCOUNT_EXPORT_FIELDS = [
   'id', 'webId', 'username', 'email', 'podName', 'createdAt', 'updatedAt',
@@ -97,6 +106,14 @@ const ACCOUNT_EXPORT_FIELDS = [
 ];
 
 /**
+ * Error vocabulary note: 401 uses the OAuth-Bearer-defined
+ * `invalid_token` (RFC 6750), while 403/404 use plain HTTP-semantic
+ * tokens (`forbidden`, `not_found`). This mixed convention is
+ * deliberate and consistent with the rest of `src/idp/` (see
+ * credentials.js: 401→`invalid_token`/`invalid_grant`, 403→
+ * `forbidden`, 400→`invalid_request`). Aligning to a single
+ * vocabulary across the whole IdP surface is its own refactor.
+ *
  * @param {object} request - Fastify request
  * @param {object} reply - Fastify reply
  * @param {object} options
@@ -191,6 +208,29 @@ export async function handleExportAccount(request, reply, options = {}) {
     };
   }
 
+  // Defense-in-depth: in multi-user mode `excludeAtRoot` is null
+  // because the pod is at <dataRoot>/<podName>/ (already isolated
+  // from server-internal dotfiles by the path layout). But if
+  // account-creation validation ever regressed and allowed a
+  // username matching `.idp` / `.private`, podDir would resolve to
+  // the server-internal directory and the export would happily
+  // walk it. Refuse here — account creation rejecting these names
+  // is the primary defense; this is the second line.
+  if (
+    !(options.singleUser && isRootPod) &&
+    ROOT_POD_EXCLUDE.has(path.basename(podDir))
+  ) {
+    request.log.error(
+      { podDir, basename: path.basename(podDir) },
+      'export refused — podDir resolved to a server-internal name; ' +
+      'account-creation validation regression?',
+    );
+    return reply.code(500).send({
+      error: 'server_error',
+      error_description: 'Pod resolution conflicts with server-internal layout',
+    });
+  }
+
   // Defensive: the pod dir should exist for any legitimate caller.
   // 404 lets the client distinguish "auth was fine, but there's
   // nothing on disk" from a true server error.
@@ -252,12 +292,21 @@ export async function handleExportAccount(request, reply, options = {}) {
   // multi-GB pod that's wasted IO + fds until the walk finishes.
   // Destroying both ends short-circuits the walk via stream error
   // propagation; the request.log captures the abort for diagnostics.
+  //
+  // The `packFinished` flag closes a race window: socket 'close'
+  // can briefly observe `writableEnded === false` on a perfectly
+  // normal completion (between socket close and writableEnded
+  // flipping), which would log a spurious "client disconnected"
+  // warn line for successful exports on slow/congested writes.
+  // We set the flag synchronously after pack.finalize() resolves
+  // so the close handler can distinguish "real disconnect mid-walk"
+  // from "natural end of stream".
+  let packFinished = false;
   reply.raw.on('close', () => {
-    if (!reply.raw.writableEnded) {
-      request.log.warn('pod export client disconnected mid-stream');
-      pack.destroy(new Error('client disconnected'));
-      gzip.destroy(new Error('client disconnected'));
-    }
+    if (packFinished || reply.raw.writableEnded) return;
+    request.log.warn('pod export client disconnected mid-stream');
+    pack.destroy(new Error('client disconnected'));
+    gzip.destroy(new Error('client disconnected'));
   });
 
   // Pump in the background; entries are added asynchronously below.
@@ -269,7 +318,7 @@ export async function handleExportAccount(request, reply, options = {}) {
     manifest,
     accountRecord,
     excludeAtRoot: (options.singleUser && isRootPod) ? ROOT_POD_EXCLUDE : null,
-  }).catch(onStreamError);
+  }).then(() => { packFinished = true; }).catch(onStreamError);
 
   void streamingPromise;
 

--- a/src/idp/export.js
+++ b/src/idp/export.js
@@ -41,7 +41,8 @@
  */
 
 import path from 'path';
-import { promises as fsp } from 'fs';
+import { promises as fsp, constants as fsConstants } from 'fs';
+import crypto from 'crypto';
 import zlib from 'zlib';
 import tar from 'tar-stream';
 import { getWebIdFromRequestAsync } from '../auth/token.js';
@@ -159,7 +160,35 @@ export async function handleExportAccount(request, reply, options = {}) {
     // idpEnabled, so a missing account record means "caller is not
     // the seeded owner" — refuse with the same 403 shape as
     // multi-user.
-    isRootPod = !options.singleUserName;
+    //
+    // Refuse empty-string / non-string singleUserName explicitly.
+    // The previous `!singleUserName` falsy-check silently mapped
+    // both '' and null to root-pod, but '' is almost certainly a
+    // misconfiguration — an operator who meant root-pod omits the
+    // option entirely, and an operator who meant a named pod
+    // wouldn't use empty string. WORSE, with `!''`=true the old
+    // code took the root-pod branch and applied ROOT_POD_EXCLUDE;
+    // a strict null check WITHOUT this refusal would take the
+    // named-pod branch with podDir = path.join(dataRoot, '') =
+    // dataRoot AND excludeAtRoot = null, silently exporting
+    // server-internal `.idp/` and `.private/`. So we explicitly
+    // reject the empty-string / non-string case before deciding
+    // isRootPod.
+    if (
+      options.singleUserName !== null &&
+      options.singleUserName !== undefined &&
+      (typeof options.singleUserName !== 'string' || options.singleUserName.length === 0)
+    ) {
+      request.log.error(
+        { singleUserName: options.singleUserName },
+        'pod export refused — singleUserName must be null/undefined or a non-empty string',
+      );
+      return reply.code(500).send({
+        error: 'server_error',
+        error_description: 'Invalid singleUserName configuration',
+      });
+    }
+    isRootPod = options.singleUserName == null;
     podDir = isRootPod
       ? dataRoot
       : path.join(dataRoot, options.singleUserName);
@@ -285,11 +314,12 @@ export async function handleExportAccount(request, reply, options = {}) {
       err.code = 'ENOTDIR';
       throw err;
     }
-    // Pre-flight readability via the same call walkAndPack will use
-    // for its first iteration. Discard the result; walkAndPack will
-    // redo this — readdir on a top-level pod dir is O(top-level
-    // entries) and cheap relative to the streamed walk.
-    await fsp.readdir(podDir);
+    // Pre-flight readability with `fsp.access(R_OK | X_OK)` rather
+    // than a discarded readdir — same effect (catches EACCES on the
+    // pod directory) without scanning the whole top-level entry
+    // list twice. R_OK gates listing, X_OK gates traversal into
+    // subdirectories, both required by the recursive walk.
+    await fsp.access(podDir, fsConstants.R_OK | fsConstants.X_OK);
   } catch (err) {
     if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) {
       request.log.warn({ podDir }, 'pod export: podDir missing or not a directory');
@@ -308,7 +338,12 @@ export async function handleExportAccount(request, reply, options = {}) {
   // 3. Set headers and start streaming.
   const slug = sanitizeSlug(webId);
   const isoDate = manifest.exportedAt.replace(/[:.]/g, '-');
-  const filename = `jss-export-${slug}-${isoDate}.tar.gz`;
+  // Short random suffix avoids collisions when a client batches
+  // exports — ISO timestamps have only millisecond resolution and
+  // two consecutive calls in the same ms would otherwise produce
+  // identical filenames that overwrite each other on the client.
+  const rand = crypto.randomBytes(3).toString('hex');  // 6 hex chars
+  const filename = `jss-export-${slug}-${isoDate}-${rand}.tar.gz`;
 
   // sanitizeSlug() restricts the slug to [A-Za-z0-9._-] and isoDate
   // is ISO-8601 with `:`/`.` replaced — both are strict-ASCII safe

--- a/src/idp/export.js
+++ b/src/idp/export.js
@@ -20,9 +20,16 @@
  *
  * Failure modes:
  *   401 — unauthenticated
- *   403 — multi-user: no account for the caller's WebID
+ *   403 — caller's WebID has no matching local account record;
+ *         applies to multi-user (no account for the WebID) and
+ *         single-user (authenticated WebID is not the seeded owner —
+ *         e.g. an external Solid-OIDC / LWS-CID identity)
  *   404 — pod directory unexpectedly missing (shouldn't happen for
  *         an account with a valid WebID, but caught defensively)
+ *   500 — defense-in-depth: podDir resolved to a server-internal
+ *         name (`.idp` / `.private` / etc.) in non-root-pod mode,
+ *         meaning account-creation validation has regressed and
+ *         allowed a reserved username through
  *
  * Cross-account access is structurally impossible: the endpoint
  * takes no target parameter and always scopes to the caller's
@@ -34,7 +41,6 @@
  */
 
 import path from 'path';
-import fs from 'fs';
 import { promises as fsp } from 'fs';
 import zlib from 'zlib';
 import tar from 'tar-stream';
@@ -233,14 +239,19 @@ export async function handleExportAccount(request, reply, options = {}) {
 
   // Defensive: the pod dir should exist for any legitimate caller.
   // 404 lets the client distinguish "auth was fine, but there's
-  // nothing on disk" from a true server error.
+  // nothing on disk" from a true server error. The
+  // error_description is intentionally generic — echoing the
+  // resolved podDir back would leak the operator's filesystem
+  // layout to any authenticated owner whose pod is missing. The
+  // path is in the server log via request context for debugging.
   try {
     const st = await fsp.stat(podDir);
     if (!st.isDirectory()) throw new Error('not a directory');
   } catch {
+    request.log.warn({ podDir }, 'pod export: podDir missing or not a directory');
     return reply.code(404).send({
       error: 'not_found',
-      error_description: `No pod directory at ${podDir}`,
+      error_description: 'Pod data not found',
     });
   }
 

--- a/src/idp/export.js
+++ b/src/idp/export.js
@@ -24,6 +24,11 @@
  *   404 — pod directory unexpectedly missing (shouldn't happen for
  *         an account with a valid WebID, but caught defensively)
  *
+ * Cross-account access is structurally impossible: the endpoint
+ * takes no target parameter and always scopes to the caller's
+ * authenticated WebID. There's no `403 cross-account` failure mode
+ * because there's no path to attempt the access in the first place.
+ *
  * Out of scope: re-import, cross-server pod migration, periodic
  * scheduled backups, partial / per-resource selection. See #353.
  */
@@ -35,6 +40,19 @@ import zlib from 'zlib';
 import tar from 'tar-stream';
 import { getWebIdFromRequestAsync } from '../auth/token.js';
 import { findByWebId } from './accounts.js';
+
+/**
+ * Entries at the data root that are server-internal, not pod data.
+ * In single-user *root* pod mode, podDir IS dataRoot — packing it
+ * naively would ship the IdP accounts (incl. passwordHash for every
+ * user), the IdP signing keys (mint tokens for any user), and OIDC
+ * adapter state (sessions, refresh tokens) to the caller. Skip them.
+ *
+ * Named-pod single-user (podDir = <dataRoot>/<name>/) and multi-user
+ * (podDir = <dataRoot>/<podName>/) don't hit this code path — the
+ * pod tree is already isolated by the path layout.
+ */
+const ROOT_POD_EXCLUDE = new Set(['.idp']);
 
 /**
  * @param {object} request - Fastify request
@@ -63,12 +81,13 @@ export async function handleExportAccount(request, reply, options = {}) {
   let podDir;
   let accountRecord = null;
   let manifest;
+  let isRootPod = false;
 
   if (options.singleUser) {
     // Single-user: pod is at `/` (root pod) or `/<name>/` based on
     // singleUserName. There's at most one IDP account; if it exists
     // include it, else emit a single-user manifest with no account.
-    const isRootPod = !options.singleUserName;
+    isRootPod = !options.singleUserName;
     podDir = isRootPod
       ? dataRoot
       : path.join(dataRoot, options.singleUserName);
@@ -124,37 +143,54 @@ export async function handleExportAccount(request, reply, options = {}) {
   const isoDate = manifest.exportedAt.replace(/[:.]/g, '-');
   const filename = `jss-export-${slug}-${isoDate}.tar.gz`;
 
+  // sanitizeSlug() restricts the slug to [A-Za-z0-9._-] and isoDate
+  // is ISO-8601 with `:`/`.` replaced — both are strict-ASCII safe
+  // for the legacy `filename=` form. Also emit `filename*=UTF-8''…`
+  // (RFC 5987) so any future non-ASCII slip-through degrades to
+  // valid UTF-8 percent-encoding rather than a malformed header.
+  const cdValue =
+    `attachment; filename="${filename}"; ` +
+    `filename*=UTF-8''${encodeURIComponent(filename)}`;
   reply
     .type('application/x-tar+gzip')
-    .header('Content-Disposition', `attachment; filename="${filename}"`)
+    .header('Content-Disposition', cdValue)
     .header('Cache-Control', 'no-store');
 
   const pack = tar.pack();
   const gzip = zlib.createGzip();
   pack.pipe(gzip);
 
+  // Surface stream-level errors. Once response headers are out an
+  // EACCES / mid-pack failure can otherwise present as a silently
+  // truncated download — the client gets 200 + partial gzip + no
+  // error signal. We log on the server side and destroy the
+  // pipeline so the client at least sees an aborted transfer rather
+  // than a corrupt but seemingly-complete archive.
+  const onStreamError = (err) => {
+    request.log?.error({ err }, 'pod export stream error');
+    pack.destroy(err);
+    gzip.destroy(err);
+  };
+  pack.on('error', onStreamError);
+  gzip.on('error', onStreamError);
+
   // Pump in the background; entries are added asynchronously below.
+  // The root-pod denylist is wired in so single-user-root-pod mode
+  // doesn't ship .idp/ (accounts + signing keys + OIDC state).
   const streamingPromise = packExport({
     pack,
     podDir,
     manifest,
     accountRecord,
-  }).catch((err) => {
-    // Once headers + body bytes are out, the only thing we can do is
-    // destroy the stream and let Fastify surface the connection drop.
-    request.log?.error({ err }, 'pod export failed mid-stream');
-    pack.destroy(err);
-  });
+    excludeAtRoot: (options.singleUser && isRootPod) ? ROOT_POD_EXCLUDE : null,
+  }).catch(onStreamError);
 
-  // Don't await streamingPromise here — Fastify will close the
-  // response when `gzip` ends. We do attach the catch above so an
-  // error during traversal is logged instead of being swallowed.
   void streamingPromise;
 
   return reply.send(gzip);
 }
 
-async function packExport({ pack, podDir, manifest, accountRecord }) {
+async function packExport({ pack, podDir, manifest, accountRecord, excludeAtRoot }) {
   // Manifest first so consumers can read the shape before deciding
   // whether to keep streaming the (potentially large) pod tree.
   await addEntry(pack, 'jss-export/manifest.json',
@@ -168,39 +204,80 @@ async function packExport({ pack, podDir, manifest, accountRecord }) {
       Buffer.from(JSON.stringify(safeAccount, null, 2), 'utf8'));
   }
 
-  // Pod tree. Walk the directory, stream each file in turn. Symlinks
-  // are followed (we want the file content, not the link metadata).
-  await walkAndPack(pack, podDir, 'jss-export/pod');
+  // Pod tree. The first-level filter (`excludeAtRoot`) is what
+  // prevents single-user-root-pod mode from leaking .idp/.
+  await walkAndPack(pack, podDir, 'jss-export/pod', excludeAtRoot);
 
   pack.finalize();
 }
 
 /**
  * Recursively pack `dir` into `pack` under the tar prefix `tarBase`.
+ *
+ * @param {Set<string>|null} excludeAtRoot - first-level names to skip
+ *   (applied only at the top of the walk; deeper entries pass freely).
+ *   Set to `ROOT_POD_EXCLUDE` in single-user-root-pod mode where
+ *   podDir is the data root and server-internal dotfiles live next
+ *   to pod data.
  */
-async function walkAndPack(pack, dir, tarBase) {
+async function walkAndPack(pack, dir, tarBase, excludeAtRoot = null) {
   const entries = await fsp.readdir(dir, { withFileTypes: true });
   for (const dirent of entries) {
+    if (excludeAtRoot && excludeAtRoot.has(dirent.name)) {
+      // Top-level server-internal dir — never appears in any export.
+      continue;
+    }
     const fullPath = path.join(dir, dirent.name);
     const tarPath = `${tarBase}/${dirent.name}`;
     if (dirent.isDirectory()) {
-      await walkAndPack(pack, fullPath, tarPath);
+      // Emit an explicit directory entry so empty LDP containers
+      // (a container the operator provisioned but hasn't populated)
+      // survive a round-trip — preserves the pod's LDP shape on
+      // restore. tar requires the trailing slash on directory names.
+      await addDirEntry(pack, `${tarPath}/`);
+      // No `excludeAtRoot` on recursion — the denylist is first-level only.
+      await walkAndPack(pack, fullPath, tarPath, null);
     } else if (dirent.isFile()) {
-      const stat = await fsp.stat(fullPath);
-      // Stream the file into the entry — keeps memory constant
-      // even for large media files in a pod.
-      await new Promise((resolve, reject) => {
-        const entry = pack.entry(
-          { name: tarPath, size: stat.size, mode: stat.mode & 0o777 },
-          (err) => err ? reject(err) : resolve(),
-        );
-        fs.createReadStream(fullPath).pipe(entry);
-      });
+      // Stream the file into the entry from an *open fd* — opens
+      // and stats off the same fd, so a concurrent truncate/grow
+      // can't desync `size` from the bytes actually piped. Without
+      // this, a stat-then-open dance would TOCTOU on a live pod
+      // and produce a corrupt tar that fails extraction.
+      const fh = await fsp.open(fullPath, 'r');
+      try {
+        const st = await fh.stat();
+        await new Promise((resolve, reject) => {
+          const entry = pack.entry(
+            { name: tarPath, size: st.size, mode: st.mode & 0o777 },
+            (err) => err ? reject(err) : resolve(),
+          );
+          const rs = fh.createReadStream({ autoClose: false });
+          rs.on('error', reject);
+          entry.on('error', reject);
+          rs.pipe(entry);
+        });
+      } finally {
+        await fh.close();
+      }
     }
-    // Symlinks, sockets, etc. are intentionally skipped — they're
-    // out of scope for "downloadable pod data" and would complicate
-    // restore semantics without serving a real use case.
+    // Symlinks, sockets, FIFOs, etc. are intentionally skipped —
+    // `dirent.isFile()` is false for those, even when the symlink
+    // points at a regular file. Out of scope for "downloadable pod
+    // data" and would complicate restore semantics.
   }
+}
+
+/**
+ * Add a tar directory entry. `tar-stream` distinguishes by name
+ * suffix (`/`) and explicit `type: 'directory'`.
+ */
+function addDirEntry(pack, name) {
+  return new Promise((resolve, reject) => {
+    pack.entry({ name, type: 'directory', size: 0 }, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
 }
 
 /**

--- a/src/idp/export.js
+++ b/src/idp/export.js
@@ -172,6 +172,31 @@ export async function handleExportAccount(request, reply, options = {}) {
           'Authenticated WebID does not match the single-user account',
       });
     }
+    // Defense-in-depth: in named-pod single-user mode, the seeded
+    // accountRecord.podName MUST equal options.singleUserName (the
+    // CLI option that derives podDir). If seedSingleUserIdpAccount
+    // ever drifted, manifest.podName (read from accountRecord) would
+    // advertise X while the pod tree is read from <dataRoot>/Y.
+    // Refuse with 500 so a seeding regression fails loudly rather
+    // than producing a silently mismatched archive.
+    //
+    // Skipped in root-pod mode where podDir is dataRoot regardless
+    // of the seeded podName (which is intentionally 'me' for OIDC
+    // identity, not a path component).
+    if (!isRootPod && accountRecord.podName !== options.singleUserName) {
+      request.log.error(
+        {
+          seededPodName: accountRecord.podName,
+          cliSingleUserName: options.singleUserName,
+        },
+        'pod export refused — accountRecord.podName disagrees with ' +
+        'singleUserName; seedSingleUserIdpAccount regression?',
+      );
+      return reply.code(500).send({
+        error: 'server_error',
+        error_description: 'Pod identity inconsistent with on-disk layout',
+      });
+    }
     // manifest.podName mirrors the IDP account's podName (the OIDC
     // short name) for parity with the multi-user branch — both
     // branches now read podName from accountRecord, so a downstream
@@ -237,21 +262,46 @@ export async function handleExportAccount(request, reply, options = {}) {
     });
   }
 
-  // Defensive: the pod dir should exist for any legitimate caller.
-  // 404 lets the client distinguish "auth was fine, but there's
-  // nothing on disk" from a true server error. The
-  // error_description is intentionally generic — echoing the
-  // resolved podDir back would leak the operator's filesystem
-  // layout to any authenticated owner whose pod is missing. The
-  // path is in the server log via request context for debugging.
+  // Pre-flight the pod directory BEFORE flushing response headers.
+  // We do both checks (stat for existence/type, readdir for
+  // readability) up front so a first-byte EACCES on the top-level
+  // readdir doesn't surface inside the streaming pipeline AFTER
+  // reply.send(gzip) has already flushed headers — that would leave
+  // the client with a 200 + truncated/empty body instead of a clean
+  // 5xx JSON error.
+  //
+  // 404 vs 500 split:
+  //   ENOENT/ENOTDIR → 404 (auth was fine, just no pod on disk)
+  //   anything else (EACCES, EIO, etc.) → 500 (server-side problem)
+  //
+  // Generic error_descriptions on the wire — echoing the resolved
+  // podDir back would leak the operator's filesystem layout. Path
+  // stays in the server log via request.log.{warn,error} for
+  // operator debugging.
   try {
     const st = await fsp.stat(podDir);
-    if (!st.isDirectory()) throw new Error('not a directory');
-  } catch {
-    request.log.warn({ podDir }, 'pod export: podDir missing or not a directory');
-    return reply.code(404).send({
-      error: 'not_found',
-      error_description: 'Pod data not found',
+    if (!st.isDirectory()) {
+      const err = new Error('not a directory');
+      err.code = 'ENOTDIR';
+      throw err;
+    }
+    // Pre-flight readability via the same call walkAndPack will use
+    // for its first iteration. Discard the result; walkAndPack will
+    // redo this — readdir on a top-level pod dir is O(top-level
+    // entries) and cheap relative to the streamed walk.
+    await fsp.readdir(podDir);
+  } catch (err) {
+    if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) {
+      request.log.warn({ podDir }, 'pod export: podDir missing or not a directory');
+      return reply.code(404).send({
+        error: 'not_found',
+        error_description: 'Pod data not found',
+      });
+    }
+    request.log.error({ err, podDir }, 'pod export: pre-flight failed');
+    return reply.code(500).send({
+      error: 'server_error',
+      error_description: 'Pod data is unreadable',
     });
   }
 
@@ -323,15 +373,18 @@ export async function handleExportAccount(request, reply, options = {}) {
   // Pump in the background; entries are added asynchronously below.
   // The root-pod denylist is wired in so single-user-root-pod mode
   // doesn't ship .idp/ (accounts + signing keys + OIDC state).
-  const streamingPromise = packExport({
+  // No `void` / no local — `.then().catch(onStreamError)` already
+  // attaches a rejection handler, so there's no unhandled-rejection
+  // risk and the pipeline runs detached.
+  packExport({
     pack,
     podDir,
     manifest,
     accountRecord,
     excludeAtRoot: (options.singleUser && isRootPod) ? ROOT_POD_EXCLUDE : null,
-  }).then(() => { packFinished = true; }).catch(onStreamError);
-
-  void streamingPromise;
+  })
+    .then(() => { packFinished = true; })
+    .catch(onStreamError);
 
   return reply.send(gzip);
 }

--- a/src/idp/export.js
+++ b/src/idp/export.js
@@ -63,6 +63,20 @@ import { findByWebId } from './accounts.js';
  * Named-pod single-user (podDir = <dataRoot>/<name>/) and multi-user
  * (podDir = <dataRoot>/<podName>/) don't hit this code path — the
  * pod tree is already isolated by the path layout.
+ *
+ * !!! SECURITY-CRITICAL — DO NOT ADD A NEW SERVER-INTERNAL TOP-LEVEL
+ * DIRECTORY WITHOUT ALSO ADDING IT HERE AND ADDING A REGRESSION TEST.
+ *
+ * We use a denylist (not an allowlist of pod-data subdirs) because
+ * pod content is open-ended — operators and apps create arbitrary
+ * top-level containers, and an allowlist would break Credible Exit
+ * by silently dropping legitimate user data. The trade-off: any new
+ * server-managed dotfile dir landing at the data root must be added
+ * here in the same PR that introduces it. The denylist test in
+ * test/idp-export.test.js asserts on the property "no IdP secrets
+ * appear in the archive" against on-disk seeded files, so it will
+ * regress loudly if a future feature drops a secret-bearing dir at
+ * the data root and forgets to update this set.
  */
 const ROOT_POD_EXCLUDE = new Set(['.idp', '.private']);
 
@@ -113,18 +127,35 @@ export async function handleExportAccount(request, reply, options = {}) {
 
   if (options.singleUser) {
     // Single-user: pod is at `/` (root pod) or `/<name>/` based on
-    // singleUserName. There's at most one IDP account; if it exists
-    // include it, else emit a single-user manifest with no account.
+    // singleUserName. The seeded IDP account (per
+    // seedSingleUserIdpAccount in src/server.js) is the sole owner —
+    // an authenticated WebID without a matching local account is
+    // some third-party identity (external Solid-OIDC, LWS-CID JWT,
+    // etc.), NOT the pod owner, and must not get the operator's
+    // /private/privkey.jsonld. The route is only mounted when
+    // idpEnabled, so a missing account record means "caller is not
+    // the seeded owner" — refuse with the same 403 shape as
+    // multi-user.
     isRootPod = !options.singleUserName;
     podDir = isRootPod
       ? dataRoot
       : path.join(dataRoot, options.singleUserName);
 
-    accountRecord = await findByWebId(webId);   // may be null in --no-idp mode
+    accountRecord = await findByWebId(webId);
+    if (!accountRecord) {
+      return reply.code(403).send({
+        error: 'forbidden',
+        error_description:
+          'Authenticated WebID does not match the single-user account',
+      });
+    }
     manifest = {
-      webId,
-      mode: 'single-user',
+      webId: accountRecord.webId,
+      username: accountRecord.username,
+      email: accountRecord.email,
       podName: isRootPod ? null : options.singleUserName,
+      mode: 'single-user',
+      createdAt: accountRecord.createdAt,
       exportedAt: new Date().toISOString(),
       jssVersion: options.jssVersion ?? 'unknown',
     };

--- a/src/idp/export.js
+++ b/src/idp/export.js
@@ -44,15 +44,43 @@ import { findByWebId } from './accounts.js';
 /**
  * Entries at the data root that are server-internal, not pod data.
  * In single-user *root* pod mode, podDir IS dataRoot — packing it
- * naively would ship the IdP accounts (incl. passwordHash for every
- * user), the IdP signing keys (mint tokens for any user), and OIDC
- * adapter state (sessions, refresh tokens) to the caller. Skip them.
+ * naively would ship server-managed material to the caller. Skip:
+ *
+ *   .idp/      — IDP accounts (passwordHash for every user!) +
+ *                 signing keys (mint tokens for any user) +
+ *                 OIDC adapter state (sessions, refresh tokens)
+ *   .private/  — pay/Bitcoin keypair + UTXO state (drainable)
+ *
+ * The pod's *own* /private/ folder (no leading dot) lives at
+ * <dataRoot>/private/ in root-pod mode and IS pod data — operator
+ * key, etc. — and is INCLUDED.
+ *
+ * Public namespaces under .well-known/ (webledgers, openid-config,
+ * etc.) are reachable by any HTTP client by spec, so they're
+ * "pod data" in the sense that they're part of the pod's public
+ * surface — included.
  *
  * Named-pod single-user (podDir = <dataRoot>/<name>/) and multi-user
  * (podDir = <dataRoot>/<podName>/) don't hit this code path — the
  * pod tree is already isolated by the path layout.
  */
-const ROOT_POD_EXCLUDE = new Set(['.idp']);
+const ROOT_POD_EXCLUDE = new Set(['.idp', '.private']);
+
+/**
+ * Allowlist of account record fields that are safe to include in
+ * `account.json`. Defensive: a denylist that strips only
+ * `passwordHash` would silently leak any future secret-bearing
+ * field added to the account schema (passkey credential records,
+ * OIDC client secrets, recovery tokens, etc.).
+ *
+ * Adding a new field here requires a security review. Passkey
+ * credentials are intentionally NOT included — they're device-
+ * bound and not portable to a fresh server.
+ */
+const ACCOUNT_EXPORT_FIELDS = [
+  'id', 'webId', 'username', 'email', 'podName', 'createdAt', 'updatedAt',
+  'passwordChangedAt', 'lastLoginAt',
+];
 
 /**
  * @param {object} request - Fastify request
@@ -167,12 +195,26 @@ export async function handleExportAccount(request, reply, options = {}) {
   // pipeline so the client at least sees an aborted transfer rather
   // than a corrupt but seemingly-complete archive.
   const onStreamError = (err) => {
-    request.log?.error({ err }, 'pod export stream error');
+    request.log.error({ err }, 'pod export stream error');
     pack.destroy(err);
     gzip.destroy(err);
   };
   pack.on('error', onStreamError);
   gzip.on('error', onStreamError);
+
+  // Client disconnect handler. Without this, walkAndPack keeps
+  // reading every file in the pod, opening file descriptors, and
+  // pushing into a gzip whose downstream socket is gone. For a
+  // multi-GB pod that's wasted IO + fds until the walk finishes.
+  // Destroying both ends short-circuits the walk via stream error
+  // propagation; the request.log captures the abort for diagnostics.
+  reply.raw.on('close', () => {
+    if (!reply.raw.writableEnded) {
+      request.log.warn('pod export client disconnected mid-stream');
+      pack.destroy(new Error('client disconnected'));
+      gzip.destroy(new Error('client disconnected'));
+    }
+  });
 
   // Pump in the background; entries are added asynchronously below.
   // The root-pod denylist is wired in so single-user-root-pod mode
@@ -196,10 +238,13 @@ async function packExport({ pack, podDir, manifest, accountRecord, excludeAtRoot
   await addEntry(pack, 'jss-export/manifest.json',
     Buffer.from(JSON.stringify(manifest, null, 2), 'utf8'));
 
-  // Account record minus passwordHash. Single-user mode without an
-  // IDP account skips this (no record to include).
+  // Account record — allowlisted fields only. Single-user without
+  // an IDP account skips this (no record to include).
   if (accountRecord) {
-    const { passwordHash: _omit, ...safeAccount } = accountRecord;
+    const safeAccount = {};
+    for (const key of ACCOUNT_EXPORT_FIELDS) {
+      if (accountRecord[key] !== undefined) safeAccount[key] = accountRecord[key];
+    }
     await addEntry(pack, 'jss-export/account.json',
       Buffer.from(JSON.stringify(safeAccount, null, 2), 'utf8'));
   }

--- a/src/idp/export.js
+++ b/src/idp/export.js
@@ -333,11 +333,12 @@ export async function handleExportAccount(request, reply, options = {}) {
   // error signal. We log on the server side and destroy the
   // pipeline so the client at least sees an aborted transfer rather
   // than a corrupt but seemingly-complete archive.
-  // Idempotent: invoked from pack.error, gzip.error, AND
-  // streamingPromise.catch. Destroying a stream re-emits 'error',
-  // which would re-enter this handler and produce duplicate log
-  // lines for one underlying failure. The destroyed-flag short-
-  // circuits all subsequent calls so a single failure logs once.
+  // Idempotent: invoked from pack.error, gzip.error, AND the
+  // .catch(onStreamError) chained on packExport(...) below.
+  // Destroying a stream re-emits 'error', which would re-enter this
+  // handler and produce duplicate log lines for one underlying
+  // failure. The destroyed-flag short-circuits all subsequent calls
+  // so a single failure logs once.
   const onStreamError = (err) => {
     if (gzip.destroyed || pack.destroyed) return;
     request.log.error({ err }, 'pod export stream error');
@@ -354,17 +355,23 @@ export async function handleExportAccount(request, reply, options = {}) {
   // Destroying both ends short-circuits the walk via stream error
   // propagation; the request.log captures the abort for diagnostics.
   //
-  // The `packFinished` flag closes a race window: socket 'close'
-  // can briefly observe `writableEnded === false` on a perfectly
-  // normal completion (between socket close and writableEnded
-  // flipping), which would log a spurious "client disconnected"
-  // warn line for successful exports on slow/congested writes.
-  // We set the flag synchronously after pack.finalize() resolves
-  // so the close handler can distinguish "real disconnect mid-walk"
-  // from "natural end of stream".
-  let packFinished = false;
+  // `responseFinished` closes a race window. We can't gate on
+  // `packExport`'s resolution: that fires when `pack.finalize()`
+  // returns, which is "we're done WRITING into the pipeline" — not
+  // "the client has received the bytes". For a multi-GB gzipped
+  // response over a slow link, the gap between those two events
+  // can be substantial, and a real client disconnect during the
+  // final flush would be silently swallowed (close handler
+  // short-circuits on a flag set too early). Gate instead on
+  // `reply.raw.on('finish')` — Node emits 'finish' when the last
+  // byte has been flushed to the OS socket buffer, AFTER which a
+  // 'close' event means "client disconnected after we were done"
+  // and is correctly ignored. Before 'finish', a 'close' is a
+  // genuine mid-stream disconnect and gets logged + cleans up.
+  let responseFinished = false;
+  reply.raw.on('finish', () => { responseFinished = true; });
   reply.raw.on('close', () => {
-    if (packFinished || reply.raw.writableEnded) return;
+    if (responseFinished || reply.raw.writableEnded) return;
     request.log.warn('pod export client disconnected mid-stream');
     pack.destroy(new Error('client disconnected'));
     gzip.destroy(new Error('client disconnected'));
@@ -373,18 +380,15 @@ export async function handleExportAccount(request, reply, options = {}) {
   // Pump in the background; entries are added asynchronously below.
   // The root-pod denylist is wired in so single-user-root-pod mode
   // doesn't ship .idp/ (accounts + signing keys + OIDC state).
-  // No `void` / no local — `.then().catch(onStreamError)` already
-  // attaches a rejection handler, so there's no unhandled-rejection
-  // risk and the pipeline runs detached.
+  // `.catch(onStreamError)` attaches a rejection handler so there's
+  // no unhandled-rejection risk; the pipeline runs detached.
   packExport({
     pack,
     podDir,
     manifest,
     accountRecord,
     excludeAtRoot: (options.singleUser && isRootPod) ? ROOT_POD_EXCLUDE : null,
-  })
-    .then(() => { packFinished = true; })
-    .catch(onStreamError);
+  }).catch(onStreamError);
 
   return reply.send(gzip);
 }

--- a/src/idp/index.js
+++ b/src/idp/index.js
@@ -24,6 +24,9 @@ import {
   handleCredentialsInfo,
   handleChangePassword,
   handleDeleteAccount,
+} from './credentials.js';
+import { handleExportAccount } from './export.js';
+import {
   handleAccountDeleteForm,
   setNoCacheClickjackHeaders,
 } from './credentials.js';
@@ -38,7 +41,7 @@ import { landingPage, accountDeletePage } from './views.js';
  * @param {string} options.issuer - The issuer URL
  */
 export async function idpPlugin(fastify, options) {
-  const { issuer, inviteOnly = false, singleUser = false } = options;
+  const { issuer, inviteOnly = false, singleUser = false, singleUserName = null, jssVersion } = options;
 
   if (!issuer) {
     throw new Error('IdP requires issuer URL');
@@ -295,6 +298,27 @@ export async function idpPlugin(fastify, options) {
     }
   }, async (request, reply) => {
     return handleDeleteAccount(request, reply, { singleUser });
+  });
+
+  // GET account export — authenticated owner downloads their pod tree as
+  // a streamed tar.gz (#353). MVP slice of the Credible Exit ladder
+  // (#448). Lighter rate-limit than the destructive endpoints — this is
+  // a read, but a heavy one (entire pod), so cap at 3/min/IP to deter
+  // abuse without blocking a legitimate operator pulling a backup.
+  fastify.get('/idp/account/export', {
+    config: {
+      rateLimit: {
+        max: 3,
+        timeWindow: '1 minute',
+        keyGenerator: (request) => request.ip
+      }
+    }
+  }, async (request, reply) => {
+    return handleExportAccount(request, reply, {
+      singleUser,
+      singleUserName,
+      jssVersion,
+    });
   });
 
   // GET account-delete form (#392) - human-friendly UI for #352. Public

--- a/src/idp/index.js
+++ b/src/idp/index.js
@@ -304,16 +304,18 @@ export async function idpPlugin(fastify, options) {
   // a read, but a heavy one (entire pod), so cap at 3/min to deter
   // abuse without blocking a legitimate operator pulling a backup.
   //
-  // Key by request.webId when present (so one user's heavy pull doesn't
-  // lock out everyone behind a shared NAT / proxy egress) and fall back
-  // to IP for unauthenticated requests (which 401 anyway, but the rate
-  // limiter runs before the handler).
+  // Keyed by IP, consistent with the other /idp/ endpoints. We can't
+  // honestly key by WebID here: the global auth hook in src/server.js
+  // skips /idp/* (so request.webId is unset at this phase) and the
+  // rate-limit keyGenerator is sync, so we can't await token
+  // verification inline. Per-user keying is a follow-up that needs
+  // a preParsing hook resolving auth before the limiter runs.
   fastify.get('/idp/account/export', {
     config: {
       rateLimit: {
         max: 3,
         timeWindow: '1 minute',
-        keyGenerator: (request) => request.webId || request.ip
+        keyGenerator: (request) => request.ip
       }
     }
   }, async (request, reply) => {

--- a/src/idp/index.js
+++ b/src/idp/index.js
@@ -24,12 +24,10 @@ import {
   handleCredentialsInfo,
   handleChangePassword,
   handleDeleteAccount,
-} from './credentials.js';
-import { handleExportAccount } from './export.js';
-import {
   handleAccountDeleteForm,
   setNoCacheClickjackHeaders,
 } from './credentials.js';
+import { handleExportAccount } from './export.js';
 import * as passkey from './passkey.js';
 import { addTrustedIssuer } from '../auth/solid-oidc.js';
 import { landingPage, accountDeletePage } from './views.js';
@@ -303,14 +301,19 @@ export async function idpPlugin(fastify, options) {
   // GET account export — authenticated owner downloads their pod tree as
   // a streamed tar.gz (#353). MVP slice of the Credible Exit ladder
   // (#448). Lighter rate-limit than the destructive endpoints — this is
-  // a read, but a heavy one (entire pod), so cap at 3/min/IP to deter
+  // a read, but a heavy one (entire pod), so cap at 3/min to deter
   // abuse without blocking a legitimate operator pulling a backup.
+  //
+  // Key by request.webId when present (so one user's heavy pull doesn't
+  // lock out everyone behind a shared NAT / proxy egress) and fall back
+  // to IP for unauthenticated requests (which 401 anyway, but the rate
+  // limiter runs before the handler).
   fastify.get('/idp/account/export', {
     config: {
       rateLimit: {
         max: 3,
         timeWindow: '1 minute',
-        keyGenerator: (request) => request.ip
+        keyGenerator: (request) => request.webId || request.ip
       }
     }
   }, async (request, reply) => {

--- a/src/idp/index.js
+++ b/src/idp/index.js
@@ -37,6 +37,18 @@ import { landingPage, accountDeletePage } from './views.js';
  * @param {FastifyInstance} fastify
  * @param {object} options
  * @param {string} options.issuer - The issuer URL
+ * @param {boolean} [options.inviteOnly=false] - If true, /idp/register
+ *   requires a valid invite code; public registration is disabled.
+ * @param {boolean} [options.singleUser=false] - Single-user mode.
+ *   Disables /idp/register and /idp/account DELETE; gates the
+ *   single-user branch in /idp/account/export.
+ * @param {string|null} [options.singleUserName=null] - Single-user
+ *   pod name. null → root pod (podDir = dataRoot); string → pod
+ *   lives at <dataRoot>/<name>/. Threaded into /idp/account/export
+ *   so the handler can resolve podDir + apply ROOT_POD_EXCLUDE.
+ * @param {string} [options.jssVersion] - Server version, written
+ *   into the export manifest for forensic / "what server made this"
+ *   purposes. Defaults to 'unknown' inside the export handler.
  */
 export async function idpPlugin(fastify, options) {
   const { issuer, inviteOnly = false, singleUser = false, singleUserName = null, jssVersion } = options;

--- a/src/server.js
+++ b/src/server.js
@@ -330,9 +330,14 @@ export function createServer(options = {}) {
     // export endpoint independent of any seedServerRoot work.
     let jssVersion = 'unknown';
     try {
-      // Synchronous read — createServer isn't async, and the file is
-      // tiny + on local disk. Same approach the existing config code
-      // uses for package.json metadata.
+      // Sync read because createServer isn't async and we need the
+      // version to thread into idpPlugin registration below. The file
+      // is tiny + on local disk. There is a second async read of
+      // package.json in the onReady hook for seedServerRoot — both
+      // are read-once at startup so drift is bounded to "package.json
+      // changed between two ~ms-apart reads", which doesn't happen
+      // in practice. Hoisting both into a memoized module-level
+      // helper is a worthwhile follow-up but out of scope for #353.
       const pkgRaw = readFileSync(join(__dirname, '..', 'package.json'), 'utf8');
       jssVersion = JSON.parse(pkgRaw).version;
     } catch { /* keep 'unknown' */ }

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,7 @@
 import Fastify from 'fastify';
 import rateLimit from '@fastify/rate-limit';
 import { readFile } from 'fs/promises';
+import { readFileSync } from 'fs';
 import { STATUS_CODES } from 'node:http';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -321,7 +322,23 @@ export function createServer(options = {}) {
 
   // Register Identity Provider plugin if enabled
   if (idpEnabled) {
-    fastify.register(idpPlugin, { issuer: idpIssuer, inviteOnly, singleUser });
+    // singleUserName + jssVersion are threaded through for the
+    // pod-data export endpoint (#353), which uses singleUserName to
+    // resolve the pod's on-disk path and writes the version into
+    // the export manifest for forensic / "what server made this"
+    // purposes. Reading the package.json lazily here keeps the
+    // export endpoint independent of any seedServerRoot work.
+    let jssVersion = 'unknown';
+    try {
+      // Synchronous read — createServer isn't async, and the file is
+      // tiny + on local disk. Same approach the existing config code
+      // uses for package.json metadata.
+      const pkgRaw = readFileSync(join(__dirname, '..', 'package.json'), 'utf8');
+      jssVersion = JSON.parse(pkgRaw).version;
+    } catch { /* keep 'unknown' */ }
+    fastify.register(idpPlugin, {
+      issuer: idpIssuer, inviteOnly, singleUser, singleUserName, jssVersion,
+    });
   }
 
   // Register Nostr relay if enabled

--- a/test/idp-export.test.js
+++ b/test/idp-export.test.js
@@ -1,0 +1,225 @@
+/**
+ * GET /idp/account/export — pod data export endpoint (#353).
+ *
+ * MVP slice of the Credible Exit ladder (#448). The end user takes
+ * their pod data with them, no operator help required.
+ *
+ * Coverage:
+ *   - 401 unauthenticated
+ *   - 403 cross-account (multi-user: caller authed as B can't pull A)
+ *   - 200 owner export → valid tar.gz containing manifest + account
+ *     + pod tree
+ *   - account.json never carries passwordHash
+ *   - manifest shape (webId, podName, mode, exportedAt, jssVersion)
+ *   - Single-user mode + --provision-keys: archive contains
+ *     /private/privkey.jsonld (per Credible Exit framing — the
+ *     user's secret IS theirs and must leave with them)
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs-extra';
+import path from 'path';
+import zlib from 'zlib';
+import tar from 'tar-stream';
+import { Readable } from 'stream';
+import { createServer } from '../src/server.js';
+
+async function startServer(dataDir, options = {}) {
+  await fs.remove(dataDir);
+  await fs.ensureDir(dataDir);
+  const server = createServer({
+    logger: false,
+    forceCloseConnections: true,
+    root: dataDir,
+    idp: true,
+    idpIssuer: 'http://127.0.0.1/',
+    ...options,
+  });
+  await server.listen({ port: 0, host: '127.0.0.1' });
+  const baseUrl = `http://127.0.0.1:${server.server.address().port}`;
+  return { server, baseUrl };
+}
+
+async function stopServer(server, dataDir) {
+  await server.close();
+  await fs.remove(dataDir);
+}
+
+/**
+ * Read a tar.gz archive from a Buffer or Response into a map of
+ * `{ filename: Buffer-content }`. Tests can then assert on filenames
+ * + content shapes without touching disk.
+ */
+async function unpackTarGz(buf) {
+  const out = {};
+  const extract = tar.extract();
+  await new Promise((resolve, reject) => {
+    extract.on('entry', (header, stream, next) => {
+      const chunks = [];
+      stream.on('data', (c) => chunks.push(c));
+      stream.on('end', () => {
+        out[header.name] = Buffer.concat(chunks);
+        next();
+      });
+      stream.on('error', reject);
+      stream.resume();
+    });
+    extract.on('finish', resolve);
+    extract.on('error', reject);
+    Readable.from(buf).pipe(zlib.createGunzip()).pipe(extract);
+  });
+  return out;
+}
+
+describe('GET /idp/account/export — multi-user', () => {
+  const DATA_DIR = './test-data-export-mu';
+  let server, baseUrl, aliceToken, bobToken;
+
+  before(async () => {
+    ({ server, baseUrl } = await startServer(DATA_DIR));
+    // Create two pods so the cross-account 403 case is real.
+    const aliceRes = await fetch(`${baseUrl}/.pods`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'alice', email: 'alice@example.com', password: 'pw-alice-123'
+      })
+    });
+    aliceToken = (await aliceRes.json()).token;
+    const bobRes = await fetch(`${baseUrl}/.pods`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'bob', email: 'bob@example.com', password: 'pw-bob-456'
+      })
+    });
+    bobToken = (await bobRes.json()).token;
+  });
+
+  after(async () => {
+    await stopServer(server, DATA_DIR);
+  });
+
+  it('returns 401 unauthenticated', async () => {
+    const res = await fetch(`${baseUrl}/idp/account/export`);
+    assert.strictEqual(res.status, 401);
+  });
+
+  it('returns 200 with a tar.gz for the authenticated owner', async () => {
+    const res = await fetch(`${baseUrl}/idp/account/export`, {
+      headers: { Authorization: `Bearer ${aliceToken}` }
+    });
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.headers.get('content-type'), 'application/x-tar+gzip');
+    assert.match(res.headers.get('content-disposition') || '', /^attachment; filename="jss-export-/);
+    const buf = Buffer.from(await res.arrayBuffer());
+    const files = await unpackTarGz(buf);
+
+    // Manifest first.
+    assert.ok(files['jss-export/manifest.json'], 'manifest must be present');
+    const manifest = JSON.parse(files['jss-export/manifest.json'].toString('utf8'));
+    assert.strictEqual(manifest.username, 'alice');
+    assert.strictEqual(manifest.podName, 'alice');
+    assert.strictEqual(manifest.mode, 'multi-user');
+    assert.match(manifest.exportedAt, /^\d{4}-\d{2}-\d{2}T/);
+    assert.match(manifest.webId, /alice\/profile\/card\.jsonld#me$/);
+
+    // Account record present, sans passwordHash.
+    assert.ok(files['jss-export/account.json'], 'account.json must be present');
+    const account = JSON.parse(files['jss-export/account.json'].toString('utf8'));
+    assert.strictEqual(account.username, 'alice');
+    assert.strictEqual(account.email, 'alice@example.com');
+    assert.strictEqual(account.passwordHash, undefined,
+      'account.json must NEVER include the password hash');
+
+    // Pod tree contents — at minimum the seeded files.
+    const podKeys = Object.keys(files).filter(k => k.startsWith('jss-export/pod/'));
+    assert.ok(podKeys.length > 0, 'pod tree must be packed');
+    assert.ok(podKeys.some(k => k.endsWith('profile/card.jsonld')),
+      'WebID profile must be in the export');
+    assert.ok(podKeys.some(k => k.endsWith('.acl')),
+      'ACL files must be in the export');
+  });
+
+  it("returns 403 for an authenticated caller exporting somebody else's account", async () => {
+    // bob is authenticated, but the export endpoint scopes to the
+    // caller's WebID — bob can only get bob's data, never alice's.
+    // The endpoint doesn't take a target parameter; cross-account is
+    // already prevented by design. This test pins that property by
+    // confirming bob's export contains bob, never alice.
+    const res = await fetch(`${baseUrl}/idp/account/export`, {
+      headers: { Authorization: `Bearer ${bobToken}` }
+    });
+    assert.strictEqual(res.status, 200);
+    const buf = Buffer.from(await res.arrayBuffer());
+    const files = await unpackTarGz(buf);
+    const manifest = JSON.parse(files['jss-export/manifest.json'].toString('utf8'));
+    assert.strictEqual(manifest.username, 'bob');
+    assert.strictEqual(manifest.podName, 'bob');
+    // No alice/* in bob's export.
+    const podKeys = Object.keys(files).filter(k => k.startsWith('jss-export/pod/'));
+    for (const k of podKeys) {
+      assert.doesNotMatch(k, /\/alice\//, `bob's export must not contain alice's data: ${k}`);
+    }
+  });
+});
+
+describe('GET /idp/account/export — single-user with --provision-keys', () => {
+  const DATA_DIR = './test-data-export-su-keys';
+  let server, baseUrl, ownerToken;
+
+  before(async () => {
+    ({ server, baseUrl } = await startServer(DATA_DIR, {
+      singleUser: true,
+      singleUserName: 'me',
+      singleUserPassword: 'pw-me-789',
+      provisionKeys: true,
+    }));
+    // Auth via the seeded IDP account password.
+    const credRes = await fetch(`${baseUrl}/idp/credentials`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ username: 'me', password: 'pw-me-789' }).toString(),
+    });
+    if (credRes.status === 200) {
+      const body = await credRes.json();
+      ownerToken = body.access_token || body.token;
+    }
+  });
+
+  after(async () => {
+    await stopServer(server, DATA_DIR);
+  });
+
+  it('exports the pod tree including the on-disk owner secret', async (t) => {
+    if (!ownerToken) {
+      t.skip('IDP credentials endpoint did not return a token in this layout');
+      return;
+    }
+    const res = await fetch(`${baseUrl}/idp/account/export`, {
+      headers: { Authorization: `Bearer ${ownerToken}` }
+    });
+    assert.strictEqual(res.status, 200);
+    const buf = Buffer.from(await res.arrayBuffer());
+    const files = await unpackTarGz(buf);
+
+    const manifest = JSON.parse(files['jss-export/manifest.json'].toString('utf8'));
+    assert.strictEqual(manifest.mode, 'single-user',
+      'manifest.mode reflects the server mode, not the existence of an account record');
+    assert.strictEqual(manifest.podName, 'me',
+      'singleUserName="me" → pod is at <DATA_ROOT>/me/ → podName is "me"');
+
+    // The on-disk secret must be in the archive — Credible Exit
+    // requires the user can leave with their identity, not just
+    // their bytes. Refusing to include the secret would make L4+
+    // identity migration impossible.
+    const podKeys = Object.keys(files).filter(k => k.startsWith('jss-export/pod/'));
+    assert.ok(
+      podKeys.some(k => k.endsWith('private/privkey.jsonld')),
+      `/private/privkey.jsonld must be in the archive (Credible Exit). Pod entries: ${podKeys.join(', ')}`
+    );
+    // And the WebID profile carrying the public side.
+    assert.ok(podKeys.some(k => k.endsWith('profile/card.jsonld')));
+  });
+});

--- a/test/idp-export.test.js
+++ b/test/idp-export.test.js
@@ -309,6 +309,24 @@ describe('GET /idp/account/export — single-user ROOT pod (denylist check)', ()
       'pod content must still be exported');
     assert.ok(podKeys.some(k => k.endsWith('private/privkey.jsonld')),
       'pod /private/ must still be exported (this is pod data, not server-internal)');
+
+    // Manifest shape in root-pod mode. Pins the parity property:
+    // manifest.podName MUST equal account.json.podName so a downstream
+    // importer keying on either field gets the same answer. Without
+    // this, root-pod previously emitted manifest.podName=null while
+    // accountRecord.podName='me' — silent disagreement in the same
+    // archive.
+    assert.ok(files['jss-export/manifest.json'], 'manifest.json must be present');
+    assert.ok(files['jss-export/account.json'], 'account.json must be present');
+    const manifest = JSON.parse(files['jss-export/manifest.json'].toString('utf8'));
+    const account = JSON.parse(files['jss-export/account.json'].toString('utf8'));
+    assert.strictEqual(manifest.mode, 'single-user');
+    assert.strictEqual(manifest.username, 'me',
+      'root-pod manifest carries the seeded username');
+    assert.strictEqual(manifest.podName, account.podName,
+      'manifest.podName must match account.json.podName — single source of truth');
+    assert.strictEqual(account.podName, 'me',
+      'seeded root-pod account.podName is "me" (the OIDC short name)');
   });
 });
 

--- a/test/idp-export.test.js
+++ b/test/idp-export.test.js
@@ -142,12 +142,12 @@ describe('GET /idp/account/export — multi-user', () => {
       'ACL files must be in the export');
   });
 
-  it("returns 403 for an authenticated caller exporting somebody else's account", async () => {
-    // bob is authenticated, but the export endpoint scopes to the
-    // caller's WebID — bob can only get bob's data, never alice's.
-    // The endpoint doesn't take a target parameter; cross-account is
-    // already prevented by design. This test pins that property by
-    // confirming bob's export contains bob, never alice.
+  it("scopes the export to the authenticated caller — no cross-account exposure", async () => {
+    // The endpoint takes no target parameter; the WebID is taken
+    // from the auth context. Cross-account access is structurally
+    // impossible to attempt (so there's no 403 case). This test
+    // pins the *property* by confirming bob's authenticated call
+    // returns bob's data and never anything from alice's pod.
     const res = await fetch(`${baseUrl}/idp/account/export`, {
       headers: { Authorization: `Bearer ${bobToken}` }
     });
@@ -162,6 +162,74 @@ describe('GET /idp/account/export — multi-user', () => {
     for (const k of podKeys) {
       assert.doesNotMatch(k, /\/alice\//, `bob's export must not contain alice's data: ${k}`);
     }
+  });
+});
+
+describe('GET /idp/account/export — single-user ROOT pod (denylist check)', () => {
+  // Critical: in single-user root-pod mode (the default since #348),
+  // podDir IS dataRoot. Without an explicit denylist, the export would
+  // ship `.idp/accounts/*.json` (every account record incl.
+  // passwordHash) AND `.idp/keys/` (the IdP signing keys that mint
+  // tokens for any user) to the caller. The handler must refuse to
+  // include `.idp/` at the top level.
+  const DATA_DIR = './test-data-export-root-pod';
+  let server, baseUrl, ownerToken;
+
+  before(async () => {
+    ({ server, baseUrl } = await startServer(DATA_DIR, {
+      singleUser: true,
+      // No singleUserName → root pod (#348 default)
+      singleUserName: null,
+      singleUserPassword: 'pw-root-321',
+      provisionKeys: true,
+    }));
+    const credRes = await fetch(`${baseUrl}/idp/credentials`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ username: 'me', password: 'pw-root-321' }).toString(),
+    });
+    if (credRes.status === 200) {
+      const body = await credRes.json();
+      ownerToken = body.access_token || body.token;
+    }
+  });
+
+  after(async () => {
+    await stopServer(server, DATA_DIR);
+  });
+
+  it('does NOT pack /.idp/ (accounts, signing keys, OIDC adapter state)', async (t) => {
+    if (!ownerToken) {
+      t.skip('IDP credentials handshake unavailable');
+      return;
+    }
+    // Sanity: confirm the IdP actually wrote .idp/ to disk so the
+    // denylist test is exercising a non-empty thing.
+    assert.ok(
+      await fs.pathExists(path.join(DATA_DIR, '.idp')),
+      'pre-condition: .idp/ must exist on disk for the test to be meaningful'
+    );
+    const res = await fetch(`${baseUrl}/idp/account/export`, {
+      headers: { Authorization: `Bearer ${ownerToken}` }
+    });
+    assert.strictEqual(res.status, 200);
+    const buf = Buffer.from(await res.arrayBuffer());
+    const files = await unpackTarGz(buf);
+
+    // Critical: NOTHING under jss-export/pod/.idp/ in the archive.
+    const idpEntries = Object.keys(files).filter(k =>
+      k.startsWith('jss-export/pod/.idp/') || k === 'jss-export/pod/.idp'
+    );
+    assert.strictEqual(idpEntries.length, 0,
+      `.idp/ must not be packed in single-user root-pod export. ` +
+      `Found: ${idpEntries.join(', ')}`);
+
+    // Sanity: actual pod content IS in the archive.
+    const podKeys = Object.keys(files).filter(k => k.startsWith('jss-export/pod/'));
+    assert.ok(podKeys.some(k => k.endsWith('profile/card.jsonld')),
+      'pod content must still be exported');
+    assert.ok(podKeys.some(k => k.endsWith('private/privkey.jsonld')),
+      'pod /private/ must still be exported (this is pod data, not server-internal)');
   });
 });
 

--- a/test/idp-export.test.js
+++ b/test/idp-export.test.js
@@ -74,11 +74,19 @@ async function unpackTarGz(buf) {
 
 describe('GET /idp/account/export — multi-user', () => {
   const DATA_DIR = './test-data-export-mu';
+  // Alice plants a uniquely-named marker resource in her pod. Bob's
+  // export must not contain anything matching this name OR contents.
+  // Anchors the cross-account test against the actual files-on-disk
+  // shape rather than the archive's prefix layout (which never embeds
+  // a username segment, so a plain `/alice/` regex would tautologically
+  // pass even if Bob's archive somehow contained Alice's bytes).
+  const ALICE_CANARY_NAME = 'alice-canary-do-not-leak.txt';
+  const ALICE_CANARY_BODY = 'ALICE_SECRET_CANARY_a7f3e9d1c4b2';
   let server, baseUrl, aliceToken, bobToken;
 
   before(async () => {
     ({ server, baseUrl } = await startServer(DATA_DIR));
-    // Create two pods so the cross-account 403 case is real.
+    // Create two pods so the cross-account property is real.
     const aliceRes = await fetch(`${baseUrl}/.pods`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -95,6 +103,14 @@ describe('GET /idp/account/export — multi-user', () => {
       })
     });
     bobToken = (await bobRes.json()).token;
+
+    // Plant the alice-only canary file directly on disk under
+    // <DATA_ROOT>/alice/. PUT through the LDP layer would also work
+    // but adds an auth round-trip we don't need for this assertion.
+    await fs.outputFile(
+      path.join(DATA_DIR, 'alice', ALICE_CANARY_NAME),
+      ALICE_CANARY_BODY,
+    );
   });
 
   after(async () => {
@@ -154,13 +170,39 @@ describe('GET /idp/account/export — multi-user', () => {
     assert.strictEqual(res.status, 200);
     const buf = Buffer.from(await res.arrayBuffer());
     const files = await unpackTarGz(buf);
+
+    // Manifest identifies bob.
     const manifest = JSON.parse(files['jss-export/manifest.json'].toString('utf8'));
     assert.strictEqual(manifest.username, 'bob');
     assert.strictEqual(manifest.podName, 'bob');
-    // No alice/* in bob's export.
-    const podKeys = Object.keys(files).filter(k => k.startsWith('jss-export/pod/'));
-    for (const k of podKeys) {
-      assert.doesNotMatch(k, /\/alice\//, `bob's export must not contain alice's data: ${k}`);
+
+    // Account record (the actual server-side record, not the manifest)
+    // identifies bob — guards against a bug where the wrong account
+    // is looked up but the manifest is built from the request webId.
+    assert.ok(files['jss-export/account.json'],
+      'account.json must be present in bob\'s export');
+    const account = JSON.parse(files['jss-export/account.json'].toString('utf8'));
+    assert.strictEqual(account.username, 'bob',
+      'account.json.username must be bob, not alice');
+    assert.strictEqual(account.email, 'bob@example.com');
+
+    // The alice-only canary file must NOT appear in bob's archive,
+    // by entry name or by entry contents. This is the substantive
+    // cross-account assertion — the previous `/alice/` regex check
+    // was tautological because pod-tree entries are namespaced by
+    // archive prefix (`jss-export/pod/...`), not by username segment.
+    const allKeys = Object.keys(files);
+    for (const k of allKeys) {
+      assert.ok(
+        !k.endsWith(ALICE_CANARY_NAME),
+        `bob's export must not contain alice's canary file: ${k}`,
+      );
+      // Body check: even if the entry name was reshaped, the canary
+      // body bytes must never appear in any of bob's archive entries.
+      assert.ok(
+        !files[k].includes(ALICE_CANARY_BODY),
+        `bob's export entry ${k} contains alice's canary body bytes`,
+      );
     }
   });
 });
@@ -168,10 +210,14 @@ describe('GET /idp/account/export — multi-user', () => {
 describe('GET /idp/account/export — single-user ROOT pod (denylist check)', () => {
   // Critical: in single-user root-pod mode (the default since #348),
   // podDir IS dataRoot. Without an explicit denylist, the export would
-  // ship `.idp/accounts/*.json` (every account record incl.
-  // passwordHash) AND `.idp/keys/` (the IdP signing keys that mint
-  // tokens for any user) to the caller. The handler must refuse to
-  // include `.idp/` at the top level.
+  // ship server-internal directories that live next to pod data:
+  //
+  //   .idp/      — every account record (incl. passwordHash) and the
+  //                IdP signing keys that mint tokens for any user
+  //   .private/  — pay handler's Bitcoin keypair + UTXO state
+  //                (recipient could drain pay balance / spend UTXOs)
+  //
+  // The handler must refuse to include either at the top level.
   const DATA_DIR = './test-data-export-root-pod';
   let server, baseUrl, ownerToken;
 
@@ -198,16 +244,30 @@ describe('GET /idp/account/export — single-user ROOT pod (denylist check)', ()
     await stopServer(server, DATA_DIR);
   });
 
-  it('does NOT pack /.idp/ (accounts, signing keys, OIDC adapter state)', async (t) => {
-    if (!ownerToken) {
-      t.skip('IDP credentials handshake unavailable');
-      return;
-    }
-    // Sanity: confirm the IdP actually wrote .idp/ to disk so the
-    // denylist test is exercising a non-empty thing.
+  it('does NOT pack server-internal dirs (.idp/, .private/) at root', async () => {
+    // Hard-fail rather than t.skip — a credentials regression must
+    // not silently disable this denylist test, which is the only
+    // assertion guarding against the catastrophic root-pod leak.
+    assert.ok(ownerToken,
+      'pre-condition: IDP credentials handshake must return a token; ' +
+      'a regression here would silently skip the denylist assertion');
+
+    // Sanity: confirm the server actually wrote these dirs to disk so
+    // the denylist assertion below is exercising real entries. We
+    // synthesize .private/ ourselves (pay handler only writes it on
+    // first /pay use) so the test doesn't depend on side-channel
+    // activity to be meaningful.
+    await fs.outputFile(
+      path.join(DATA_DIR, '.private', 'keypair.json'),
+      JSON.stringify({ canary: 'must-not-leak' }),
+    );
     assert.ok(
       await fs.pathExists(path.join(DATA_DIR, '.idp')),
       'pre-condition: .idp/ must exist on disk for the test to be meaningful'
+    );
+    assert.ok(
+      await fs.pathExists(path.join(DATA_DIR, '.private')),
+      'pre-condition: .private/ must exist on disk for the test to be meaningful'
     );
     const res = await fetch(`${baseUrl}/idp/account/export`, {
       headers: { Authorization: `Bearer ${ownerToken}` }
@@ -216,13 +276,14 @@ describe('GET /idp/account/export — single-user ROOT pod (denylist check)', ()
     const buf = Buffer.from(await res.arrayBuffer());
     const files = await unpackTarGz(buf);
 
-    // Critical: NOTHING under jss-export/pod/.idp/ in the archive.
-    const idpEntries = Object.keys(files).filter(k =>
-      k.startsWith('jss-export/pod/.idp/') || k === 'jss-export/pod/.idp'
+    // Critical: NOTHING under jss-export/pod/.idp/ or jss-export/pod/.private/.
+    const leakedEntries = Object.keys(files).filter(k =>
+      k.startsWith('jss-export/pod/.idp/') || k === 'jss-export/pod/.idp' ||
+      k.startsWith('jss-export/pod/.private/') || k === 'jss-export/pod/.private'
     );
-    assert.strictEqual(idpEntries.length, 0,
-      `.idp/ must not be packed in single-user root-pod export. ` +
-      `Found: ${idpEntries.join(', ')}`);
+    assert.strictEqual(leakedEntries.length, 0,
+      `Server-internal dirs must not be packed in root-pod export. ` +
+      `Found: ${leakedEntries.join(', ')}`);
 
     // Sanity: actual pod content IS in the archive.
     const podKeys = Object.keys(files).filter(k => k.startsWith('jss-export/pod/'));
@@ -260,11 +321,12 @@ describe('GET /idp/account/export — single-user with --provision-keys', () => 
     await stopServer(server, DATA_DIR);
   });
 
-  it('exports the pod tree including the on-disk owner secret', async (t) => {
-    if (!ownerToken) {
-      t.skip('IDP credentials endpoint did not return a token in this layout');
-      return;
-    }
+  it('exports the pod tree including the on-disk owner secret', async () => {
+    // Hard-fail rather than t.skip — a credentials regression must
+    // not silently turn this Credible Exit assertion into a no-op.
+    assert.ok(ownerToken,
+      'pre-condition: IDP credentials must return a token; a silent ' +
+      'skip here would mask a regression in single-user authentication');
     const res = await fetch(`${baseUrl}/idp/account/export`, {
       headers: { Authorization: `Bearer ${ownerToken}` }
     });

--- a/test/idp-export.test.js
+++ b/test/idp-export.test.js
@@ -97,6 +97,9 @@ describe('GET /idp/account/export — multi-user', () => {
   before(async () => {
     ({ server, baseUrl } = await startServer(DATA_DIR));
     // Create two pods so the cross-account property is real.
+    // Hard-fail on pod creation so a /.pods shape regression surfaces
+    // as "pod creation failed" rather than as cryptic 401s in every
+    // downstream test. Same pattern as the single-user before hooks.
     const aliceRes = await fetch(`${baseUrl}/.pods`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -104,7 +107,9 @@ describe('GET /idp/account/export — multi-user', () => {
         name: 'alice', email: 'alice@example.com', password: 'pw-alice-123'
       })
     });
+    assert.ok(aliceRes.ok, `alice pod creation failed: ${aliceRes.status}`);
     aliceToken = (await aliceRes.json()).token;
+    assert.ok(aliceToken, 'alice pod creation must return a token');
     const bobRes = await fetch(`${baseUrl}/.pods`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -112,7 +117,9 @@ describe('GET /idp/account/export — multi-user', () => {
         name: 'bob', email: 'bob@example.com', password: 'pw-bob-456'
       })
     });
+    assert.ok(bobRes.ok, `bob pod creation failed: ${bobRes.status}`);
     bobToken = (await bobRes.json()).token;
+    assert.ok(bobToken, 'bob pod creation must return a token');
 
     // Plant the alice-only canary file directly on disk under
     // <DATA_ROOT>/alice/. PUT through the LDP layer would also work

--- a/test/idp-export.test.js
+++ b/test/idp-export.test.js
@@ -24,8 +24,15 @@ import zlib from 'zlib';
 import tar from 'tar-stream';
 import { Readable } from 'stream';
 import { createServer } from '../src/server.js';
+import { createToken } from '../src/auth/token.js';
 
+// startServer/stopServer manage process.env.DATA_ROOT via a snapshot
+// stored on the returned server. createServer mutates DATA_ROOT
+// (src/server.js:175); without restore, subsequent unrelated tests
+// reading DATA_ROOT in this run see a stale path pointing at a
+// now-removed directory.
 async function startServer(dataDir, options = {}) {
+  const prevDataRoot = process.env.DATA_ROOT;
   await fs.remove(dataDir);
   await fs.ensureDir(dataDir);
   const server = createServer({
@@ -38,12 +45,15 @@ async function startServer(dataDir, options = {}) {
   });
   await server.listen({ port: 0, host: '127.0.0.1' });
   const baseUrl = `http://127.0.0.1:${server.server.address().port}`;
+  server.__prevDataRoot = prevDataRoot;
   return { server, baseUrl };
 }
 
 async function stopServer(server, dataDir) {
   await server.close();
   await fs.remove(dataDir);
+  if (server.__prevDataRoot === undefined) delete process.env.DATA_ROOT;
+  else process.env.DATA_ROOT = server.__prevDataRoot;
 }
 
 /**
@@ -256,18 +266,26 @@ describe('GET /idp/account/export — single-user ROOT pod (denylist check)', ()
     // the denylist assertion below is exercising real entries. We
     // synthesize .private/ ourselves (pay handler only writes it on
     // first /pay use) so the test doesn't depend on side-channel
-    // activity to be meaningful.
+    // activity to be meaningful. We also pin the IdP secret-bearing
+    // file specifically — the property under test is "no IdP secrets
+    // appear in the export", not just "no entries under one specific
+    // dotted prefix". A future refactor moving secrets out of
+    // `.idp/accounts/*.json` would fail this pre-condition loudly
+    // and force the denylist + assertion to be re-pinned to wherever
+    // the secrets moved.
     await fs.outputFile(
       path.join(DATA_DIR, '.private', 'keypair.json'),
       JSON.stringify({ canary: 'must-not-leak' }),
     );
+    const idpAccounts = await fs.readdir(path.join(DATA_DIR, '.idp', 'accounts'))
+      .catch(() => []);
+    const accountFiles = idpAccounts.filter(f => f.endsWith('.json'));
+    assert.ok(accountFiles.length > 0,
+      'pre-condition: .idp/accounts/*.json must exist (the actual ' +
+      'secret-bearing material that the denylist must keep out of the export)');
     assert.ok(
-      await fs.pathExists(path.join(DATA_DIR, '.idp')),
-      'pre-condition: .idp/ must exist on disk for the test to be meaningful'
-    );
-    assert.ok(
-      await fs.pathExists(path.join(DATA_DIR, '.private')),
-      'pre-condition: .private/ must exist on disk for the test to be meaningful'
+      await fs.pathExists(path.join(DATA_DIR, '.private', 'keypair.json')),
+      'pre-condition: .private/keypair.json must exist'
     );
     const res = await fetch(`${baseUrl}/idp/account/export`, {
       headers: { Authorization: `Bearer ${ownerToken}` }
@@ -339,6 +357,12 @@ describe('GET /idp/account/export — single-user with --provision-keys', () => 
       'manifest.mode reflects the server mode, not the existence of an account record');
     assert.strictEqual(manifest.podName, 'me',
       'singleUserName="me" → pod is at <DATA_ROOT>/me/ → podName is "me"');
+    // Single-user manifest now includes account-derived fields when an
+    // account record exists, matching the multi-user manifest shape so
+    // a downstream importer doesn't see different shapes per server mode.
+    assert.strictEqual(manifest.username, 'me');
+    assert.match(manifest.webId, /me\/profile\/card\.jsonld#me$/);
+    assert.ok(manifest.createdAt, 'manifest.createdAt must be populated from the seeded account');
 
     // The on-disk secret must be in the archive — Credible Exit
     // requires the user can leave with their identity, not just
@@ -351,5 +375,30 @@ describe('GET /idp/account/export — single-user with --provision-keys', () => 
     );
     // And the WebID profile carrying the public side.
     assert.ok(podKeys.some(k => k.endsWith('profile/card.jsonld')));
+  });
+
+  it('rejects an authenticated third-party WebID with 403', async () => {
+    // Single-user mode previously trusted ANY successfully-authenticated
+    // WebID and shipped the entire pod (incl. /private/privkey.jsonld)
+    // to the caller. If the server accepts external Solid-OIDC issuers,
+    // LWS-CID JWTs, or any non-local WebID, that meant a third party's
+    // bearer token was sufficient to download the operator's secret.
+    //
+    // The handler now refuses with 403 when the authenticated WebID
+    // does NOT match the seeded single-user account — same shape as
+    // the multi-user "no local account record" 403.
+    //
+    // We mint the third-party token with createToken (same HMAC
+    // SECRET the server uses) so verifyToken accepts the signature
+    // and getWebIdFromRequestAsync resolves to the foreign WebID.
+    const intruderWebId = 'http://attacker.example.com/profile/card.jsonld#me';
+    const intruderToken = createToken(intruderWebId, 3600);
+    const res = await fetch(`${baseUrl}/idp/account/export`, {
+      headers: { Authorization: `Bearer ${intruderToken}` }
+    });
+    assert.strictEqual(res.status, 403,
+      'authenticated-but-not-owner WebID must NOT receive the pod export');
+    const body = await res.json();
+    assert.strictEqual(body.error, 'forbidden');
   });
 });


### PR DESCRIPTION
## Summary

`GET /idp/account/export` — authenticated owner downloads their pod tree as a streamed tar.gz. The L0-3 backup MVP from the Credible Exit ladder (#448), and the third leg of the user-rights trio (#351 password change, #352 account delete, this).

## Archive shape

```
jss-export/
├── manifest.json   — webId, username, email, podName, mode,
│                     createdAt, exportedAt, jssVersion
├── account.json    — allowlisted fields only (id, webId,
│                     username, email, podName, createdAt, etc.)
│                     Never carries passwordHash, passkey
│                     credentials, OIDC client secrets, or any
│                     non-allowlisted field — adding a new
│                     allowlisted field requires security review.
└── pod/...         — entire pod tree, including /private/
```

In single-user *root* pod mode (`podDir = dataRoot`), `ROOT_POD_EXCLUDE` keeps server-internal directories out of the archive: `.idp/` (IDP accounts incl. passwordHash for every user, IDP signing keys, OIDC adapter state) and `.private/` (pay handler's Bitcoin keypair + UTXO state — drainable). Adding a new server-managed dotfile dir at the data root WITHOUT updating this set is a security bug; the regression test pins the property "no IdP secrets in the export" against on-disk seeded files.

## Authorization

- **Multi-user**: caller's WebID must resolve to a local account record (`findByWebId`); else 403.
- **Single-user**: same — caller's WebID must match the seeded single-user account; an authenticated third-party WebID (external Solid-OIDC, LWS-CID JWT, etc.) gets 403, not the operator's `/private/privkey.jsonld`.

## Design call: include `/private/privkey.jsonld`?

**Yes.** Per the Credible Exit framing in #448, the user's secret IS theirs and must leave with them. Refusing to export it would make L4+ identity migration impossible. The endpoint is owner-authenticated; the secret never leaves the WAC perimeter to anyone but the owner.

## Streaming

`tar.pack → zlib.createGzip → reply`. Memory stays constant regardless of pod size — a multi-GB pod doesn't OOM. Stream-error handler destroys the pipeline on mid-pack failures (so clients see an aborted transfer rather than a silently-truncated archive). Client-disconnect handler on `reply.raw.on('close')` short-circuits the walk so we don't keep reading every file in a multi-GB pod into a dead socket.

## Rate limiting

3/min, **keyed by source IP**, consistent with the other `/idp/` endpoints. Per-WebID keying isn't possible in the current code path: the global auth hook in `src/server.js` skips `/idp/*` (so `request.webId` is unset at the rate-limit phase) and `@fastify/rate-limit`'s `keyGenerator` is sync, so we can't await token verification inline. Per-user keying is a follow-up that needs a `preParsing` hook resolving auth before the limiter runs. Operators behind a NAT: the limit is shared across all users on the source IP.

## Tests

`test/idp-export.test.js` — 6/6 passing locally, full suite green.

- `401` unauthenticated
- `200` for the authenticated owner — valid tar.gz with manifest + account + pod tree
- `account.json` allowlist (no `passwordHash`)
- Cross-account: alice plants a uniquely-named canary file; bob's archive contains neither the canary name nor the canary body bytes
- Single-user-root-pod denylist: `.idp/accounts/*.json` and `.private/keypair.json` synthesized on disk pre-export, asserted absent from archive
- Single-user + `--provision-keys`: archive contains the on-disk `/private/privkey.jsonld` (Credible Exit), manifest carries `username`/`email`/`createdAt` parity with multi-user
- Single-user 403: third-party HMAC token with `attacker.example.com` WebID gets 403, not the operator's pod

`process.env.DATA_ROOT` is snapshotted/restored in `startServer`/`stopServer` to prevent cross-test leakage to subsequent test files in the same run.

## New dep

`tar-stream@^3.2.0`. Pure JS, no native bindings. Functional install footprint on Node is just `tar-stream` (~60K) — but the npm install also drops `streamx`, `b4a`, and the `bare-*` family (`bare-fs`, `bare-os`, `bare-path`, `bare-stream`, `bare-url`, `bare-events`) totaling ~4.4 MB on disk. Those `bare-*` packages exist for the [Bare](https://github.com/holepunchto/bare) runtime and are lazy-loaded only when running outside Node — on Node they sit on disk but never load, contributing zero runtime weight. Verified install + tests run cleanly on the Termux/mobile target.

The disk footprint matters more for our mobile/embedded targets than I'd want — tracked as #450 (replace `tar-stream` with a leaner producer, e.g. ~200 lines of hand-rolled POSIX ustar). Out of scope here; ship the working endpoint, optimize the dep tree as a focused follow-up.

## Out of scope (per #353)

- Re-import / cross-server pod migration (separate spec problem)
- Periodic / scheduled backups (operator concern, not per-user right)
- Partial / per-resource selection (defer until someone asks)
- UI button on `/idp/account` (endpoint first, UI follow-up)
- Per-WebID rate-limit keying (follow-up: needs preParsing-hook auth resolution)

Closes #353. First slice of #448.
