### PR TITLE
fix(mcp): write_acl safety check + footgun docs

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -171,6 +171,40 @@ http://localhost:4443/mcp
 
 For authenticated access, configure the client to send `Authorization: Bearer <token>`. Tokens come from `POST /idp/credentials` (username/password) or from any compatible OIDC/DPoP flow.
 
+## Footguns
+
+A short list of real gotchas to know about, learned from live-fire use:
+
+### Use absolute WebIDs in `write_acl` agents
+
+The `agents` array in a `write_acl` authorization is interpreted as a list of URIs. Relative paths (e.g. `../profile/card.jsonld#me`) resolve against the **.acl file's URL**, not the pod root — and the .acl URL changes depending on which resource the ACL applies to. Two pitfalls:
+
+```json
+// Pod owner WebID: http://example.com/profile/card.jsonld#me
+// Writing this ACL to /public/forum/.acl:
+{
+  "agents": ["../profile/card.jsonld#me"],          // wrong — resolves to /public/profile/card.jsonld#me
+  "agents": ["./profile/card.jsonld#me"],           // wrong — resolves to /public/forum/profile/card.jsonld#me
+  "agents": ["/profile/card.jsonld#me"],            // right — absolute path, resolves to /profile/card.jsonld#me
+  "agents": ["http://example.com/profile/card.jsonld#me"]  // right — absolute URL, host-portable
+}
+```
+
+**Always use absolute WebID URLs unless you know exactly what relative-URL resolution will give you.** Absolute URLs also make the ACL portable across hostnames.
+
+### `write_acl` will refuse if you'd lock yourself out
+
+If the proposed ACL doesn't grant `Control` to the caller (typically a relative-URL mistake), `write_acl` refuses with an explanatory error. This is a safety, not a permission check — it's stopping you from breaking your own access.
+
+If you really want to transfer ownership (remove your own access), do it in two steps:
+
+1. First `write_acl` granting Control to the new owner *in addition to* yourself
+2. Then the new owner calls `write_acl` removing you
+
+### Subscribe over long-running connections needs a keep-alive client
+
+The `subscribe` tool keeps an HTTP+SSE connection open indefinitely. Some HTTP clients, proxies, or load balancers will time out idle streams. If you're subscribing for hours, ensure your client handles SSE reconnect (most do; raw `curl` does not).
+
 ## What's not included (yet)
 
 The current cut ships CRUD, structured ACL editing, subscribe, federation, skills, docs, and introspection. Deferred:

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -12,7 +12,7 @@
 import * as storage from '../storage/filesystem.js';
 import { checkAccess } from '../wac/checker.js';
 import { AccessMode, parseAcl, serializeAcl } from '../wac/parser.js';
-import { resourceEvents } from '../notifications/events.js';
+import { resourceEvents, emitChange } from '../notifications/events.js';
 import { toolText, toolError, toolJson } from './protocol.js';
 import { discoverSkills, readSkill, readPodSkill } from './skills.js';
 import { readFile, readdir, stat as fsStat } from 'fs/promises';
@@ -139,6 +139,7 @@ async function write_resource({ path, content, contentType }, ctx) {
   await storage.write(path, Buffer.from(content, 'utf8'), {
     contentType: contentType || 'text/plain'
   });
+  emitChange(buildUrl(ctx, path));
   return toolText(`wrote ${path} (${Buffer.byteLength(content, 'utf8')} bytes)`);
 }
 
@@ -156,11 +157,13 @@ async function create_resource({ container, slug, content, contentType, isContai
   const childPath = `${container}${name}${isContainer ? '/' : ''}`;
   if (isContainer) {
     await storage.createContainer(childPath);
+    emitChange(buildUrl(ctx, childPath));
     return toolText(`created container ${childPath}`);
   }
   await storage.write(childPath, Buffer.from(content || '', 'utf8'), {
     contentType: contentType || 'text/plain'
   });
+  emitChange(buildUrl(ctx, childPath));
   return toolText(`created ${childPath}`);
 }
 
@@ -173,6 +176,7 @@ async function delete_resource({ path }, ctx) {
     return toolError(`not found: ${path}`);
   }
   await storage.remove(path);
+  emitChange(buildUrl(ctx, path));
   return toolText(`deleted ${path}`);
 }
 
@@ -337,9 +341,37 @@ async function write_acl({ path, authorizations }, ctx) {
   }
   const aclPath = aclUrlFor(path);
   const doc = buildAclDoc({ authorizations });
