### PR TITLE
feat(mcp): subscribe, read_acl/write_acl, call_remote_pod (closes #494 #495 #496)

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -82,6 +82,79 @@ Both `SKILL.md` (Anthropic markdown format) and `SKILL.jsonld` (typed JSON-LD de
 
 Pod-resident docs (`/docs/`, `/public/apps/<name>/docs/`) are reachable via the regular CRUD tools — no separate surface.
 
+### ACL editing (#496)
+
+The most common owner operation is delegating an agent access to a resource. The MCP server exposes ACL editing as first-class tools so bots don't need to hand-roll JSON-LD.
+
+| Tool | Effect | WAC check |
+|---|---|---|
+| `read_acl` | Return the ACL for a resource as a structured list (agents, agentClasses, modes, isDefault) | Control on resource |
+| `write_acl` | Persist a structured ACL to the resource's `.acl` file | Control on resource |
+
+```json
+// write_acl arguments
+{
+  "path": "/private/notes/",
+  "authorizations": [
+    {
+      "agents": ["did:nostr:abc...", "https://alice.example.com/profile#me"],
+      "modes": ["Read", "Append"],
+      "isDefault": true
+    },
+    {
+      "agentClasses": ["acl:AuthenticatedAgent"],
+      "modes": ["Read"]
+    }
+  ]
+}
+```
+
+The structured form abstracts away JSON-LD shape (`acl:agent` vs `acl:agentClass`, mode URI prefixes, `acl:default` propagation). New WAC vocabulary additions extend the structure without breaking existing bots.
+
+### Subscribe — live change notifications (#494)
+
+`subscribe` is a streaming tool. The response switches to SSE (`text/event-stream`) and emits MCP notifications as resources change. WAC-filtered per event so subscribers only see resources they have Read access to.
+
+| Tool | Effect |
+|---|---|
+| `subscribe` | Stream resource_changed events for a container subtree or specific path |
+
+```bash
+curl -N http://localhost:4443/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"subscribe","arguments":{"path":"/forum/channels/general/"}}}'
+```
+
+Events arrive as:
+```
+event: notification
+data: {"jsonrpc":"2.0","method":"notifications/tool_event","params":{"tool":"subscribe","event":{"type":"resource_changed","path":"/forum/channels/general/abc.jsonld"}}}
+```
+
+For chat-style bots, replace polling with `subscribe` and react to events as they land.
+
+### Federation — bot-to-bot (#495)
+
+`call_remote_pod` lets a bot on this pod invoke MCP tools on another pod. WAC-gated on both ends; depth-capped at 3 hops.
+
+| Tool | Effect | Gating |
+|---|---|---|
+| `call_remote_pod` | Forward an MCP `tools/call` to another pod | Caller needs acl:Write on `<their-pod>/private/federation/` on this pod |
+
+```json
+{
+  "pod_url": "https://alice.example.com",
+  "tool": "read_resource",
+  "arguments": { "path": "/public/notes/shared.md" },
+  "auth": { "type": "bearer", "token": "..." }
+}
+```
+
+To delegate outbound federation to a specific agent, grant them `acl:Write` on your `/private/federation/` container. Owners control which agents can initiate calls; remote pods control what they expose.
+
+Foreign WebIDs (identities hosted on other pods) cannot initiate federation from this pod — there's no local path for the gate to live at. Multi-pod federation chains compose by hopping between pods, each gated locally.
+
 ### Introspection
 
 | Tool | Returns |
@@ -100,11 +173,11 @@ For authenticated access, configure the client to send `Authorization: Bearer <t
 
 ## What's not included (yet)
 
-The first cut ships CRUD, ACL-as-resource (you can read/write `.acl` files via the regular tools), skills, docs, and introspection. Deferred:
+The current cut ships CRUD, structured ACL editing, subscribe, federation, skills, docs, and introspection. Deferred:
 
 - **`update_resource` (PATCH)** — SPARQL Update / N3 patches. Read-modify-write through the CRUD tools is the workaround.
-- **`subscribe`** — wrap JSS's WebSocket notifications as MCP events over SSE. Today, agents can `read_resource` + poll.
-- **`call_remote_pod`** — federation primitive for bot-to-bot. Today, an agent can talk to two pods by registering both as MCP servers in its client.
+- **Discovery layer** — no DNS SRV / Solid Type Index entry for "this pod offers MCP". Owners share URLs explicitly today.
+- **Pod-resident federation credentials** — every `call_remote_pod` carries its own auth. A vault for storing remote-pod credentials is a separate security surface worth its own design pass.
 
 These are tracked as follow-ups on issue #490.
 

--- a/src/mcp/index.js
+++ b/src/mcp/index.js
@@ -23,7 +23,7 @@ import {
   rpcResult,
   rpcError
 } from './protocol.js';
-import { listToolsForRpc, callTool } from './tools.js';
+import { listToolsForRpc, callTool, TOOLS } from './tools.js';
 import { getWebIdFromRequestAsync } from '../auth/token.js';
 
 const ALLOWED_METHODS = new Set([
@@ -84,6 +84,75 @@ async function dispatch(msg, ctx) {
   return rpcError(id, RPC_ERRORS.METHOD_NOT_FOUND, `unhandled method: ${method}`);
 }
 
+function isStreamingToolCall(body) {
+  return body
+    && body.method === 'tools/call'
+    && body.params?.name
+    && TOOLS[body.params.name]
+    // Sniff: invoke the handler synchronously so we can detect the
+    // `{ stream: true, init, run }` shape. Streaming tools must be
+    // pure-synchronous in their shape-decision (no awaits before
+    // returning the stream descriptor).
+    && (() => {
+      try {
+        // We can't safely call the handler without a ctx, so we just
+        // rely on the tool name being in our streaming-tools set.
+        return STREAMING_TOOLS.has(body.params.name);
+      } catch { return false; }
+    })();
+}
+
+const STREAMING_TOOLS = new Set(['subscribe']);
+
+async function handleStreamingTool(request, reply, body, ctx) {
+  const tool = TOOLS[body.params.name];
+  let descriptor;
+  try {
+    descriptor = tool.handler(body.params.arguments || {}, ctx);
+  } catch (e) {
+    reply.code(500);
+    reply.header('Content-Type', 'application/json');
+    return rpcError(body.id, RPC_ERRORS.INTERNAL_ERROR, e.message);
+  }
+  if (!descriptor || descriptor.stream !== true) {
+    // Tool decided not to stream after all — emit single-shot response
+    reply.header('Content-Type', 'application/json');
+    return rpcResult(body.id, descriptor);
+  }
+
+  // Switch to SSE
+  reply.raw.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache, no-transform',
+    'Connection': 'keep-alive',
+    'X-Accel-Buffering': 'no'
+  });
+
+  const controller = new AbortController();
+  request.raw.on('close', () => controller.abort());
+
+  const sendEvent = (payload) => {
+    if (controller.signal.aborted) return;
+    const note = {
+      jsonrpc: '2.0',
+      method: 'notifications/tool_event',
+      params: { tool: body.params.name, event: payload }
+    };
+    reply.raw.write(`event: notification\ndata: ${JSON.stringify(note)}\n\n`);
+  };
+
+  try {
+    const initial = await descriptor.init();
+    if (initial) sendEvent(initial);
+    await descriptor.run(sendEvent, controller.signal);
+  } catch (e) {
+    sendEvent({ type: 'error', message: e.message });
+  } finally {
+    if (!controller.signal.aborted) reply.raw.end();
+  }
+  return reply;
+}
+
 /**
  * Register the MCP plugin with Fastify.
  */
@@ -99,10 +168,20 @@ export async function mcpPlugin(fastify, _options) {
     // null webId means "anonymous"; WAC will treat it accordingly.
     const { webId } = await getWebIdFromRequestAsync(request).catch(() => ({ webId: null }));
 
+    // Federation depth (used by call_remote_pod to enforce the cap)
+    const depthHdr = request.headers['mcp-federation-depth'];
+    const federationDepth = depthHdr ? parseInt(depthHdr, 10) || 0 : 0;
+
     const ctx = {
       webId: webId || null,
-      origin: originOf(request)
+      origin: originOf(request),
+      federationDepth
     };
+
+    // Streaming tool? Hand off to SSE handler.
+    if (!Array.isArray(body) && isStreamingToolCall(body)) {
+      return handleStreamingTool(request, reply, body, ctx);
+    }
 
     // Batch support (array of requests)
     if (Array.isArray(body)) {

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -11,12 +11,37 @@
 
 import * as storage from '../storage/filesystem.js';
 import { checkAccess } from '../wac/checker.js';
-import { AccessMode } from '../wac/parser.js';
+import { AccessMode, parseAcl, serializeAcl } from '../wac/parser.js';
+import { resourceEvents } from '../notifications/events.js';
 import { toolText, toolError, toolJson } from './protocol.js';
 import { discoverSkills, readSkill, readPodSkill } from './skills.js';
 import { readFile, readdir, stat as fsStat } from 'fs/promises';
 import { join, dirname, resolve as pathResolve } from 'path';
 import { fileURLToPath } from 'url';
+
+const ACL_NS = 'http://www.w3.org/ns/auth/acl#';
+const FOAF_AGENT = 'http://xmlns.com/foaf/0.1/Agent';
+const ACL_AUTH_AGENT = 'http://www.w3.org/ns/auth/acl#AuthenticatedAgent';
+const SHORT_MODE = {
+  [`${ACL_NS}Read`]: 'Read',
+  [`${ACL_NS}Write`]: 'Write',
+  [`${ACL_NS}Append`]: 'Append',
+  [`${ACL_NS}Control`]: 'Control'
+};
+const SHORT_AGENT_CLASS = {
+  [FOAF_AGENT]: 'foaf:Agent',
+  [ACL_AUTH_AGENT]: 'acl:AuthenticatedAgent'
+};
+const FULL_MODE = {
+  Read: `${ACL_NS}Read`,
+  Write: `${ACL_NS}Write`,
+  Append: `${ACL_NS}Append`,
+  Control: `${ACL_NS}Control`
+};
+const FULL_AGENT_CLASS = {
+  'foaf:Agent': FOAF_AGENT,
+  'acl:AuthenticatedAgent': ACL_AUTH_AGENT
+};
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const JSS_DOCS_DIR = pathResolve(__dirname, '..', '..', 'docs');
@@ -220,6 +245,268 @@ async function read_docs({ name }, _ctx) {
   }
 }
 
+// --- ACL tools (#496) ---
+
+function aclUrlFor(path) {
+  // For containers, ACL is <container>.acl
+  // For resources, ACL is <resource>.acl
+  if (path.endsWith('/')) return path + '.acl';
+  return path + '.acl';
+}
+
+function shortMode(mode) {
+  return SHORT_MODE[mode] || mode;
+}
+
+function shortAgentClass(uri) {
+  return SHORT_AGENT_CLASS[uri] || uri;
+}
+
+function fullMode(mode) {
+  return FULL_MODE[mode] || mode;
+}
+
+function fullAgentClass(value) {
+  return FULL_AGENT_CLASS[value] || value;
+}
+
+async function read_acl({ path }, ctx) {
+  if (!path) return toolError('path required');
+  // Reading the ACL document itself requires Control on the resource.
+  if (!(await wac(ctx, path, AccessMode.CONTROL))) {
+    return toolError(`access denied: control ${path}`);
+  }
+  const aclPath = aclUrlFor(path);
+  if (!(await storage.exists(aclPath))) {
+    return toolJson({ path, aclPath, exists: false, authorizations: [] });
+  }
+  const content = await storage.read(aclPath);
+  const aclUrl = buildUrl(ctx, aclPath);
+  const auths = await parseAcl(content.toString('utf8'), aclUrl);
+  return toolJson({
+    path,
+    aclPath,
+    exists: true,
+    authorizations: auths.map(a => ({
+      agents: a.agents || [],
+      agentClasses: (a.agentClasses || []).map(shortAgentClass),
+      modes: (a.modes || []).map(shortMode),
+      isDefault: !!a.default
+    }))
+  });
+}
+
+function buildAclDoc(structured) {
+  const graph = structured.authorizations.map((auth, i) => {
+    const node = {
+      '@id': `#auth${i}`,
+      '@type': 'acl:Authorization',
+      'acl:accessTo': { '@id': './' },
+      'acl:mode': (auth.modes || []).map(m => ({ '@id': `acl:${m}` }))
+    };
+    if (auth.agents && auth.agents.length) {
+      node['acl:agent'] = auth.agents.map(a => ({ '@id': a }));
+    }
+    if (auth.agentClasses && auth.agentClasses.length) {
+      node['acl:agentClass'] = auth.agentClasses.map(c => ({
+        '@id': fullAgentClass(c)
+      }));
+    }
+    if (auth.isDefault) {
+      node['acl:default'] = { '@id': './' };
+    }
+    return node;
+  });
+  return {
+    '@context': {
+      acl: ACL_NS,
+      foaf: 'http://xmlns.com/foaf/0.1/'
+    },
+    '@graph': graph
+  };
+}
+
+async function write_acl({ path, authorizations }, ctx) {
+  if (!path) return toolError('path required');
+  if (!Array.isArray(authorizations)) {
+    return toolError('authorizations must be an array');
+  }
+  // Writing the ACL document requires Control on the resource.
+  if (!(await wac(ctx, path, AccessMode.CONTROL))) {
+    return toolError(`access denied: control ${path}`);
+  }
+  const aclPath = aclUrlFor(path);
+  const doc = buildAclDoc({ authorizations });
+  await storage.write(aclPath, Buffer.from(serializeAcl(doc), 'utf8'), {
+    contentType: 'application/ld+json'
+  });
+  return toolText(`wrote ${aclPath} (${authorizations.length} authorization${authorizations.length === 1 ? '' : 's'})`);
+}
+
+// --- subscribe (#494) ---
+//
+// `subscribe` is a streaming tool. The handler signals its streaming
+// shape by returning { stream: true, init, run }. The MCP plugin
+// switches the HTTP response to SSE when it sees this shape and calls
+// `init` first (for the initial event) then `run(send, signal)` to push
+// notifications until the client disconnects.
+
+function pathMatchesScope(eventUrl, scopePath, origin) {
+  if (!eventUrl.startsWith(origin)) return false;
+  const eventPath = eventUrl.slice(origin.length);
+  if (scopePath === '/') return true;
+  if (scopePath.endsWith('/')) return eventPath.startsWith(scopePath);
+  return eventPath === scopePath;
+}
+
+function subscribe({ path }, ctx) {
+  const scope = path || '/';
+  return {
+    stream: true,
+    async init() {
+      return {
+        type: 'subscribed',
+        scope,
+        origin: ctx.origin,
+        identity: ctx.webId || null
+      };
+    },
+    async run(send, signal) {
+      const onChange = async (eventUrl) => {
+        if (signal.aborted) return;
+        if (!pathMatchesScope(eventUrl, scope, ctx.origin)) return;
+
+        // Per-event WAC filter — don't leak resources the subscriber
+        // can't see. The check is best-effort: if the resource was just
+        // deleted we may not have storage to read its ACL from, so we
+        // err on the side of not emitting.
+        const eventPath = eventUrl.slice(ctx.origin.length);
+        try {
+          const allowed = await wac(ctx, eventPath, AccessMode.READ);
+          if (!allowed) return;
+        } catch {
+          return;
+        }
+        send({
+          type: 'resource_changed',
+          path: eventPath,
+          url: eventUrl
+        });
+      };
+      resourceEvents.on('change', onChange);
+      const cleanup = () => resourceEvents.off('change', onChange);
+      signal.addEventListener('abort', cleanup, { once: true });
+      // Resolve when aborted — keeps the stream open until client disconnect
+      await new Promise(resolve => signal.addEventListener('abort', resolve, { once: true }));
+      cleanup();
+    }
+  };
+}
+
+// --- federation (#495) ---
+
+// Conservative defaults locked in for v1. Future PRs may add more flexibility.
+//
+//   1. Federation gate is `<agent-pod>/private/federation/` — caller must
+//      have acl:Write there to initiate outbound federation. The agent's
+//      pod is derived from their WebID. Foreign WebIDs are denied (no
+//      local path to gate against).
+//   2. No pod-resident credential storage — every call carries its own
+//      credentials in the `auth` argument (or none for anonymous reads).
+//   3. Depth cap via MCP-Federation-Depth header, max 3.
+const MAX_FEDERATION_DEPTH = 3;
+
+function federationGatePathFor(webId, origin) {
+  if (!webId || !origin) return null;
+  if (!webId.startsWith(origin)) return null;  // foreign WebID — deny
+  const localPath = webId.slice(origin.length);
+  // Extract pod root: everything up to and including the segment before /profile/
+  const profileIdx = localPath.indexOf('/profile/');
+  const podPath = profileIdx > 0 ? localPath.slice(0, profileIdx + 1) : '/';
+  return podPath + 'private/federation/';
+}
+
+async function call_remote_pod({ pod_url, tool, arguments: remoteArgs, auth }, ctx) {
+  if (!pod_url || typeof pod_url !== 'string') {
+    return toolError('pod_url required');
+  }
+  if (!tool || typeof tool !== 'string') {
+    return toolError('tool required');
+  }
+  try {
+    new URL(pod_url);
+  } catch {
+    return toolError(`pod_url is not a valid URL: ${pod_url}`);
+  }
+
+  // Local WAC gate — derived from the agent's WebID. Foreign or
+  // anonymous identities can't federate.
+  const gatePath = federationGatePathFor(ctx.webId, ctx.origin);
+  if (!gatePath) {
+    return toolError(
+      'access denied: federation requires a local WebID identity (anonymous and foreign identities cannot initiate outbound federation)'
+    );
+  }
+  if (!(await wac(ctx, gatePath, AccessMode.WRITE))) {
+    return toolError(
+      `access denied: write ${gatePath} (federation gate). Owner must grant acl:Write at this path to delegate outbound federation.`
+    );
+  }
+
+  // Depth cap
+  const depth = (ctx.federationDepth ?? 0) + 1;
+  if (depth > MAX_FEDERATION_DEPTH) {
+    return toolError(`federation depth exceeded (max ${MAX_FEDERATION_DEPTH})`);
+  }
+
+  // Build remote MCP request
+  const remoteEndpoint = pod_url.replace(/\/+$/, '') + '/mcp';
+  const body = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'tools/call',
+    params: { name: tool, arguments: remoteArgs || {} }
+  };
+
+  const headers = {
+    'Content-Type': 'application/json',
+    'MCP-Federation-Depth': String(depth)
+  };
+  if (auth && typeof auth === 'object') {
+    if (auth.type === 'bearer' && auth.token) {
+      headers.Authorization = `Bearer ${auth.token}`;
+    } else if (auth.type === 'header' && auth.name && auth.value) {
+      headers[auth.name] = auth.value;
+    }
+  }
+
+  let response, payload;
+  try {
+    response = await fetch(remoteEndpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30_000)
+    });
+  } catch (e) {
+    return toolError(`remote pod unreachable: ${e.message}`);
+  }
+  try {
+    payload = await response.json();
+  } catch (e) {
+    return toolError(`remote response not JSON (${response.status}): ${e.message}`);
+  }
+  if (payload.error) {
+    return toolError(`remote MCP error ${payload.error.code}: ${payload.error.message}`);
+  }
+  return toolJson({
+    pod_url,
+    tool,
+    depth,
+    remote_result: payload.result || null
+  });
+}
+
 // --- pod info ---
 
 async function pod_info(_args, ctx) {
@@ -345,6 +632,72 @@ export const TOOLS = {
     description: 'Basic pod identity and MCP capabilities.',
     inputSchema: { type: 'object', properties: {} },
     handler: pod_info
+  },
+  read_acl: {
+    description: 'Read the WAC ACL for a resource as a structured list of authorizations. Requires acl:Control.',
+    inputSchema: {
+      type: 'object',
+      properties: { path: { type: 'string' } },
+      required: ['path']
+    },
+    handler: read_acl
+  },
+  write_acl: {
+    description: 'Write a structured ACL for a resource. authorizations: [{ agents?, agentClasses?, modes, isDefault? }]. Requires acl:Control.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string' },
+        authorizations: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              agents: { type: 'array', items: { type: 'string' } },
+              agentClasses: { type: 'array', items: { type: 'string', enum: ['foaf:Agent', 'acl:AuthenticatedAgent'] } },
+              modes: { type: 'array', items: { type: 'string', enum: ['Read', 'Write', 'Append', 'Control'] } },
+              isDefault: { type: 'boolean' }
+            },
+            required: ['modes']
+          }
+        }
+      },
+      required: ['path', 'authorizations']
+    },
+    handler: write_acl
+  },
+  subscribe: {
+    description: 'Subscribe to change events on a resource or container subtree. Returns an SSE stream of MCP notifications as resources change. WAC-filtered per event.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string', description: 'Container path (with trailing /) to watch a subtree, or exact resource path. Default: / (whole pod, filtered by Read access).' }
+      }
+    },
+    handler: subscribe
+  },
+  call_remote_pod: {
+    description: 'Invoke an MCP tool on another pod. Caller must have acl:Write on /private/federation/ on this pod. Depth-capped at 3.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        pod_url: { type: 'string', description: 'Origin of the remote pod (e.g. https://alice.example.com)' },
+        tool: { type: 'string', description: 'Tool name to invoke on the remote' },
+        arguments: { type: 'object', description: 'Arguments to pass to the remote tool' },
+        auth: {
+          type: 'object',
+          description: 'Auth for the remote call. Currently { type: "bearer", token } or { type: "header", name, value }. Omit for anonymous.',
+          properties: {
+            type: { type: 'string', enum: ['bearer', 'header'] },
+            token: { type: 'string' },
+            name: { type: 'string' },
+            value: { type: 'string' }
+          }
+        }
+      },
+      required: ['pod_url', 'tool']
+    },
+    handler: call_remote_pod
   }
 };
 

