### PR TITLE
fix(git): auto-init regular (non-bare) repos so pushed files are served

### DIFF
--- a/src/handlers/git.js
+++ b/src/handlers/git.js
@@ -90,11 +90,20 @@ function findGitDir(repoPath) {
 }
 
 /**
- * Auto-initialize a bare git repo at repoAbs to accept a first push, but
- * only when it's safe to do so. The caller must invoke this *after* the
- * standard ACL Write check has passed (i.e. inside the existing
- * preHandler-gated path for `git-receive-pack`), so authorization is
- * already enforced.
+ * Auto-initialize a regular (non-bare) git repo at repoAbs to accept a
+ * first push, but only when it's safe to do so. The caller must invoke
+ * this *after* the standard ACL Write check has passed (i.e. inside the
+ * existing preHandler-gated path for `git-receive-pack`), so
+ * authorization is already enforced.
+ *
+ * Regular (not bare): the repo has a `.git/` subdirectory plus a
+ * working tree. Combined with the `receive.denyCurrentBranch
+ * updateInstead` config the main handler sets on every push, the
+ * working tree is auto-extracted on each push. This means pushed files
+ * appear as static resources at the corresponding pod URL — the "apps
+ * live in pods" install pattern works end-to-end. (Bare repos store
+ * content in pack files only, so a pushed `index.html` wouldn't be
+ * servable as HTTP.)
  *
  * Safe iff one of:
  *   - the target path does not exist (we create it), or
@@ -123,7 +132,7 @@ function findGitDir(repoPath) {
  * @param {object} [log] - optional Fastify request logger for diagnostics
  * @returns {{gitDir: string, isRegular: boolean}|null}
  */