-  await storage.write(aclPath, Buffer.from(serializeAcl(doc), 'utf8'), {
+  const serialized = serializeAcl(doc);
+
+  // Safety: refuse to write an ACL that would lock the caller out of
+  // future Control. This is the most common write_acl footgun —
+  // typically caused by relative WebID paths in `agents` resolving
+  // against the .acl URL to a different absolute URI than the caller's
+  // actual WebID. Parse the proposed ACL with its real URL so relative
+  // agents resolve correctly, then check whether any authorization
+  // grants Control to the caller.
+  const aclAbsUrl = buildUrl(ctx, aclPath);
+  const proposed = await parseAcl(serialized, aclAbsUrl);
+  const callerHasControl = proposed.some(auth => {
+    if (!(auth.modes || []).includes(AccessMode.CONTROL)) return false;
+    if (ctx.webId && (auth.agents || []).includes(ctx.webId)) return true;
+    if ((auth.agentClasses || []).includes(FOAF_AGENT)) return true;
+    if (ctx.webId && (auth.agentClasses || []).includes(ACL_AUTH_AGENT)) return true;
+    return false;
+  });
+  if (!callerHasControl) {
+    return toolError(
+      `write_acl refused: the proposed ACL would not grant Control to the caller (${ctx.webId || 'anonymous'}). ` +
+      'This is typically caused by relative WebID paths in agents resolving against the .acl URL — use absolute WebIDs. ' +
+      'If you really want to remove your own access (e.g. transferring ownership), do it in two steps: ' +
+      'first grant Control to the new owner, then have the new owner write_acl without you.'
+    );
+  }
+
+  await storage.write(aclPath, Buffer.from(serialized, 'utf8'), {
     contentType: 'application/ld+json'
   });
+  emitChange(buildUrl(ctx, aclPath));
   return toolText(`wrote ${aclPath} (${authorizations.length} authorization${authorizations.length === 1 ? '' : 's'})`);
 }
 

--- a/test/mcp.test.js
+++ b/test/mcp.test.js
@@ -290,6 +290,26 @@ describe('MCP server (--mcp enabled)', () => {
     assert.ok(classes.includes('foaf:Agent'));
   });
 
+  it('write_acl refuses to lock caller out (safety)', async () => {
+    // Try to write an ACL that grants Control only to a foreign WebID
+    // — would lock the caller (mcptest owner) out. Safety should refuse.
+    const { body } = await rpc({
+      jsonrpc: '2.0', id: 204, method: 'tools/call',
+      params: { name: 'write_acl', arguments: {
+        path: '/mcptest/public/',
+        authorizations: [
+          {
+            agents: ['https://stranger.example/profile#me'],
+            modes: ['Read', 'Write', 'Control'],
+            isDefault: true
+          }
+        ]
+      } }
+    }, { token });
+    assert.ok(body.result.isError);
+    assert.match(body.result.content[0].text, /lock the caller out|would not grant Control/i);
+  });
+
   it('write_acl denied without Control', async () => {
     const { body } = await rpc({
       jsonrpc: '2.0', id: 203, method: 'tools/call',


### PR DESCRIPTION
Live-fire smoke of #497 surfaced two real gotchas with the new \`write_acl\` tool. Fixing both.

## The bugs

### 1. write_acl could lock you out

Relative WebID paths in \`agents\` (e.g. \`../profile/card.jsonld#me\`) resolve against the \`.acl\` URL, not the pod root. Writing an ACL with a wrong-relative agent silently produced an ACL that didn't actually grant the caller Control — and on the next read_acl, they'd be locked out. AuthenticatedAgent Write was the only escape hatch.

### 2. No clear docs on URL resolution

The \`agents\` field accepting URIs (and the URL resolution rules) was implicit. Users had to know WAC well enough to predict resolution behavior.

## The fixes

- **Safety check**: after building the proposed ACL doc, parse it with its real URL so relative agents resolve correctly, then verify the caller's WebID still has Control. If not, refuse with an explanatory error pointing at the most common cause (relative WebIDs).
- **Footguns docs section**: concrete right/wrong examples for relative vs absolute WebIDs in \`agents\`, plus notes on the safety check and SSE keep-alive considerations.

## Legitimate ownership transfer

Still possible — just two steps:

1. \`write_acl\` granting Control to the new owner in addition to yourself
2. New owner calls \`write_acl\` removing you

## Test plan
- [x] 27/27 MCP tests pass (added test that triggers the safety)
- [x] Live-fire: tried to lock self out → safety fires with clear error