### PR TITLE
Bump version to 0.0.201

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-solid-server",
-  "version": "0.0.200",
+  "version": "0.0.201",
   "description": "A minimal, fast Solid server",
   "main": "src/index.js",
   "type": "module",


### PR DESCRIPTION
Picks up since 0.0.200:

- **#497** — \`subscribe\`, \`read_acl\` / \`write_acl\`, \`call_remote_pod\` (the three Tier-2 follow-ups to the MCP capstone). 16 tools across CRUD / Skills / Docs / Introspect / ACL / Subscribe / Federation.
- **#498** — \`write_acl\` lock-yourself-out safety + Footguns docs section (relative vs absolute WebIDs).