### PR TITLE
feat(git): auto-init a bare repo on first push to an empty path

### DIFF
--- a/src/handlers/git.js
+++ b/src/handlers/git.js
@@ -1,5 +1,5 @@
-import { spawn, execSync } from 'child_process';
-import { existsSync, statSync, mkdirSync, writeFileSync } from 'fs';
+import { spawn, spawnSync, execSync } from 'child_process';
+import { existsSync, statSync, mkdirSync, readdirSync, writeFileSync } from 'fs';
 import { join, resolve, dirname } from 'path';
 import { getDataRoot } from '../utils/url.js';
 
@@ -89,6 +89,46 @@ function findGitDir(repoPath) {
   return null;
 }
 
+/**
+ * Auto-initialize a bare git repo at repoAbs to accept a first push, but
+ * only when it's safe to do so. The caller must invoke this *after* the
+ * standard ACL Write check has passed (i.e. inside the existing
+ * preHandler-gated path for `git-receive-pack`), so authorization is
+ * already enforced.
+ *
+ * Safe iff one of:
+ *   - the target path does not exist (we create it), or
+ *   - the target path exists, is a directory, and is empty.
+ *
+ * Refuses (returns null) for any other state — most importantly when the
+ * directory contains non-`.git` files, so we don't risk corrupting a
+ * user-content directory (e.g. /public/apps/foo with regular files) by
+ * promoting it into a git repo.
+ *
+ * Uses spawnSync with an arg array (no shell interpolation) and swallows
+ * exceptions; on any failure the caller falls through to the normal 404.
+ *
+ * @param {string} repoAbs - absolute path to the candidate repo
+ * @returns {{gitDir: string, isRegular: boolean}|null}
+ */
+function tryAutoInitBareRepo(repoAbs) {
+  try {
+    if (existsSync(repoAbs)) {
+      if (!statSync(repoAbs).isDirectory()) return null;
+      if (readdirSync(repoAbs).length > 0) return null;
+    } else {
+      mkdirSync(repoAbs, { recursive: true });
+    }
+    const result = spawnSync('git', ['init', '--bare', repoAbs], {
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+    if (result.status !== 0) return null;
+    return findGitDir(repoAbs);
+  } catch {
+    return null;
+  }
+}
+
 // CORS headers for git responses. Single source of truth — used by the
 // success path (Fastify reply on the OPTIONS preflight, raw stream on
 // http-backend output) and by every 4xx early-return. Without these,
@@ -151,8 +191,16 @@ export async function handleGit(request, reply) {
     return reply.code(403).send({ error: 'Path traversal detected' });
   }
 
-  // Find git directory
-  const gitInfo = findGitDir(repoAbs);
+  // Find git directory. On a push (`git-receive-pack`) to a path that
+  // doesn't yet contain a repo, auto-init a bare one if the location is
+  // safe to claim — the standard preHandler has already verified ACL
+  // Write on this path, so authorization is enforced. See
+  // tryAutoInitBareRepo for the safety conditions (empty / non-existent
+  // path only; refuses to clobber existing files).
+  let gitInfo = findGitDir(repoAbs);
+  if (!gitInfo && isGitWriteOperation(request.url)) {
+    gitInfo = tryAutoInitBareRepo(repoAbs);
+  }
   if (!gitInfo) {
     setGitCorsHeaders(reply);
     return reply.code(404).send({ error: 'Not a git repository' });

--- a/src/handlers/git.js
+++ b/src/handlers/git.js
@@ -105,13 +105,25 @@ function findGitDir(repoPath) {
  * user-content directory (e.g. /public/apps/foo with regular files) by
  * promoting it into a git repo.
  *
- * Uses spawnSync with an arg array (no shell interpolation) and swallows
- * exceptions; on any failure the caller falls through to the normal 404.
+ * Uses spawnSync with an arg array (no shell interpolation). On any
+ * failure (missing `git`, permission denied, init exits non-zero) the
+ * caller falls through to the normal 404, with the underlying cause
+ * surfaced to the request logger so operators can diagnose.
+ *
+ * SYMLINK CAVEAT: this function relies on the caller's path-string
+ * containment check (isPathWithinDataRoot) which does not follow
+ * symlinks. If an attacker with Write ACL has placed a symlink under
+ * dataRoot pointing outside, statSync/readdirSync/spawnSync here will
+ * dereference it. That's a pre-existing weakness of the JSS handler,
+ * not introduced by auto-init — fixing it requires realpath
+ * normalisation across every write path in the handler, out of scope
+ * for this PR. Hardening tracked for a follow-up.
  *
  * @param {string} repoAbs - absolute path to the candidate repo
+ * @param {object} [log] - optional Fastify request logger for diagnostics
  * @returns {{gitDir: string, isRegular: boolean}|null}
  */
-function tryAutoInitBareRepo(repoAbs) {
+function tryAutoInitBareRepo(repoAbs, log) {
   try {
     if (existsSync(repoAbs)) {
       if (!statSync(repoAbs).isDirectory()) return null;
@@ -122,9 +134,18 @@ function tryAutoInitBareRepo(repoAbs) {
     const result = spawnSync('git', ['init', '--bare', repoAbs], {
       stdio: ['ignore', 'pipe', 'pipe']
     });
-    if (result.status !== 0) return null;
-    return findGitDir(repoAbs);
-  } catch {
+    if (result.status !== 0) {
+      log?.warn?.(
+        { repoAbs, status: result.status, stderr: result.stderr?.toString?.().slice(0, 500) },
+        'git auto-init: `git init --bare` exited non-zero'
+      );
+      return null;
+    }
+    const info = findGitDir(repoAbs);
+    if (info) log?.info?.({ repoAbs }, 'git auto-init: bare repo created on first push');
+    return info;
+  } catch (err) {
+    log?.warn?.({ err, repoAbs }, 'git auto-init: refusing to init (filesystem error)');
     return null;
   }
 }
@@ -199,7 +220,7 @@ export async function handleGit(request, reply) {
   // path only; refuses to clobber existing files).
   let gitInfo = findGitDir(repoAbs);
   if (!gitInfo && isGitWriteOperation(request.url)) {
-    gitInfo = tryAutoInitBareRepo(repoAbs);
+    gitInfo = tryAutoInitBareRepo(repoAbs, request.log);
   }
   if (!gitInfo) {
     setGitCorsHeaders(reply);

--- a/test/git-auto-init.test.js
+++ b/test/git-auto-init.test.js
@@ -1,0 +1,130 @@
+/**
+ * Git auto-init on first push.
+ *
+ * Verifies that `git-receive-pack` requests to a path with no existing
+ * repo will (a) auto-init a bare repo when the path is empty or
+ * non-existent, and (b) refuse with the existing 404 when the path
+ * contains user content. ACL enforcement is exercised upstream by the
+ * server's preHandler; these tests run with `public: true` so the
+ * authorization gate is open and we can isolate the init logic.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { createServer } from '../src/server.js';
+import { createServer as createNetServer } from 'net';
+import fs from 'fs-extra';
+import path from 'path';
+import { existsSync, statSync, writeFileSync } from 'fs';
+
+const TEST_HOST = 'localhost';
+const DATA_DIR = './test-data-git-auto-init';
+
+function getAvailablePort() {
+  return new Promise((resolve, reject) => {
+    const srv = createNetServer();
+    srv.on('error', reject);
+    srv.listen(0, TEST_HOST, () => {
+      const port = srv.address().port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+describe('Git auto-init on first push', () => {
+  let server;
+  let baseUrl;
+
+  before(async () => {
+    await fs.remove(DATA_DIR);
+    await fs.ensureDir(DATA_DIR);
+
+    const port = await getAvailablePort();
+    baseUrl = `http://${TEST_HOST}:${port}`;
+
+    server = createServer({
+      logger: false,
+      root: DATA_DIR,
+      git: true,
+      public: true   // skip WAC so the auto-init logic runs in isolation
+    });
+    await server.listen({ port, host: TEST_HOST });
+  });
+
+  after(async () => {
+    if (server) await server.close();
+    await fs.remove(DATA_DIR);
+  });
+
+  it('auto-inits a bare repo on push-advertise to a non-existent path', async () => {
+    const repoPath = 'public/apps/penny';
+    const url = `${baseUrl}/${repoPath}/info/refs?service=git-receive-pack`;
+
+    const res = await fetch(url);
+    assert.strictEqual(res.status, 200, 'advertise must succeed (200) after auto-init');
+
+    const repoAbs = path.resolve(DATA_DIR, repoPath);
+    assert.ok(existsSync(repoAbs), 'directory must be created');
+    assert.ok(statSync(repoAbs).isDirectory(), 'created path must be a directory');
+    // Bare repo: HEAD + objects/ + refs/ live at the path itself.
+    assert.ok(existsSync(path.join(repoAbs, 'HEAD')), 'bare repo HEAD must exist');
+    assert.ok(existsSync(path.join(repoAbs, 'objects')), 'bare repo objects/ must exist');
+    assert.ok(existsSync(path.join(repoAbs, 'refs')), 'bare repo refs/ must exist');
+  });
+
+  it('auto-inits a bare repo when the target directory exists but is empty', async () => {
+    const repoPath = 'public/empty-dir';
+    await fs.ensureDir(path.resolve(DATA_DIR, repoPath));
+
+    const url = `${baseUrl}/${repoPath}/info/refs?service=git-receive-pack`;
+    const res = await fetch(url);
+    assert.strictEqual(res.status, 200);
+
+    const repoAbs = path.resolve(DATA_DIR, repoPath);
+    assert.ok(existsSync(path.join(repoAbs, 'HEAD')), 'bare repo HEAD must exist');
+  });
+
+  it('refuses to auto-init when the target directory contains user content', async () => {
+    const repoPath = 'public/has-files';
+    const repoAbs = path.resolve(DATA_DIR, repoPath);
+    await fs.ensureDir(repoAbs);
+    writeFileSync(path.join(repoAbs, 'index.html'), '<p>hi</p>');
+
+    const url = `${baseUrl}/${repoPath}/info/refs?service=git-receive-pack`;
+    const res = await fetch(url);
+    assert.strictEqual(res.status, 404, 'must return 404 when path has non-git content');
+
+    // User's file must be intact and no .git should have been created.
+    assert.ok(existsSync(path.join(repoAbs, 'index.html')), 'user file must survive');
+    assert.ok(!existsSync(path.join(repoAbs, 'HEAD')), 'no bare-repo files should appear');
+    assert.ok(!existsSync(path.join(repoAbs, 'objects')), 'no bare-repo objects/ should appear');
+  });
+
+  it('does NOT auto-init on a fetch (`git-upload-pack`)', async () => {
+    const repoPath = 'public/fetch-only';
+    const url = `${baseUrl}/${repoPath}/info/refs?service=git-upload-pack`;
+
+    const res = await fetch(url);
+    assert.strictEqual(res.status, 404, 'fetch on missing repo must remain a 404');
+
+    const repoAbs = path.resolve(DATA_DIR, repoPath);
+    assert.ok(!existsSync(repoAbs), 'no directory should be created for a fetch');
+  });
+
+  it('subsequent pushes use the existing repo (no re-init)', async () => {
+    const repoPath = 'public/apps/penny';
+    const repoAbs = path.resolve(DATA_DIR, repoPath);
+    // Repo was created by the first test in this suite; capture its
+    // initial HEAD inode/mtime to verify we don't recreate the repo.
+    const headPath = path.join(repoAbs, 'HEAD');
+    assert.ok(existsSync(headPath), 'prereq: repo from earlier test still exists');
+    const before = statSync(headPath);
+
+    const url = `${baseUrl}/${repoPath}/info/refs?service=git-receive-pack`;
+    const res = await fetch(url);
+    assert.strictEqual(res.status, 200);
+
+    const after = statSync(headPath);
+    assert.strictEqual(after.ino, before.ino, 'HEAD inode must not change (no re-init)');
+  });
+});

--- a/test/git-auto-init.test.js
+++ b/test/git-auto-init.test.js
@@ -111,6 +111,42 @@ describe('Git auto-init on first push', () => {
     assert.ok(!existsSync(repoAbs), 'no directory should be created for a fetch');
   });
 
+  it('refuses auto-init when ACL Write is not granted (unauthenticated)', async () => {
+    // Spin up a *separate* server WITHOUT public:true so WAC actually
+    // gates write operations. This is the contract-level guard: if a
+    // future refactor of the preHandler ever lets an unauth request
+    // reach handleGit, auto-init would silently materialize repos. This
+    // test fails loudly in that scenario.
+    const DATA_DIR_AUTH = './test-data-git-auto-init-authcheck';
+    await fs.remove(DATA_DIR_AUTH);
+    await fs.ensureDir(DATA_DIR_AUTH);
+    const port = await getAvailablePort();
+    const authBaseUrl = `http://${TEST_HOST}:${port}`;
+    const authServer = createServer({
+      logger: false,
+      root: DATA_DIR_AUTH,
+      git: true
+      // NOTE: no `public: true` — WAC enforces real ACLs
+    });
+    try {
+      await authServer.listen({ port, host: TEST_HOST });
+
+      const repoPath = 'public/needs-auth';
+      const url = `${authBaseUrl}/${repoPath}/info/refs?service=git-receive-pack`;
+      const res = await fetch(url);  // no Authorization header
+
+      assert.ok(res.status === 401 || res.status === 403,
+        `expected 401/403 for unauthenticated push, got ${res.status}`);
+
+      const repoAbs = path.resolve(DATA_DIR_AUTH, repoPath);
+      assert.ok(!existsSync(repoAbs),
+        'auto-init MUST NOT create a directory for an unauthenticated request');
+    } finally {
+      await authServer.close();
+      await fs.remove(DATA_DIR_AUTH);
+    }
+  });
+
   it('subsequent pushes use the existing repo (no re-init)', async () => {
     const repoPath = 'public/apps/penny';
     const repoAbs = path.resolve(DATA_DIR, repoPath);


### PR DESCRIPTION
Resolves #465.

## Summary

Today `git push http://localhost:5444/public/apps/penny main` to a fresh path 404s — there's no `.git` yet and no HTTP path to *create* one. The only workaround has been to shell into the data directory and `git init --bare` manually, which defeats the point of having a git HTTP backend.

This PR adds auto-init on first push, gated narrowly so it can't corrupt user content. After this lands, `git push` to a fresh pod path Just Works™, GitHub-style.

## Safety conditions

Auto-init runs only when **all** of:

- Request is `git-receive-pack` (push). Fetches to a missing path still 404.
- ACL Write has already been verified by the existing preHandler hook in `server.js` (no change to authorization).
- Target path is **empty or non-existent**. A directory containing non-`.git` files (e.g. `/public/apps/foo` with `index.html`) stays a 404 — we never risk promoting a user-content directory into a git repo.
- Path resolves inside the data root (existing check above the new code).

## Implementation notes

- New helper `tryAutoInitBareRepo(repoAbs)` near `findGitDir`; documented with the safety conditions and the caller's responsibility (ACL must be checked upstream).
- Uses `spawnSync('git', [...])` with an arg array — no shell interpolation. Errors swallowed; caller falls through to the standard 404. A missing `git` binary or a permission issue surfaces as 404, not 500.
- Concurrent first pushes to the same path are benign: `mkdirSync({ recursive: true })` is idempotent and a second `git init --bare` no-ops on an existing bare repo.

## Diff size

`src/handlers/git.js`: 52 lines added (40 are JSDoc / comments explaining the safety contract). `test/git-auto-init.test.js`: new file, 5 tests.

## Tests

New `test/git-auto-init.test.js` exercises:

1. ✅ Non-existent path → 200 + bare repo materialized
2. ✅ Empty existing directory → 200 + bare repo materialized
3. ✅ Non-empty directory (has `index.html`) → 404, file untouched, no `.git`/`HEAD`/`objects`
4. ✅ Fetch (`git-upload-pack`) to a missing path → 404, no filesystem side effect
5. ✅ Second push to a path with an existing repo → 200, no re-init (HEAD inode unchanged)

These are the first tests of the git HTTP backend, period — no prior coverage existed.

Run with: `node --test test/git-auto-init.test.js`

## What this unblocks

- jspod's [\`jspod install <git-url>\`](https://github.com/JavaScriptSolidServer/jspod/issues/25) story — once you can push to a fresh path, the install flow is a local clone + `git push` instead of needing filesystem access on the pod machine
- The broader [apps-in-pods](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/issues/464) direction — pods become composable git remotes
- Any downstream wrapper that wants to deploy app code over the existing JSS git HTTP backend

## Refs

- #465 — the upstream issue (auto-init proposal, Option A from the three options listed)
- [jspod#25](https://github.com/JavaScriptSolidServer/jspod/issues/25), [jspod#26](https://github.com/JavaScriptSolidServer/jspod/issues/26) — downstream consumers
- #463, #464 — broader apps-in-pods architecture