-function tryAutoInitBareRepo(repoAbs, log) {
+function tryAutoInitRepo(repoAbs, log) {
   try {
     if (existsSync(repoAbs)) {
       if (!statSync(repoAbs).isDirectory()) return null;
@@ -131,18 +140,18 @@ function tryAutoInitBareRepo(repoAbs, log) {
     } else {
       mkdirSync(repoAbs, { recursive: true });
     }
-    const result = spawnSync('git', ['init', '--bare', repoAbs], {
+    const result = spawnSync('git', ['init', repoAbs], {
       stdio: ['ignore', 'pipe', 'pipe']
     });
     if (result.status !== 0) {
       log?.warn?.(
         { repoAbs, status: result.status, stderr: result.stderr?.toString?.().slice(0, 500) },
-        'git auto-init: `git init --bare` exited non-zero'
+        'git auto-init: `git init` exited non-zero'
       );
       return null;
     }
     const info = findGitDir(repoAbs);
-    if (info) log?.info?.({ repoAbs }, 'git auto-init: bare repo created on first push');
+    if (info) log?.info?.({ repoAbs }, 'git auto-init: repo created on first push');
     return info;
   } catch (err) {
     log?.warn?.({ err, repoAbs }, 'git auto-init: refusing to init (filesystem error)');
@@ -213,14 +222,17 @@ export async function handleGit(request, reply) {
   }
 
   // Find git directory. On a push (`git-receive-pack`) to a path that
-  // doesn't yet contain a repo, auto-init a bare one if the location is
-  // safe to claim — the standard preHandler has already verified ACL
-  // Write on this path, so authorization is enforced. See
-  // tryAutoInitBareRepo for the safety conditions (empty / non-existent
-  // path only; refuses to clobber existing files).
+  // doesn't yet contain a repo, auto-init one if the location is safe
+  // to claim — the standard preHandler has already verified ACL Write
+  // on this path, so authorization is enforced. See tryAutoInitRepo
+  // for the safety conditions (empty / non-existent path only; refuses
+  // to clobber existing files). Auto-init creates a regular (non-bare)
+  // repo so the `denyCurrentBranch updateInstead` config below
+  // auto-extracts the working tree on each push — pushed files become
+  // static resources at the corresponding pod URL.
   let gitInfo = findGitDir(repoAbs);
   if (!gitInfo && isGitWriteOperation(request.url)) {
-    gitInfo = tryAutoInitBareRepo(repoAbs, request.log);
+    gitInfo = tryAutoInitRepo(repoAbs, request.log);
   }
   if (!gitInfo) {
     setGitCorsHeaders(reply);

--- a/test/git-auto-init.test.js
+++ b/test/git-auto-init.test.js
@@ -56,7 +56,7 @@ describe('Git auto-init on first push', () => {
     await fs.remove(DATA_DIR);
   });
 
-  it('auto-inits a bare repo on push-advertise to a non-existent path', async () => {
+  it('auto-inits a regular repo on push-advertise to a non-existent path', async () => {
     const repoPath = 'public/apps/penny';
     const url = `${baseUrl}/${repoPath}/info/refs?service=git-receive-pack`;
 
@@ -66,13 +66,18 @@ describe('Git auto-init on first push', () => {
     const repoAbs = path.resolve(DATA_DIR, repoPath);
     assert.ok(existsSync(repoAbs), 'directory must be created');
     assert.ok(statSync(repoAbs).isDirectory(), 'created path must be a directory');
-    // Bare repo: HEAD + objects/ + refs/ live at the path itself.
-    assert.ok(existsSync(path.join(repoAbs, 'HEAD')), 'bare repo HEAD must exist');
-    assert.ok(existsSync(path.join(repoAbs, 'objects')), 'bare repo objects/ must exist');
-    assert.ok(existsSync(path.join(repoAbs, 'refs')), 'bare repo refs/ must exist');
+    // Regular (non-bare) repo: .git/ subdirectory holds the internals.
+    // Working tree lives at the path itself so pushed files become
+    // static resources.
+    const dotGit = path.join(repoAbs, '.git');
+    assert.ok(existsSync(dotGit), '.git subdirectory must exist');
+    assert.ok(statSync(dotGit).isDirectory(), '.git must be a directory');
+    assert.ok(existsSync(path.join(dotGit, 'HEAD')), '.git/HEAD must exist');
+    assert.ok(existsSync(path.join(dotGit, 'objects')), '.git/objects must exist');
+    assert.ok(existsSync(path.join(dotGit, 'refs')), '.git/refs must exist');
   });
 
-  it('auto-inits a bare repo when the target directory exists but is empty', async () => {
+  it('auto-inits a regular repo when the target directory exists but is empty', async () => {
     const repoPath = 'public/empty-dir';
     await fs.ensureDir(path.resolve(DATA_DIR, repoPath));
 
@@ -81,7 +86,7 @@ describe('Git auto-init on first push', () => {
     assert.strictEqual(res.status, 200);
 
     const repoAbs = path.resolve(DATA_DIR, repoPath);
-    assert.ok(existsSync(path.join(repoAbs, 'HEAD')), 'bare repo HEAD must exist');
+    assert.ok(existsSync(path.join(repoAbs, '.git', 'HEAD')), '.git/HEAD must exist');
   });
 
   it('refuses to auto-init when the target directory contains user content', async () => {
@@ -96,8 +101,7 @@ describe('Git auto-init on first push', () => {
 
     // User's file must be intact and no .git should have been created.
     assert.ok(existsSync(path.join(repoAbs, 'index.html')), 'user file must survive');
-    assert.ok(!existsSync(path.join(repoAbs, 'HEAD')), 'no bare-repo files should appear');
-    assert.ok(!existsSync(path.join(repoAbs, 'objects')), 'no bare-repo objects/ should appear');
+    assert.ok(!existsSync(path.join(repoAbs, '.git')), 'no .git directory should appear');
   });
 
   it('does NOT auto-init on a fetch (`git-upload-pack`)', async () => {
@@ -151,8 +155,8 @@ describe('Git auto-init on first push', () => {
     const repoPath = 'public/apps/penny';
     const repoAbs = path.resolve(DATA_DIR, repoPath);
     // Repo was created by the first test in this suite; capture its
-    // initial HEAD inode/mtime to verify we don't recreate the repo.
-    const headPath = path.join(repoAbs, 'HEAD');
+    // initial HEAD inode to verify we don't recreate the repo.
+    const headPath = path.join(repoAbs, '.git', 'HEAD');
     assert.ok(existsSync(headPath), 'prereq: repo from earlier test still exists');
     const before = statSync(headPath);
 


### PR DESCRIPTION
Resolves #468. Follow-up to #466.

## Problem

#466 chose `git init --bare` for auto-init. That works for "pod is a git remote" (clone / fetch / push all work) but **breaks "install an app via git push"** — the original motivation in #465 + #464. Pushed files land in pack objects with no working tree, so a pushed `index.html` isn't servable as an HTTP static resource.

Repro: pushing [Hub](https://github.com/solid-apps/hub) into a pod with the current auto-init succeeds at the protocol level but `curl http://localhost:5444/public/apps/hub/` returns the LDP container listing of bare-repo internals (`HEAD`, `objects/`, `refs/`), not Hub's index.html.

## Fix

Switch auto-init to non-bare. The existing handler already runs `git config receive.denyCurrentBranch updateInstead` for non-bare repos on every push — that config auto-extracts the working tree, so pushed files appear at the corresponding URL.

## Diff size

- `src/handlers/git.js`: drop `--bare` from one `spawnSync` arg list. Rename `tryAutoInitBareRepo` → `tryAutoInitRepo`. Refresh JSDoc + handler comment to explain why non-bare is the right choice for the "apps live in pods" pattern.
- `test/git-auto-init.test.js`: assert the regular-repo shape (`.git/HEAD`, `.git/objects`, `.git/refs`) instead of bare-repo files at the root.

## Tests

All 6 git-auto-init tests pass:
- ✅ auto-inits a regular repo on push to non-existent path
- ✅ auto-inits a regular repo when target dir exists but is empty
- ✅ refuses to auto-init when target dir contains user content
- ✅ does NOT auto-init on a fetch (`git-upload-pack`)
- ✅ refuses auto-init when ACL Write is not granted (unauthenticated)
- ✅ subsequent pushes use the existing repo (no re-init)

Full JSS suite: **876 / 876 passing.**

## Compatibility

Operators who manually pre-create *bare* repos at pod paths (the workflow that existed before #466) keep working — `findGitDir` handles both shapes, only the *auto-init* path changes. No published surface broken.

## Trade-off acknowledged

A regular repo has both `.git/` history and the checked-out working tree, so disk footprint is ~2× a bare repo for equivalent content. Acceptable: it's the price of having the pushed files be reachable as HTTP resources, which is the whole point.

Refs #466 (parent), #465 (original init issue), #464, [jspod#25](https://github.com/JavaScriptSolidServer/jspod/issues/25), [jspod#26](https://github.com/JavaScriptSolidServer/jspod/issues/26)