### PR TITLE
Pass provisionKeys to IdP registration flow

### DIFF
--- a/src/idp/interactions.js
+++ b/src/idp/interactions.js
@@ -543,7 +543,8 @@ export async function handleRegisterPost(request, reply, issuer, inviteOnly = fa
     }
 
     // Create pod structure
-    await createPodStructure(username, webId, podUri, issuer);
+    await createPodStructure(username, webId, podUri, issuer, 0,
+      { provisionKeys: request.provisionKeys === true });
 
     // Create account
     await createAccount({

--- a/src/server.js
+++ b/src/server.js
@@ -280,6 +280,7 @@ export function createServer(options = {}) {
     request.mashlibVersion = mashlibVersion;
     request.mashlibModule = mashlibModule;
     request.defaultQuota = defaultQuota;
+    request.provisionKeys = provisionKeysEnabled;
     request.config = { public: options.public, readOnly: options.readOnly };
     request.liveReloadEnabled = liveReloadEnabled;
     request.singleUser = singleUser;

--- a/src/server.js
+++ b/src/server.js
@@ -265,6 +265,7 @@ export function createServer(options = {}) {
   fastify.decorateRequest('mashlibVersion', null);
   fastify.decorateRequest('mashlibModule', null);
   fastify.decorateRequest('defaultQuota', null);
+  fastify.decorateRequest('provisionKeys', null);
   fastify.decorateRequest('config', null);
   fastify.decorateRequest('liveReloadEnabled', null);
   fastify.decorateRequest('singleUser', null);


### PR DESCRIPTION
## Summary

Fixes #454

- The browser registration path (`handleRegisterPost` in `interactions.js`) called `createPodStructure` without passing the `provisionKeys` option, so pods created via IdP registration never got owner keys — even when `--provision-keys` / `"provisionKeys": true` was set in config.
- `provisionKeysEnabled` was not attached to the Fastify request object, so IdP handlers had no way to access it.
- Two-line fix: add `request.provisionKeys` to the `onRequest` hook in `server.js`, pass it through in `interactions.js`.

## Test plan

- [ ] Register a new account via browser with `provisionKeys: true` in config
- [ ] Verify `/private/privkey.jsonld` exists in the new pod
- [ ] Verify the WebID profile at `/profile/card.jsonld` contains the verification method
- [ ] Verify existing `POST /.pods` endpoint still works with provisionKeys