### PR TITLE
Bump version to 0.0.197

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-solid-server",
-  "version": "0.0.196",
+  "version": "0.0.197",
   "description": "A minimal, fast Solid server",
   "main": "src/index.js",
   "type": "module",


### PR DESCRIPTION
Releases the auto-init default-branch fix (#472) so jspod and other clients can rely on `git push HEAD:main` working regardless of the server's `init.defaultBranch`.

## Included since 0.0.196

- #472 — pin auto-init default branch to \`main\`

## Test plan

- [x] End-to-end verified locally: server with `init.defaultBranch=gh-pages`, client pushes `HEAD:main`, working tree extracts, files servable over HTTP
- [x] Auto-init test suite green (7/7)