### PR TITLE
fix(git): pin auto-init default branch to `main`

### DIFF
--- a/src/handlers/git.js
+++ b/src/handlers/git.js
@@ -140,7 +140,13 @@ function tryAutoInitRepo(repoAbs, log) {
     } else {
       mkdirSync(repoAbs, { recursive: true });
     }
-    const result = spawnSync('git', ['init', repoAbs], {
+    // Pin the initial branch to `main` regardless of the server's
+    // `init.defaultBranch` config. `receive.denyCurrentBranch
+    // updateInstead` only extracts the working tree when the push
+    // targets the branch HEAD points at, so a deterministic default
+    // keeps `git push pod HEAD:main` working on every deployment. See
+    // #471.
+    const result = spawnSync('git', ['init', '-b', 'main', repoAbs], {
       stdio: ['ignore', 'pipe', 'pipe']
     });
     if (result.status !== 0) {

--- a/test/git-auto-init.test.js
+++ b/test/git-auto-init.test.js
@@ -15,7 +15,7 @@ import { createServer } from '../src/server.js';
 import { createServer as createNetServer } from 'net';
 import fs from 'fs-extra';
 import path from 'path';
-import { existsSync, statSync, writeFileSync } from 'fs';
+import { existsSync, statSync, writeFileSync, readFileSync } from 'fs';
 
 const TEST_HOST = 'localhost';
 const DATA_DIR = './test-data-git-auto-init';
@@ -75,6 +75,21 @@ describe('Git auto-init on first push', () => {
     assert.ok(existsSync(path.join(dotGit, 'HEAD')), '.git/HEAD must exist');
     assert.ok(existsSync(path.join(dotGit, 'objects')), '.git/objects must exist');
     assert.ok(existsSync(path.join(dotGit, 'refs')), '.git/refs must exist');
+  });
+
+  it('pins the initial branch to `main` regardless of server config', async () => {
+    // `updateInstead` only extracts the working tree when the push
+    // targets the branch HEAD points at. If `git init` honoured the
+    // server's `init.defaultBranch`, a server configured for e.g.
+    // `gh-pages` would silently fail to extract files pushed to `main`.
+    // Pin the auto-init'd HEAD so `git push pod HEAD:main` works
+    // everywhere. See #471.
+    const repoPath = 'public/apps/penny';
+    const headPath = path.resolve(DATA_DIR, repoPath, '.git', 'HEAD');
+    assert.ok(existsSync(headPath), 'prereq: repo from earlier test still exists');
+    const head = readFileSync(headPath, 'utf8').trim();
+    assert.strictEqual(head, 'ref: refs/heads/main',
+      `HEAD must point at refs/heads/main, got: ${head}`);
   });
 
   it('auto-inits a regular repo when the target directory exists but is empty', async () => {


### PR DESCRIPTION
Fixes #471.

## What

`tryAutoInitRepo` now calls `git init -b main <path>` instead of bare `git init <path>`. The auto-init'd `HEAD` points at `refs/heads/main` regardless of the server's `init.defaultBranch` setting.

## Why

`receive.denyCurrentBranch updateInstead` only extracts the working tree when the incoming push targets the branch `HEAD` points at. If a server has `init.defaultBranch=gh-pages` (e.g. an operator who lives in GitHub Pages land), then `git push pod HEAD:main` succeeds at the protocol layer — the ref is created — but no files appear on disk and the path returns 404 for every resource. Silent failure that's invisible at the protocol layer.

Bit us during end-to-end install testing of solid-apps (chrome, vellum, etc.) on jspod. Workaround was "know the server's `init.defaultBranch` and push to that name" — not acceptable for a public-facing onboarding flow.

## Behavior change

| Server `init.defaultBranch` | Before | After |
|---|---|---|
| `main` | works | works |
| `master` | `push HEAD:master` works; `HEAD:main` silently fails | `push HEAD:main` works |
| `gh-pages` | only `HEAD:gh-pages` works | `push HEAD:main` works |
| unset / other | depends on local git | `push HEAD:main` works |

Users pushing to a non-`main` branch name will continue to see refs accepted but the working tree not extracted (same as today, just now consistent across deployments). The wrapper docs (jspod) will note "push to `main`".

## Optional follow-up

A `--git-default-branch <name>` server flag (defaulting to `main`) would let operators override without an explicit per-request mechanism. Not needed for this fix; can file separately if anyone asks.

## Test plan

- [x] Added `pins the initial branch to \`main\` regardless of server config` in `test/git-auto-init.test.js` — reads `.git/HEAD` after auto-init and asserts `ref: refs/heads/main`
- [x] All 7 tests in `test/git-auto-init.test.js` pass locally on this branch
- [ ] CI green