### PR TITLE
Add MAINTAINERS.md and README maintainers section

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,29 @@
+# Maintainers
+
+JSS is maintained by a small group with commit access, working in the open.
+Decisions are recorded in issues and PRs.
+
+## Current maintainers
+
+| Maintainer | GitHub | Focus |
+|---|---|---|
+| Melvin Carvalho | [@melvincarvalho](https://github.com/melvincarvalho) | Project lead; substrate, releases |
+| John O'Hare | [@jjohare](https://github.com/jjohare) | (onboarding) |
+
+See [.github/CODEOWNERS](.github/CODEOWNERS) for path-level review routing.
+
+## Process
+
+Workflow, code style, and AI-assistance disclosure are covered in
+[CONTRIBUTING.md](CONTRIBUTING.md). Maintainers follow the same workflow
+as other contributors (issue → branch → PR → review → merge).
+
+## Becoming a maintainer
+
+By invitation of an existing maintainer, after demonstrated substantive
+contribution. No formal vote; existing maintainers make the call and
+update this file.
+
+## Security
+
+Security disclosures: use [GitHub private security advisories](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer/security/advisories/new).

--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ Full options: [docs/configuration.md](docs/configuration.md)
 npm test
 ```
 
+## Maintainers
+
+JSS is maintained by [@melvincarvalho](https://github.com/melvincarvalho) and [@jjohare](https://github.com/jjohare). See [MAINTAINERS.md](MAINTAINERS.md).
+
 ## License
 
 Licensed under [AGPL-3.0](./LICENSE).


### PR DESCRIPTION
Closes #502.

Adds a top-level `MAINTAINERS.md` formalising the maintainer team and a one-paragraph Maintainers section in `README.md`.

## Changes

- **`MAINTAINERS.md`** (new): current maintainers (@melvincarvalho project lead, @jjohare maintainer-onboarding), pointers to `CONTRIBUTING.md` and `.github/CODEOWNERS`, brief notes on the lightweight governance model (decisions in issues/PRs, new maintainers by invitation, security via GitHub private advisories).
- **`README.md`**: one paragraph added between "Running Tests" and "License" pointing at `MAINTAINERS.md`.

## Scope

Limited to listing + lightweight governance per #502. Out of scope (deferred):

- Formal governance / voting / charter
- Code of Conduct
- Maintainer-emeritus or contributor-recognition sections

## Open questions deferred to review

- @jjohare focus area description (currently "(onboarding)") — feel free to update
- Security contact: currently points to GitHub private security advisories; could add an email if preferred