### PR TITLE
Bump version to 0.0.199

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-solid-server",
-  "version": "0.0.198",
+  "version": "0.0.199",
   "description": "A minimal, fast Solid server",
   "main": "src/index.js",
   "type": "module",


### PR DESCRIPTION
Picks up since 0.0.198:

- #486 — `jss install --bundle <source>` (Phase 6 of #464)
- #487 — bundle resolver uses `/HEAD/` (works for both `main`- and `gh-pages`-default repos)
- #488 — `docs/app-install.md` + README link