### PR TITLE
Fix OIDC server_error after account delete + re-create

### DIFF
--- a/src/idp/cookies.js
+++ b/src/idp/cookies.js
@@ -14,6 +14,12 @@ const SESSION_COOKIE_NAMES = [
   '_session.legacy.sig',
 ];
 
+function buildExpiredHeaders(secure) {
+  const attrs = 'Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax'
+    + (secure ? '; Secure' : '');
+  return SESSION_COOKIE_NAMES.map((name) => `${name}=; ${attrs}`);
+}
+
 /**
  * Expire oidc-provider session cookies on a Fastify reply.
  *
@@ -22,12 +28,11 @@ const SESSION_COOKIE_NAMES = [
  * oidc-provider's consent check (#452).
  *
  * @param {object} reply - Fastify reply object
+ * @param {object} [request] - Fastify request (used to detect HTTPS)
  */
-export function expireSessionCookies(reply) {
-  const expired = 'Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax';
-  reply.header('Set-Cookie', SESSION_COOKIE_NAMES.map(
-    (name) => `${name}=; ${expired}`,
-  ));
+export function expireSessionCookies(reply, request) {
+  const secure = request?.protocol === 'https' || process.env.NODE_ENV === 'production';
+  reply.header('Set-Cookie', buildExpiredHeaders(secure));
 }
 
 /**
@@ -39,8 +44,6 @@ export function expireSessionCookies(reply) {
  * @param {object} ctx - Koa context object
  */
 export function expireSessionCookiesKoa(ctx) {
-  const expired = 'Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax';
-  ctx.set('Set-Cookie', SESSION_COOKIE_NAMES.map(
-    (name) => `${name}=; ${expired}`,
-  ));
+  const secure = ctx.secure || process.env.NODE_ENV === 'production';
+  ctx.set('Set-Cookie', buildExpiredHeaders(secure));
 }

--- a/src/idp/cookies.js
+++ b/src/idp/cookies.js
@@ -1,0 +1,46 @@
+/**
+ * Shared cookie helpers for the IdP module.
+ *
+ * JSS doesn't register @fastify/cookie, so we emit Set-Cookie headers
+ * directly. oidc-provider sets four session cookies (_session,
+ * _session.sig, _session.legacy, _session.legacy.sig); all four must
+ * be expired together to fully clear the browser's session state.
+ */
+
+const SESSION_COOKIE_NAMES = [
+  '_session',
+  '_session.sig',
+  '_session.legacy',
+  '_session.legacy.sig',
+];
+
+/**
+ * Expire oidc-provider session cookies on a Fastify reply.
+ *
+ * Used by account deletion (credentials.js) and account switching
+ * (interactions.js) to prevent stale session references from crashing
+ * oidc-provider's consent check (#452).
+ *
+ * @param {object} reply - Fastify reply object
+ */
+export function expireSessionCookies(reply) {
+  const expired = 'Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax';
+  reply.header('Set-Cookie', SESSION_COOKIE_NAMES.map(
+    (name) => `${name}=; ${expired}`,
+  ));
+}
+
+/**
+ * Expire oidc-provider session cookies on a Koa context.
+ *
+ * Used by renderError in provider.js for stale-session recovery,
+ * where the response object is a Koa ctx, not a Fastify reply.
+ *
+ * @param {object} ctx - Koa context object
+ */
+export function expireSessionCookiesKoa(ctx) {
+  const expired = 'Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax';
+  ctx.set('Set-Cookie', SESSION_COOKIE_NAMES.map(
+    (name) => `${name}=; ${expired}`,
+  ));
+}

--- a/src/idp/credentials.js
+++ b/src/idp/credentials.js
@@ -11,6 +11,7 @@ import { authenticate, findByUsername, findByWebId, updatePassword, verifyPasswo
 import { getJwks } from './keys.js';
 import { getWebIdFromRequestAsync } from '../auth/token.js';
 import { accountDeletePage } from './views.js';
+import { expireSessionCookies } from './cookies.js';
 
 /**
  * Handle POST /idp/credentials
@@ -395,22 +396,6 @@ export function setNoCacheClickjackHeaders(reply) {
   reply.header('Pragma', 'no-cache');
   reply.header('X-Frame-Options', 'DENY');
   reply.header('Content-Security-Policy', "frame-ancestors 'none'");
-}
-
-/**
- * Expire oidc-provider session cookies so the browser doesn't send
- * stale references after account deletion (#452). Without this, the
- * next OIDC auth request sends cookies that reference a destroyed
- * session/grant, crashing in consent.js getOIDCScopeEncountered().
- */
-function expireSessionCookies(reply) {
-  const expired = 'Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly';
-  reply.header('Set-Cookie', [
-    `_session=; ${expired}`,
-    `_session.sig=; ${expired}`,
-    `_session.legacy=; ${expired}`,
-    `_session.legacy.sig=; ${expired}`,
-  ]);
 }
 
 /**

--- a/src/idp/credentials.js
+++ b/src/idp/credentials.js
@@ -364,6 +364,10 @@ export async function handleDeleteAccount(request, reply, options = {}) {
   // and rationale (#391 pass 2 / pass 3).
   const { purged } = await deleteAccountAndOptionallyPurge(request, account, purgeData);
 
+  // Expire OIDC session cookies so the browser doesn't send stale
+  // references on the next login attempt (#452).
+  expireSessionCookies(reply);
+
   reply.header('Cache-Control', 'no-store');
   reply.header('Pragma', 'no-cache');
   return {
@@ -391,6 +395,22 @@ export function setNoCacheClickjackHeaders(reply) {
   reply.header('Pragma', 'no-cache');
   reply.header('X-Frame-Options', 'DENY');
   reply.header('Content-Security-Policy', "frame-ancestors 'none'");
+}
+
+/**
+ * Expire oidc-provider session cookies so the browser doesn't send
+ * stale references after account deletion (#452). Without this, the
+ * next OIDC auth request sends cookies that reference a destroyed
+ * session/grant, crashing in consent.js getOIDCScopeEncountered().
+ */
+function expireSessionCookies(reply) {
+  const expired = 'Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly';
+  reply.header('Set-Cookie', [
+    `_session=; ${expired}`,
+    `_session.sig=; ${expired}`,
+    `_session.legacy=; ${expired}`,
+    `_session.legacy.sig=; ${expired}`,
+  ]);
 }
 
 /**
@@ -546,6 +566,10 @@ export async function handleAccountDeleteForm(request, reply, options = {}) {
   }
 
   const { purged } = await deleteAccountAndOptionallyPurge(request, account, purgeData);
+
+  // Expire OIDC session cookies so the browser doesn't send stale
+  // references on the next login attempt (#452).
+  expireSessionCookies(reply);
 
   // If the user asked for a purge but it didn't run (fs.remove threw,
   // path-relative check rejected, etc.), surface that on the success

--- a/src/idp/credentials.js
+++ b/src/idp/credentials.js
@@ -367,7 +367,7 @@ export async function handleDeleteAccount(request, reply, options = {}) {
 
   // Expire OIDC session cookies so the browser doesn't send stale
   // references on the next login attempt (#452).
-  expireSessionCookies(reply);
+  expireSessionCookies(reply, request);
 
   reply.header('Cache-Control', 'no-store');
   reply.header('Pragma', 'no-cache');
@@ -554,7 +554,7 @@ export async function handleAccountDeleteForm(request, reply, options = {}) {
 
   // Expire OIDC session cookies so the browser doesn't send stale
   // references on the next login attempt (#452).
-  expireSessionCookies(reply);
+  expireSessionCookies(reply, request);
 
   // If the user asked for a purge but it didn't run (fs.remove threw,
   // path-relative check rejected, etc.), surface that on the success

--- a/src/idp/interactions.js
+++ b/src/idp/interactions.js
@@ -9,6 +9,7 @@ import * as storage from '../storage/filesystem.js';
 import { createPodStructure } from '../handlers/container.js';
 import { validateInvite } from './invites.js';
 import { verifyNostrAuth, getNostrPubkey, verifyNostrPubkeyAgainstWebId } from '../auth/nostr.js';
+import { expireSessionCookies } from './cookies.js';
 
 // Security: Maximum body size for IdP form submissions (1MB)
 const MAX_BODY_SIZE = 1024 * 1024;
@@ -348,22 +349,10 @@ export async function handleSwitchAccount(request, reply, provider) {
     const ttl = Math.max(1, interaction.exp - Math.floor(Date.now() / 1000));
     await interaction.save(ttl);
 
-    // Clear the user-agent's session cookie too. The IdP runs with
-    // signed cookies (provider.js cookies.long.signed = true), so each
-    // session cookie has a paired `.sig`. The `.legacy` variant is
-    // created during identifier rotation and likewise has its own
-    // `.sig`. Clearing all four keeps the browser fully tidy. JSS
-    // doesn't register @fastify/cookie, so we emit Set-Cookie headers
-    // directly with an expired Expires + Max-Age=0. Server-side state
-    // is already gone via session.destroy() above — these expirations
+    // Clear the user-agent's session cookies. Server-side state is
+    // already gone via session.destroy() above — these expirations
     // are belt-and-suspenders.
-    const expired = 'Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly';
-    reply.header('Set-Cookie', [
-      `_session=; ${expired}`,
-      `_session.sig=; ${expired}`,
-      `_session.legacy=; ${expired}`,
-      `_session.legacy.sig=; ${expired}`,
-    ]);
+    expireSessionCookies(reply);
 
     // 303 See Other — explicitly forces the UA to issue GET on the
     // Location target. 302 leaves it ambiguous (and some legacy UAs

--- a/src/idp/interactions.js
+++ b/src/idp/interactions.js
@@ -352,7 +352,7 @@ export async function handleSwitchAccount(request, reply, provider) {
     // Clear the user-agent's session cookies. Server-side state is
     // already gone via session.destroy() above — these expirations
     // are belt-and-suspenders.
-    expireSessionCookies(reply);
+    expireSessionCookies(reply, request);
 
     // 303 See Other — explicitly forces the UA to issue GET on the
     // Location target. 302 leaves it ambiguous (and some legacy UAs

--- a/src/idp/provider.js
+++ b/src/idp/provider.js
@@ -264,8 +264,15 @@ export async function createProvider(issuer) {
     // Auto-approve consent by loading/creating grants automatically
     // This skips the consent prompt for all clients (appropriate for test/dev servers)
     loadExistingGrant: async (ctx) => {
+      // Guard: if session or client is missing (e.g. stale cookies after
+      // account deletion), bail out early so oidc-provider doesn't crash
+      // calling getOIDCScopeEncountered() on an undefined grant (#452).
+      if (!ctx.oidc.session || !ctx.oidc.client) {
+        return undefined;
+      }
+
       // Check if there's an existing grant for this client/account pair
-      const grantId = ctx.oidc.session?.grantIdFor(ctx.oidc.client?.clientId);
+      const grantId = ctx.oidc.session.grantIdFor?.(ctx.oidc.client.clientId);
 
       if (grantId) {
         const existingGrant = await ctx.oidc.provider.Grant.find(grantId);
@@ -275,7 +282,7 @@ export async function createProvider(issuer) {
       }
 
       // Auto-approve: create a new grant with all requested scopes
-      if (ctx.oidc.session?.accountId && ctx.oidc.client?.clientId) {
+      if (ctx.oidc.session.accountId) {
         const grant = new ctx.oidc.provider.Grant({
           accountId: ctx.oidc.session.accountId,
           clientId: ctx.oidc.client.clientId,

--- a/src/idp/provider.js
+++ b/src/idp/provider.js
@@ -400,6 +400,29 @@ export async function createProvider(issuer) {
 
     // Render errors
     renderError: async (ctx, out, error) => {
+      // Stale session recovery (#452): when oidc-provider crashes because
+      // a deleted account's session/grant is still in the browser cookies,
+      // expire those cookies and redirect back to the same URL. The retry
+      // starts with a clean session and succeeds. The `_stale_retry` param
+      // prevents infinite redirect loops — only try once.
+      const isStaleSessionCrash = out.error === 'server_error' &&
+        error?.message?.includes('getOIDCScopeEncountered');
+      const reqUrl = ctx.req?.originalUrl || ctx.request?.url || ctx.url || '';
+      const alreadyRetried = reqUrl.includes('_stale_retry=1');
+
+      if (isStaleSessionCrash && !alreadyRetried) {
+        const expired = 'Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly';
+        ctx.set('Set-Cookie', [
+          `_session=; ${expired}`,
+          `_session.sig=; ${expired}`,
+          `_session.legacy=; ${expired}`,
+          `_session.legacy.sig=; ${expired}`,
+        ]);
+        const separator = reqUrl.includes('?') ? '&' : '?';
+        ctx.redirect(`${reqUrl}${separator}_stale_retry=1`);
+        return;
+      }
+
       ctx.type = 'html';
       ctx.body = `
         <!DOCTYPE html>

--- a/src/idp/provider.js
+++ b/src/idp/provider.js
@@ -413,7 +413,10 @@ export async function createProvider(issuer) {
       const reqUrl = ctx.req?.originalUrl || ctx.request?.url || ctx.url || '';
       const alreadyRetried = reqUrl.includes('_stale_retry=1');
 
-      if (isStaleSessionCrash && !alreadyRetried) {
+      // Only redirect browser GETs (authorization endpoint). POST/token/
+      // userinfo are programmatic — clients won't follow redirects or
+      // honor Set-Cookie, so just fall through to the error page.
+      if (isStaleSessionCrash && !alreadyRetried && ctx.method === 'GET') {
         expireSessionCookiesKoa(ctx);
         const separator = reqUrl.includes('?') ? '&' : '?';
         ctx.redirect(`${reqUrl}${separator}_stale_retry=1`);

--- a/src/idp/provider.js
+++ b/src/idp/provider.js
@@ -408,7 +408,8 @@ export async function createProvider(issuer) {
       // starts with a clean session and succeeds. The `_stale_retry` param
       // prevents infinite redirect loops — only try once.
       const isStaleSessionCrash = out.error === 'server_error' &&
-        error?.message?.includes('getOIDCScopeEncountered');
+        error instanceof TypeError &&
+        /Cannot read properties of undefined/.test(error?.message);
       const reqUrl = ctx.req?.originalUrl || ctx.request?.url || ctx.url || '';
       const alreadyRetried = reqUrl.includes('_stale_retry=1');
 

--- a/src/idp/provider.js
+++ b/src/idp/provider.js
@@ -8,6 +8,7 @@ import { createAdapter } from './adapter.js';
 import { getJwks, getCookieKeys } from './keys.js';
 import { getAccountForProvider } from './accounts.js';
 import { validateExternalUrl } from '../utils/ssrf.js';
+import { expireSessionCookiesKoa } from './cookies.js';
 
 // Cache for fetched client documents
 const clientDocumentCache = new Map();
@@ -271,7 +272,8 @@ export async function createProvider(issuer) {
         return undefined;
       }
 
-      // Check if there's an existing grant for this client/account pair
+      // Check if there's an existing grant for this client/account pair.
+      // Optional chain: grantIdFor may be absent on a stale session stub.
       const grantId = ctx.oidc.session.grantIdFor?.(ctx.oidc.client.clientId);
 
       if (grantId) {
@@ -411,13 +413,7 @@ export async function createProvider(issuer) {
       const alreadyRetried = reqUrl.includes('_stale_retry=1');
 
       if (isStaleSessionCrash && !alreadyRetried) {
-        const expired = 'Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly';
-        ctx.set('Set-Cookie', [
-          `_session=; ${expired}`,
-          `_session.sig=; ${expired}`,
-          `_session.legacy=; ${expired}`,
-          `_session.legacy.sig=; ${expired}`,
-        ]);
+        expireSessionCookiesKoa(ctx);
         const separator = reqUrl.includes('?') ? '&' : '?';
         ctx.redirect(`${reqUrl}${separator}_stale_retry=1`);
         return;


### PR DESCRIPTION
## Summary

Fixes #452

- **Root cause**: Account deletion (`DELETE /idp/account` and `POST /idp/account/delete`) did not expire the browser's OIDC session cookies. On the next login attempt, stale `_session` cookies referenced a destroyed session/grant, causing `oidc-provider` to crash in `consent.js` calling `getOIDCScopeEncountered()` on `undefined`.
- **Cookie expiration**: Both the JSON and form-based delete endpoints now expire all four `oidc-provider` session cookies (`_session`, `_session.sig`, `_session.legacy`, `_session.legacy.sig`) via `Set-Cookie` headers with `Max-Age=0`.
- **Defensive guard**: `loadExistingGrant()` in `provider.js` now returns `undefined` early when `ctx.oidc.session` or `ctx.oidc.client` is missing, preventing the crash even if stale cookies slip through other paths.

## Test plan

- [ ] Delete an account, re-create it with the same username, and verify login succeeds without `server_error`
- [ ] Verify that after account deletion, the browser's `_session` cookies are expired (check Set-Cookie headers in response)
- [ ] Verify normal login/consent flow still works for existing accounts
- [ ] Verify that both JSON (`DELETE /idp/account`) and form (`POST /idp/account/delete`) endpoints clear cookies