### PR TITLE
Bump version to 0.0.198

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-solid-server",
-  "version": "0.0.197",
+  "version": "0.0.198",
   "description": "A minimal, fast Solid server",
   "main": "src/index.js",
   "type": "module",


### PR DESCRIPTION
## Included since 0.0.197

- [#479](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/pull/479) — `jss install <name>` subcommand (Phase 1 of #464)
- [#481](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/pull/481) — generalized install spec: `<org>/<repo>`, full URLs, `#<ref>` pinning, `=<rename>` (Phase 2)
- [#483](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/pull/483) — `jss install --nostr-privkey <hex>` for NIP-98 signed installs (Phase 4)