### PR TITLE
Bump version to 0.0.200 — feature-complete capstone

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-solid-server",
-  "version": "0.0.199",
+  "version": "0.0.200",
   "description": "A minimal, fast Solid server",
   "main": "src/index.js",
   "type": "module",


### PR DESCRIPTION
The capstone release. JSS is feature-complete; consolidation begins after this.

## What's in v0.0.200

- **#491** — \`jss start --mcp\`: pod as a tool surface for agents (MCP Streamable HTTP, 2025-03-26). 12 tools across CRUD / Skills / Docs / Introspect. Auth reuses the existing chain — every tool call is WAC-gated against the inbound WebID. Skill discovery walks \`SKILL.md\` at pod/app/bot scopes.
- **#492** — fix(mcp): correct \`isDirectory\` field on listContainer entries. Caught by live-fire smoke; per-app and per-bot SKILL.md files now discoverable.

## The thesis (and the pitch)

> **MCP needs a backend. Solid is the backend.**

Pods host bots. Bots speak MCP. The pod is the bot's world — instructions read from \`SKILL.md\`, tools are URL-addressable resources, identity is a \`did:nostr:\` or WebID with the same WAC primitives as any human. Bot-to-bot federation falls out of the protocol for free.

The substrate. Visible payoffs (\`solid-apps/charlie\`, hosted Charlie via #205) build on top.

## After this

JSS development moves into consolidation mode. No new feature work without a strong reason; focus shifts to polish, performance, docs, ecosystem coverage.