### PR TITLE
Bump version to 0.0.196

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-solid-server",
-  "version": "0.0.195",
+  "version": "0.0.196",
   "description": "A minimal, fast Solid server",
   "main": "src/index.js",
   "type": "module",


### PR DESCRIPTION
Release bump for #469 (git auto-init now creates regular non-bare repos).