--- a/test/mcp.test.js
+++ b/test/mcp.test.js
@@ -19,6 +19,7 @@ import {
   getBaseUrl,
   getPodToken
 } from './helpers.js';
+import { emitChange } from '../src/notifications/events.js';
 
 let token;
 
@@ -235,6 +236,276 @@ describe('MCP server (--mcp enabled)', () => {
   it('rejects unknown method', async () => {
     const { body } = await rpc({ jsonrpc: '2.0', id: 99, method: 'doesnt/exist' });
     assert.strictEqual(body.error?.code, -32601);
+  });
+
+  // --- read_acl / write_acl (#496) ---
+
+  it('read_acl returns existing authorizations for /mcptest/public/', async () => {
+    const { body } = await rpc({
+      jsonrpc: '2.0', id: 200, method: 'tools/call',
+      params: { name: 'read_acl', arguments: { path: '/mcptest/public/' } }
+    }, { token });
+    assert.strictEqual(body.result.isError, false, body.result.content?.[0]?.text);
+    const payload = JSON.parse(body.result.content[0].text);
+    assert.strictEqual(payload.exists, true);
+    assert.ok(Array.isArray(payload.authorizations));
+    assert.ok(payload.authorizations.length > 0, 'should have at least owner auth');
+    // Owner auth should include Read, Write, Control
+    const ownerAuth = payload.authorizations.find(a => a.modes.includes('Control'));
+    assert.ok(ownerAuth, 'owner auth with Control should exist');
+  });
+
+  it('write_acl + read_acl round-trip', async () => {
+    const auths = [
+      {
+        agents: ['/mcptest/profile/card.jsonld#me'],
+        modes: ['Read', 'Write', 'Control'],
+        isDefault: true
+      },
+      {
+        agentClasses: ['acl:AuthenticatedAgent'],
+        modes: ['Read', 'Append'],
+        isDefault: true
+      },
+      {
+        agentClasses: ['foaf:Agent'],
+        modes: ['Read'],
+        isDefault: true
+      }
+    ];
+    const wr = await rpc({
+      jsonrpc: '2.0', id: 201, method: 'tools/call',
+      params: { name: 'write_acl', arguments: { path: '/mcptest/public/', authorizations: auths } }
+    }, { token });
+    assert.strictEqual(wr.body.result.isError, false, wr.body.result.content?.[0]?.text);
+
+    const rd = await rpc({
+      jsonrpc: '2.0', id: 202, method: 'tools/call',
+      params: { name: 'read_acl', arguments: { path: '/mcptest/public/' } }
+    }, { token });
+    const payload = JSON.parse(rd.body.result.content[0].text);
+    assert.strictEqual(payload.authorizations.length, 3);
+    const classes = payload.authorizations.flatMap(a => a.agentClasses || []);
+    assert.ok(classes.includes('acl:AuthenticatedAgent'));
+    assert.ok(classes.includes('foaf:Agent'));
+  });
+
+  it('write_acl denied without Control', async () => {
+    const { body } = await rpc({
+      jsonrpc: '2.0', id: 203, method: 'tools/call',
+      params: { name: 'write_acl', arguments: {
+        path: '/mcptest/public/',
+        authorizations: [{ agentClasses: ['foaf:Agent'], modes: ['Read'] }]
+      } }
+    });  // no token
+    assert.ok(body.result.isError);
+    assert.match(body.result.content[0].text, /control/i);
+  });
+
+  // --- call_remote_pod (#495) ---
+
+  it('call_remote_pod denied without federation gate access', async () => {
+    const { body } = await rpc({
+      jsonrpc: '2.0', id: 210, method: 'tools/call',
+      params: {
+        name: 'call_remote_pod',
+        arguments: {
+          pod_url: 'http://example.invalid',
+          tool: 'pod_info',
+          arguments: {}
+        }
+      }
+    });  // no token
+    assert.ok(body.result.isError);
+    // Anonymous → "local WebID identity" error; authenticated-but-not-gated → "federation gate"
+    assert.match(body.result.content[0].text, /federation/i);
+  });
+
+  it('call_remote_pod hits its own /mcp when gated open', async () => {
+    // Federation gate lives at <agent-pod>/private/federation/. For the
+    // mcptest pod owner that's /mcptest/private/federation/. Create the
+    // container, then grant AuthenticatedAgent Write there.
+    await rpc({
+      jsonrpc: '2.0', id: 220, method: 'tools/call',
+      params: {
+        name: 'create_resource',
+        arguments: { container: '/mcptest/private/', slug: 'federation', isContainer: true }
+      }
+    }, { token });
+    await rpc({
+      jsonrpc: '2.0', id: 221, method: 'tools/call',
+      params: {
+        name: 'write_acl',
+        arguments: {
+          path: '/mcptest/private/federation/',
+          authorizations: [
+            {
+              agents: ['/mcptest/profile/card.jsonld#me'],
+              modes: ['Read', 'Write', 'Control'],
+              isDefault: true
+            }
+          ]
+        }
+      }
+    }, { token });
+
+    // Now call our own MCP back at /mcp invoking pod_info
+    const base = getBaseUrl();
+    const { body } = await rpc({
+      jsonrpc: '2.0', id: 222, method: 'tools/call',
+      params: {
+        name: 'call_remote_pod',
+        arguments: {
+          pod_url: base,
+          tool: 'pod_info',
+          arguments: {}
+        }
+      }
+    }, { token });
+    assert.strictEqual(body.result.isError, false, body.result.content?.[0]?.text);
+    const payload = JSON.parse(body.result.content[0].text);
+    assert.strictEqual(payload.depth, 1);
+    assert.ok(payload.remote_result);
+  });
+
+  it('call_remote_pod enforces depth cap', async () => {
+    // Force an inbound MCP-Federation-Depth header so the next hop trips MAX
+    const res = await request('/mcp', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+        'MCP-Federation-Depth': '3'  // already at max → next hop would be 4
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0', id: 230, method: 'tools/call',
+        params: {
+          name: 'call_remote_pod',
+          arguments: {
+            pod_url: getBaseUrl(),
+            tool: 'pod_info',
+            arguments: {}
+          }
+        }
+      })
+    });
+    const data = await res.json();
+    assert.ok(data.result.isError);
+    assert.match(data.result.content[0].text, /depth exceeded/);
+  });
+
+  // --- subscribe (#494) ---
+
+  it('subscribe streams SSE events on resourceEvents change', async () => {
+    // Open the SSE stream
+    const res = await fetch(`${getBaseUrl()}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0', id: 300, method: 'tools/call',
+        params: { name: 'subscribe', arguments: { path: '/mcptest/public/' } }
+      })
+    });
+    assert.strictEqual(res.status, 200);
+    assert.match(res.headers.get('content-type') || '', /text\/event-stream/);
+
+    // Read the initial "subscribed" event then trigger a change
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let events = [];
+
+    async function readUntil(predicate, timeoutMs = 3000) {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        const { value, done } = await Promise.race([
+          reader.read(),
+          new Promise(r => setTimeout(() => r({ value: null, done: false }), 200))
+        ]);
+        if (done) break;
+        if (value) {
+          buffer += decoder.decode(value, { stream: true });
+          // Parse complete SSE events (terminated by \n\n)
+          let idx;
+          while ((idx = buffer.indexOf('\n\n')) !== -1) {
+            const chunk = buffer.slice(0, idx);
+            buffer = buffer.slice(idx + 2);
+            const dataLine = chunk.split('\n').find(l => l.startsWith('data: '));
+            if (dataLine) {
+              events.push(JSON.parse(dataLine.slice(6)));
+            }
+          }
+          if (predicate(events)) return;
+        }
+      }
+    }
+
+    await readUntil(e => e.length >= 1);  // wait for "subscribed" event
+    assert.ok(events.length >= 1);
+    assert.strictEqual(events[0].method, 'notifications/tool_event');
+    assert.strictEqual(events[0].params.event.type, 'subscribed');
+
+    // Trigger a change inside scope
+    emitChange(`${getBaseUrl()}/mcptest/public/triggered.txt`);
+
+    await readUntil(e => e.some(ev => ev.params?.event?.type === 'resource_changed'), 3000);
+    const change = events.find(ev => ev.params?.event?.type === 'resource_changed');
+    assert.ok(change, `expected resource_changed event; got ${JSON.stringify(events)}`);
+    assert.strictEqual(change.params.event.path, '/mcptest/public/triggered.txt');
+
+    // Clean up: cancel stream
+    await reader.cancel();
+  });
+
+  it('subscribe filters by scope', async () => {
+    const res = await fetch(`${getBaseUrl()}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0', id: 301, method: 'tools/call',
+        params: { name: 'subscribe', arguments: { path: '/mcptest/public/' } }
+      })
+    });
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let events = [];
+
+    async function read(ms = 800) {
+      const deadline = Date.now() + ms;
+      while (Date.now() < deadline) {
+        const { value, done } = await Promise.race([
+          reader.read(),
+          new Promise(r => setTimeout(() => r({ value: null, done: false }), 100))
+        ]);
+        if (done) break;
+        if (value) {
+          buffer += decoder.decode(value, { stream: true });
+          let idx;
+          while ((idx = buffer.indexOf('\n\n')) !== -1) {
+            const chunk = buffer.slice(0, idx);
+            buffer = buffer.slice(idx + 2);
+            const dataLine = chunk.split('\n').find(l => l.startsWith('data: '));
+            if (dataLine) events.push(JSON.parse(dataLine.slice(6)));
+          }
+        }
+      }
+    }
+
+    await read(500);  // pick up "subscribed"
+    // Out-of-scope change — should NOT trigger an event
+    emitChange(`${getBaseUrl()}/mcptest/private/notes/x.txt`);
+    await read(500);
+    const changes = events.filter(e => e.params?.event?.type === 'resource_changed');
+    assert.strictEqual(changes.length, 0, 'out-of-scope change should not emit');
+
+    await reader.cancel();
   });
 
   it('rejects unknown tool', async () => {


### PR DESCRIPTION
Three follow-ups to the v0.0.200 MCP capstone (#490), bundled into one PR as discussed.

Closes #494 (subscribe), #495 (call_remote_pod), #496 (read_acl/write_acl).

## What's in

### subscribe (#494) — streaming change notifications

Streaming tool. Response switches to SSE; emits MCP notifications as resources change. WAC-filtered per event. Wraps the existing \`resourceEvents\` from \`src/notifications/events.js\`. Path scope: trailing slash = subtree, exact = single resource. Cleanup on client disconnect.

### read_acl / write_acl (#496) — structured ACL editing

Structured form abstracts JSON-LD shape:

\`\`\`json
{
  "path": "/private/notes/",
  "authorizations": [
    { "agents": ["did:nostr:abc..."], "modes": ["Read","Append"], "isDefault": true },
    { "agentClasses": ["acl:AuthenticatedAgent"], "modes": ["Read"] }
  ]
}
\`\`\`

Round-trips via \`src/wac/parser.js\`. Requires \`acl:Control\` on the resource.

### call_remote_pod (#495) — federation primitive

Design calls locked in as discussed:

1. **Gate path is derived from agent WebID** — \`<agent-pod>/private/federation/\`. Foreign or anonymous identities can't federate (no local path to gate against). Multi-pod chains compose by hopping, each gated locally.
2. **No pod-resident credentials** — every call carries its own \`auth\` (bearer / custom header / anonymous). Credential vaulting is a separate security surface for a future PR.
3. **Depth cap** — \`MCP-Federation-Depth\` header, hardcoded max 3.

## Tool count

12 → 17. Still graspable in one read.

## Tests

26 passing (was 18). New coverage:
- read_acl returns owner authorizations on a fresh pod ACL
- write_acl + read_acl round-trip with 3 agent classes
- write_acl denied without Control
- call_remote_pod denied without federation gate (anonymous)
- call_remote_pod hits its own /mcp through the gate
- call_remote_pod depth cap (header at 3 → next hop fails)
- subscribe streams 'subscribed' init + resource_changed events
- subscribe filters by scope (out-of-scope changes silent)

\`\`\`
ℹ pass 26
ℹ fail 0
\`\`\`

## Test plan
- [x] All 26 MCP tests pass
- [ ] Live-fire: subscribe against a pod, watch /forum/ updates land in real-time
- [ ] Live-fire: write_acl to delegate, verify the granted agent can now access
- [ ] Live-fire: call_remote_pod between two pods (would need two running pods)