### PR TITLE
Fix mashlib HTML and raw RDF sharing same ETag (#456)

### DIFF
--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -134,10 +134,21 @@ export async function handleGet(request, reply) {
     return reply.code(404).send({ error: 'Not Found' });
   }
 
+  // Compute the effective ETag for this response. When mashlib will wrap
+  // an RDF resource in HTML, the response body differs from the raw
+  // resource, so the ETag must differ too — otherwise browsers confuse
+  // cached JSON-LD with the HTML variant despite Vary: Accept (#315).
+  const storedContentType304 = stats.isDirectory ? null : getContentType(storagePath);
+  const willServeMashlib = !stats.isDirectory &&
+    shouldServeMashlib(request, request.mashlibEnabled, storedContentType304);
+  const effectiveEtag = willServeMashlib
+    ? stats.etag.replace(/"$/, '-html"')
+    : stats.etag;
+
   // Check If-None-Match for conditional GET (304 Not Modified)
   const ifNoneMatch = request.headers['if-none-match'];
   if (ifNoneMatch) {
-    const check = checkIfNoneMatchForGet(ifNoneMatch, stats.etag);
+    const check = checkIfNoneMatchForGet(ifNoneMatch, effectiveEtag);
     if (!check.ok && check.notModified) {
       return reply.code(304).send();
     }
@@ -410,7 +421,7 @@ export async function handleGet(request, reply) {
       );
     const headers = getAllHeaders({
       isContainer: false,
-      etag: stats.etag,
+      etag: effectiveEtag,
       contentType: 'text/html',
       origin,
       resourceUrl,
@@ -632,9 +643,18 @@ export async function handleHead(request, reply) {
     contentType = getContentType(storagePath);
   }
 
+  // Match GET's ETag logic: mashlib HTML responses get a suffixed ETag
+  // so HEAD and GET return consistent validators (#456).
+  const headStoredType = stats.isDirectory ? null : getContentType(storagePath);
+  const headWillServeMashlib = !stats.isDirectory &&
+    shouldServeMashlib(request, request.mashlibEnabled, headStoredType);
+  const headEtag = headWillServeMashlib
+    ? stats.etag.replace(/"$/, '-html"')
+    : stats.etag;
+
   const headers = getAllHeaders({
     isContainer: stats.isDirectory,
-    etag: stats.etag,
+    etag: headEtag,
     contentType,
     origin,
     resourceUrl,

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -610,18 +610,11 @@ export async function handleHead(request, reply) {
     return reply.code(404).send();
   }
 
-  const { willServeMashlib, effectiveEtag } = getMashlibEtag(request, stats, storagePath);
-  const ifNoneMatch = request.headers['if-none-match'];
-  if (ifNoneMatch) {
-    const check = checkIfNoneMatchForGet(ifNoneMatch, effectiveEtag);
-    if (!check.ok && check.notModified) {
-      return reply.code(304).send();
-    }
-  }
-
   const origin = request.headers.origin;
   const connegEnabled = request.connegEnabled || false;
   let contentType;
+  let headEtag = stats.etag;
+  let isMashlibResponse = false;
 
   if (stats.isDirectory) {
     const indexPath = storagePath.endsWith('/') ? `${storagePath}index.html` : `${storagePath}/index.html`;
@@ -642,9 +635,6 @@ export async function handleHead(request, reply) {
       if (wantsTurtle) {
         contentType = 'text/turtle';
       } else if (wantsJsonLd) {
-        // For an index.html container, only override to JSON-LD if the
-        // Accept header explicitly asked for JSON; otherwise fall back
-        // to text/html so HEAD matches the index.html that GET serves.
         const explicitJson = EXPLICIT_JSON_RE.test(acceptHeader);
         contentType = (indexExists && !explicitJson) ? 'text/html' : 'application/ld+json';
       } else {
@@ -655,13 +645,36 @@ export async function handleHead(request, reply) {
     } else {
       contentType = 'application/ld+json';
     }
+
+    if (indexExists) {
+      // Mirror GET: containers with index.html use the index file's ETag
+      const indexStats = await storage.stat(indexPath);
+      headEtag = indexStats?.etag || stats.etag;
+    } else if (shouldServeMashlib(request, request.mashlibEnabled, 'application/ld+json')) {
+      // Container listing via mashlib — suffix the ETag (#456)
+      headEtag = stats.etag.replace(/"$/, '-html"');
+      contentType = 'text/html';
+      isMashlibResponse = true;
+    }
   } else {
+    const { willServeMashlib, effectiveEtag } = getMashlibEtag(request, stats, storagePath);
+    headEtag = effectiveEtag;
+    isMashlibResponse = willServeMashlib;
     contentType = willServeMashlib ? 'text/html' : getContentType(storagePath);
+  }
+
+  // Check If-None-Match using the final ETag (#456)
+  const ifNoneMatch = request.headers['if-none-match'];
+  if (ifNoneMatch) {
+    const check = checkIfNoneMatchForGet(ifNoneMatch, headEtag);
+    if (!check.ok && check.notModified) {
+      return reply.code(304).send();
+    }
   }
 
   const headers = getAllHeaders({
     isContainer: stats.isDirectory,
-    etag: effectiveEtag,
+    etag: headEtag,
     contentType,
     origin,
     resourceUrl,
@@ -669,10 +682,9 @@ export async function handleHead(request, reply) {
     mashlibEnabled: request.mashlibEnabled
   });
 
-  // Content-Length: only set for non-mashlib resources where the file
-  // size matches the response body. Mashlib HTML is dynamically
-  // generated so we can't know its size without rendering it.
-  if (!stats.isDirectory && !willServeMashlib) {
+  // Content-Length: only set when the file size matches the response body.
+  // Mashlib HTML and containers are dynamically generated.
+  if (!stats.isDirectory && !isMashlibResponse) {
     headers['Content-Length'] = stats.size;
   }
 

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -603,6 +603,22 @@ export async function handleHead(request, reply) {
     return reply.code(404).send();
   }
 
+  // Conditional HEAD: check If-None-Match before doing content negotiation
+  // work, using the same content-type-aware ETag as GET (#456).
+  const headStoredType0 = stats.isDirectory ? null : getContentType(storagePath);
+  const headMashlib0 = !stats.isDirectory &&
+    shouldServeMashlib(request, request.mashlibEnabled, headStoredType0);
+  const headEtag0 = headMashlib0
+    ? stats.etag.replace(/"$/, '-html"')
+    : stats.etag;
+  const ifNoneMatch = request.headers['if-none-match'];
+  if (ifNoneMatch) {
+    const check = checkIfNoneMatchForGet(ifNoneMatch, headEtag0);
+    if (!check.ok && check.notModified) {
+      return reply.code(304).send();
+    }
+  }
+
   const origin = request.headers.origin;
   const connegEnabled = request.connegEnabled || false;
   let contentType;
@@ -643,22 +659,14 @@ export async function handleHead(request, reply) {
     contentType = getContentType(storagePath);
   }
 
-  // Match GET's ETag logic: mashlib HTML responses get a suffixed ETag
-  // so HEAD and GET return consistent validators (#456).
-  const headStoredType = stats.isDirectory ? null : getContentType(storagePath);
-  const headWillServeMashlib = !stats.isDirectory &&
-    shouldServeMashlib(request, request.mashlibEnabled, headStoredType);
-  const headEtag = headWillServeMashlib
-    ? stats.etag.replace(/"$/, '-html"')
-    : stats.etag;
-
   const headers = getAllHeaders({
     isContainer: stats.isDirectory,
-    etag: headEtag,
+    etag: headEtag0,
     contentType,
     origin,
     resourceUrl,
-    connegEnabled
+    connegEnabled,
+    mashlibEnabled: request.mashlibEnabled
   });
 
   if (!stats.isDirectory) {

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -656,7 +656,7 @@ export async function handleHead(request, reply) {
       contentType = 'application/ld+json';
     }
   } else {
-    contentType = getContentType(storagePath);
+    contentType = headMashlib0 ? 'text/html' : getContentType(storagePath);
   }
 
   const headers = getAllHeaders({
@@ -669,7 +669,10 @@ export async function handleHead(request, reply) {
     mashlibEnabled: request.mashlibEnabled
   });
 
-  if (!stats.isDirectory) {
+  // Content-Length: only set for non-mashlib resources where the file
+  // size matches the response body. Mashlib HTML is dynamically
+  // generated so we can't know its size without rendering it.
+  if (!stats.isDirectory && !headMashlib0) {
     headers['Content-Length'] = stats.size;
   }
 

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -291,7 +291,7 @@ export async function handleGet(request, reply) {
         );
       const headers = getAllHeaders({
         isContainer: true,
-        etag: stats.etag,
+        etag: effectiveEtag,
         contentType: 'text/html',
         origin,
         resourceUrl,

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -10,7 +10,8 @@ import {
   canAcceptInput,
   toJsonLd,
   fromJsonLd,
-  RDF_TYPES
+  RDF_TYPES,
+  getVaryHeader
 } from '../rdf/conneg.js';
 import { emitChange } from '../notifications/events.js';
 import { checkIfMatch, checkIfNoneMatchForGet, checkIfNoneMatchForWrite } from '../utils/conditional.js';
@@ -157,6 +158,8 @@ export async function handleGet(request, reply) {
   if (ifNoneMatch) {
     const check = checkIfNoneMatchForGet(ifNoneMatch, effectiveEtag);
     if (!check.ok && check.notModified) {
+      reply.header('ETag', effectiveEtag);
+      reply.header('Vary', getVaryHeader(request.connegEnabled, request.mashlibEnabled));
       return reply.code(304).send();
     }
   }
@@ -668,6 +671,8 @@ export async function handleHead(request, reply) {
   if (ifNoneMatch) {
     const check = checkIfNoneMatchForGet(ifNoneMatch, headEtag);
     if (!check.ok && check.notModified) {
+      reply.header('ETag', headEtag);
+      reply.header('Vary', getVaryHeader(connegEnabled, request.mashlibEnabled));
       return reply.code(304).send();
     }
   }

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -126,8 +126,8 @@ function parseRangeHeader(rangeHeader, fileSize) {
  * JSON-LD with the HTML variant despite Vary: Accept (#456).
  */
 function getMashlibEtag(request, stats, storagePath) {
-  const storedType = stats.isDirectory ? null : getContentType(storagePath);
-  const willServeMashlib = !stats.isDirectory &&
+  const storedType = stats.isDirectory ? 'application/ld+json' : getContentType(storagePath);
+  const willServeMashlib =
     shouldServeMashlib(request, request.mashlibEnabled, storedType);
   const effectiveEtag = willServeMashlib
     ? stats.etag.replace(/"$/, '-html"')

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -120,6 +120,22 @@ function parseRangeHeader(rangeHeader, fileSize) {
 }
 
 /**
+ * Compute a content-type-aware ETag. When mashlib will wrap an RDF
+ * resource in HTML, the response body differs from the raw resource,
+ * so the ETag must differ too — otherwise browsers confuse cached
+ * JSON-LD with the HTML variant despite Vary: Accept (#456).
+ */
+function getMashlibEtag(request, stats, storagePath) {
+  const storedType = stats.isDirectory ? null : getContentType(storagePath);
+  const willServeMashlib = !stats.isDirectory &&
+    shouldServeMashlib(request, request.mashlibEnabled, storedType);
+  const effectiveEtag = willServeMashlib
+    ? stats.etag.replace(/"$/, '-html"')
+    : stats.etag;
+  return { willServeMashlib, effectiveEtag };
+}
+
+/**
  * Handle GET request
  */
 export async function handleGet(request, reply) {
@@ -134,16 +150,7 @@ export async function handleGet(request, reply) {
     return reply.code(404).send({ error: 'Not Found' });
   }
 
-  // Compute the effective ETag for this response. When mashlib will wrap
-  // an RDF resource in HTML, the response body differs from the raw
-  // resource, so the ETag must differ too — otherwise browsers confuse
-  // cached JSON-LD with the HTML variant despite Vary: Accept (#315).
-  const storedContentType304 = stats.isDirectory ? null : getContentType(storagePath);
-  const willServeMashlib = !stats.isDirectory &&
-    shouldServeMashlib(request, request.mashlibEnabled, storedContentType304);
-  const effectiveEtag = willServeMashlib
-    ? stats.etag.replace(/"$/, '-html"')
-    : stats.etag;
+  const { willServeMashlib, effectiveEtag } = getMashlibEtag(request, stats, storagePath);
 
   // Check If-None-Match for conditional GET (304 Not Modified)
   const ifNoneMatch = request.headers['if-none-match'];
@@ -603,17 +610,10 @@ export async function handleHead(request, reply) {
     return reply.code(404).send();
   }
 
-  // Conditional HEAD: check If-None-Match before doing content negotiation
-  // work, using the same content-type-aware ETag as GET (#456).
-  const headStoredType0 = stats.isDirectory ? null : getContentType(storagePath);
-  const headMashlib0 = !stats.isDirectory &&
-    shouldServeMashlib(request, request.mashlibEnabled, headStoredType0);
-  const headEtag0 = headMashlib0
-    ? stats.etag.replace(/"$/, '-html"')
-    : stats.etag;
+  const { willServeMashlib, effectiveEtag } = getMashlibEtag(request, stats, storagePath);
   const ifNoneMatch = request.headers['if-none-match'];
   if (ifNoneMatch) {
-    const check = checkIfNoneMatchForGet(ifNoneMatch, headEtag0);
+    const check = checkIfNoneMatchForGet(ifNoneMatch, effectiveEtag);
     if (!check.ok && check.notModified) {
       return reply.code(304).send();
     }
@@ -656,12 +656,12 @@ export async function handleHead(request, reply) {
       contentType = 'application/ld+json';
     }
   } else {
-    contentType = headMashlib0 ? 'text/html' : getContentType(storagePath);
+    contentType = willServeMashlib ? 'text/html' : getContentType(storagePath);
   }
 
   const headers = getAllHeaders({
     isContainer: stats.isDirectory,
-    etag: headEtag0,
+    etag: effectiveEtag,
     contentType,
     origin,
     resourceUrl,
@@ -672,7 +672,7 @@ export async function handleHead(request, reply) {
   // Content-Length: only set for non-mashlib resources where the file
   // size matches the response body. Mashlib HTML is dynamically
   // generated so we can't know its size without rendering it.
-  if (!stats.isDirectory && !headMashlib0) {
+  if (!stats.isDirectory && !willServeMashlib) {
     headers['Content-Length'] = stats.size;
   }
 

--- a/src/handlers/resource.js
+++ b/src/handlers/resource.js
@@ -153,9 +153,12 @@ export async function handleGet(request, reply) {
 
   const { willServeMashlib, effectiveEtag } = getMashlibEtag(request, stats, storagePath);
 
-  // Check If-None-Match for conditional GET (304 Not Modified)
+  // For non-containers, check If-None-Match early using the effective
+  // ETag. For containers, defer the check until we know which branch
+  // (index.html vs listing vs mashlib) will run — each uses a
+  // different ETag source (#456).
   const ifNoneMatch = request.headers['if-none-match'];
-  if (ifNoneMatch) {
+  if (ifNoneMatch && !stats.isDirectory) {
     const check = checkIfNoneMatchForGet(ifNoneMatch, effectiveEtag);
     if (!check.ok && check.notModified) {
       reply.header('ETag', effectiveEtag);
@@ -178,6 +181,17 @@ export async function handleGet(request, reply) {
       // Serve index.html (contains JSON-LD structured data)
       const content = await storage.read(indexPath);
       const indexStats = await storage.stat(indexPath);
+
+      // Deferred 304 check for index.html containers (#456)
+      const indexEtag = indexStats?.etag || stats.etag;
+      if (ifNoneMatch) {
+        const check = checkIfNoneMatchForGet(ifNoneMatch, indexEtag);
+        if (!check.ok && check.notModified) {
+          reply.header('ETag', indexEtag);
+          reply.header('Vary', getVaryHeader(connegEnabled, request.mashlibEnabled));
+          return reply.code(304).send();
+        }
+      }
 
       // Pick the negotiated RDF type using q-aware Accept parsing. The
       // naive `acceptHeader.includes('text/turtle')` we used to do here
@@ -272,6 +286,16 @@ export async function handleGet(request, reply) {
     }
 
     // No index.html, return JSON-LD container listing
+    // Deferred 304 check for container listings (#456)
+    if (ifNoneMatch) {
+      const check = checkIfNoneMatchForGet(ifNoneMatch, effectiveEtag);
+      if (!check.ok && check.notModified) {
+        reply.header('ETag', effectiveEtag);
+        reply.header('Vary', getVaryHeader(connegEnabled, request.mashlibEnabled));
+        return reply.code(304).send();
+      }
+    }
+
     const entries = await storage.listContainer(storagePath);
     const jsonLd = generateContainerJsonLd(resourceUrl, entries || []);
 

--- a/test/vary-cache-headers.test.js
+++ b/test/vary-cache-headers.test.js
@@ -83,6 +83,65 @@ describe('Vary / Cache-Control consistency (#315)', () => {
     }
   });
 
+  it('mashlib HTML ETag differs from raw RDF ETag (#456)', async () => {
+    const htmlRes = await request('/varytest/public/card.jsonld', {
+      headers: { Accept: 'text/html,*/*;q=0.8' }
+    });
+    const jsonRes = await request('/varytest/public/card.jsonld', {
+      headers: { Accept: 'application/ld+json' }
+    });
+    const htmlEtag = htmlRes.headers.get('etag');
+    const jsonEtag = jsonRes.headers.get('etag');
+    assert.ok(htmlEtag, 'HTML variant should have ETag');
+    assert.ok(jsonEtag, 'JSON-LD variant should have ETag');
+    assert.notStrictEqual(htmlEtag, jsonEtag,
+      'mashlib HTML and raw JSON-LD must have different ETags');
+    assert.ok(htmlEtag.endsWith('-html"'),
+      `HTML ETag should end with -html", got: ${htmlEtag}`);
+    assert.ok(!jsonEtag.includes('-html'),
+      `JSON-LD ETag should not contain -html, got: ${jsonEtag}`);
+  });
+
+  it('If-None-Match with HTML ETag does not 304 the JSON-LD variant (#456)', async () => {
+    const htmlRes = await request('/varytest/public/card.jsonld', {
+      headers: { Accept: 'text/html,*/*;q=0.8' }
+    });
+    const htmlEtag = htmlRes.headers.get('etag');
+    // Use the HTML ETag to request JSON-LD — should NOT get 304
+    const jsonRes = await request('/varytest/public/card.jsonld', {
+      headers: { Accept: 'application/ld+json', 'If-None-Match': htmlEtag }
+    });
+    assert.strictEqual(jsonRes.status, 200,
+      'JSON-LD request with HTML ETag should get 200, not 304');
+  });
+
+  it('If-None-Match with JSON-LD ETag does not 304 the HTML variant (#456)', async () => {
+    const jsonRes = await request('/varytest/public/card.jsonld', {
+      headers: { Accept: 'application/ld+json' }
+    });
+    const jsonEtag = jsonRes.headers.get('etag');
+    // Use the JSON-LD ETag to request HTML — should NOT get 304
+    const htmlRes = await request('/varytest/public/card.jsonld', {
+      headers: { Accept: 'text/html,*/*;q=0.8', 'If-None-Match': jsonEtag }
+    });
+    assert.strictEqual(htmlRes.status, 200,
+      'HTML request with JSON-LD ETag should get 200, not 304');
+  });
+
+  it('HEAD returns same ETag as GET for each variant (#456)', async () => {
+    for (const accept of ['text/html,*/*;q=0.8', 'application/ld+json']) {
+      const getRes = await request('/varytest/public/card.jsonld', {
+        headers: { Accept: accept }
+      });
+      const headRes = await request('/varytest/public/card.jsonld', {
+        method: 'HEAD',
+        headers: { Accept: accept }
+      });
+      assert.strictEqual(headRes.headers.get('etag'), getRes.headers.get('etag'),
+        `HEAD and GET ETags must match for Accept: ${accept}`);
+    }
+  });
+
   it('container index.html data-island variants also carry revalidating Cache-Control', async () => {
     // Publish an index.html with a JSON-LD data island; conneg should extract
     // and serve it as Turtle/JSON-LD. Those variants were missing


### PR DESCRIPTION
## Summary

- Suffix the ETag with `-html` when mashlib will serve the HTML wrapper, so it differs from the raw RDF ETag
- Use the suffixed ETag in the 304 `If-None-Match` check so cached HTML responses don't match the raw resource ETag
- Apply the same logic to both GET and HEAD handlers for consistency

Fixes #456

## Context

The ETag is generated from `mtime + size` in `src/storage/filesystem.js`. When the same resource is served as both `text/html` (mashlib wrapper) and `application/ld+json`, both responses carried identical ETags. Despite `Vary: Accept`, browsers could serve the wrong cached variant — showing raw JSON-LD instead of the mashlib UI on soft refresh.

Related: #101, #315

## Test plan

- [ ] `curl -sI -H 'Accept: text/html' <url>` returns ETag with `-html` suffix
- [ ] `curl -sI -H 'Accept: application/ld+json' <url>` returns base ETag (no suffix)
- [ ] Soft refresh of `card.jsonld` consistently shows mashlib UI, not raw JSON-LD
- [ ] Non-RDF resources (images, plain HTML) are unaffected