### PR TITLE
fix(mcp): use isDirectory not isContainer on listContainer entries

### DIFF
--- a/src/mcp/skills.js
+++ b/src/mcp/skills.js
@@ -50,7 +50,7 @@ async function listContainerNames(containerPath) {
   try {
     const entries = await storage.listContainer(containerPath);
     return entries
-      .filter(e => e.isContainer)
+      .filter(e => e.isDirectory)
       .map(e => e.name);
   } catch {
     return [];

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -69,10 +69,10 @@ async function list_resources({ path }, ctx) {
   const entries = await storage.listContainer(path);
   return toolJson({
     container: path,
-    items: entries.map(e => ({
+    items: (entries || []).map(e => ({
       name: e.name,
-      path: `${path}${e.name}${e.isContainer ? '/' : ''}`,
-      isContainer: e.isContainer,
+      path: `${path}${e.name}${e.isDirectory ? '/' : ''}`,
+      isContainer: e.isDirectory,
       size: e.size ?? null,
       modified: e.modified ?? null
     }))

--- a/test/mcp.test.js
+++ b/test/mcp.test.js
@@ -151,6 +151,47 @@ describe('MCP server (--mcp enabled)', () => {
     assert.ok(Array.isArray(payload['skill:items']));
   });
 
+  it('list_skills discovers per-app SKILL.md', async () => {
+    // Seed a per-app skill
+    await rpc({
+      jsonrpc: '2.0', id: 1010, method: 'tools/call',
+      params: {
+        name: 'write_resource',
+        arguments: {
+          path: '/mcptest/public/apps/demo/index.html',
+          content: '<h1>demo</h1>',
+          contentType: 'text/html'
+        }
+      }
+    }, { token });
+    await rpc({
+      jsonrpc: '2.0', id: 1011, method: 'tools/call',
+      params: {
+        name: 'write_resource',
+        arguments: {
+          path: '/mcptest/public/apps/demo/SKILL.md',
+          content: '# demo app skill',
+          contentType: 'text/markdown'
+        }
+      }
+    }, { token });
+
+    // Now list against the pod root — but list_skills walks /public/apps/
+    // and /private/bots/ at the pod root, not inside a named pod. For this
+    // test, we just verify the per-app discovery walks containers correctly
+    // by listing /mcptest/public/apps/ directly via list_resources and
+    // confirming "demo" comes back as a container (isContainer=true).
+    const { body } = await rpc({
+      jsonrpc: '2.0', id: 1012, method: 'tools/call',
+      params: { name: 'list_resources', arguments: { path: '/mcptest/public/apps/' } }
+    }, { token });
+    assert.strictEqual(body.result.isError, false);
+    const payload = JSON.parse(body.result.content[0].text);
+    const demo = payload.items.find(i => i.name === 'demo');
+    assert.ok(demo, 'demo container should be listed');
+    assert.strictEqual(demo.isContainer, true, 'isContainer must be true for directories');
+  });
+
   it('list_docs returns the JSS-builtin doc set', async () => {
     const { body } = await rpc({
       jsonrpc: '2.0', id: 11, method: 'tools/call',


### PR DESCRIPTION
Live-fire smoke against \`jss start --mcp\` caught this: three SKILL.md files seeded at the three scope paths (pod / app / bot), but \`list_skills\` only returned the pod one.

Cause: \`storage.listContainer\` returns \`{ name, isDirectory, size, modified }\` — not \`isContainer\`. The skill-discovery walker filtered on the wrong field, so the always-false filter dropped every per-app and per-bot entry. \`list_resources\` had the same bug for its \`isContainer\` *output* flag.

Fix is one-character per site: \`e.isContainer\` → \`e.isDirectory\`. Plus a regression test that asserts \`isContainer=true\` on a known directory in a \`list_resources\` result — would have failed on the old code.

Smoke after the fix:

\`\`\`
list_skills with all three scopes
[
  { "scope": "pod",  "name": "pod",     "source": "/SKILL.md" },
  { "scope": "app",  "name": "demo",    "source": "/public/apps/demo/SKILL.md" },
  { "scope": "bot",  "name": "charlie", "source": "/private/bots/charlie/SKILL.md" }
]
\`\`\`

## Test plan
- [x] 18/18 MCP tests pass
- [x] Live-fire: 3 SKILL.md files (pod/app/bot) all discovered