### PR TITLE
Bump version to 0.0.195

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-solid-server",
-  "version": "0.0.194",
+  "version": "0.0.195",
   "description": "A minimal, fast Solid server",
   "main": "src/index.js",
   "type": "module",


### PR DESCRIPTION
Release bump after #466 (git auto-init on first push).

## What's in 0.0.195

- **#466** — `feat(git)`: auto-init a bare repo on first push to an empty path. Resolves #465. Net new code: 52 lines in `src/handlers/git.js` (most of it JSDoc + safety contract documentation) + 6 tests in `test/git-auto-init.test.js` (the first test coverage of the git HTTP backend). Full test suite (876 tests) passes.

## Publish checklist

- [x] Full `npm test` green
- [x] No new dependencies
- [x] `package.json` bumped to `0.0.195`
- [ ] `npm publish` after merge

## Note on the lockfile

`package-lock.json` still reads `0.0.191` — the same drift that's been carried for 3 prior releases. Not touching it here to match the existing JSS bump convention. Worth a separate cleanup PR if/when desired.