### PR TITLE
Use ASCII control-range regex instead of Unicode property escape for password input

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1067,12 +1067,15 @@ export function createServer(options = {}) {
           password = password.slice(0, -1);
           return;
         }
-        // Only accept printable input — \P{C} excludes control codes,
-        // so escape sequences from arrow keys, function keys, etc. don't
-        // sneak invisible bytes into the password buffer.
+        // Only accept printable input — reject C0/C1 control codes, so
+        // escape sequences from arrow keys, function keys, etc. don't
+        // sneak invisible bytes into the password buffer. Uses an explicit
+        // ASCII/C1 control range rather than the \p{C} Unicode property
+        // escape, which requires a full-ICU build and throws at parse time
+        // on no-ICU runtimes (e.g. nodejs-mobile). See #520.
         if (!key.ctrl && !key.meta &&
             typeof str === 'string' && str.length > 0 &&
-            /^\P{C}+$/u.test(str)) {
+            /^[^\u0000-\u001f\u007f-\u009f]+$/.test(str)) {
           password += str;
         }
       };


### PR DESCRIPTION
## Summary
- `src/server.js` validated interactive password input with a Unicode property-escape regex (the `\P{C}` form with the `u` flag).
- That throws `SyntaxError: Invalid regular expression: Invalid property name` at **parse time** on Node builds without full ICU (e.g. nodejs-mobile), so the module fails to import and the server can't boot there.
- Replaced with an explicit exclusion of C0/C1 control code points (0x00–0x1F and 0x7F–0x9F) written as `\u`-escapes — no `u` flag, no ICU. Preserves the intent: keep control/escape bytes from arrow/function keys out of the password buffer.

Closes #520. Surfaced running JSS on Android (nodejs-mobile); see #522.

## Notes
- One-line scope. The no-ICU work also needs crypto.hash / toReversed / Intl shims, but those live in oidc-provider (Node-version assumptions), not JSS — see #523.
- Behavior: the property escape also excluded format / surrogate / private-use / unassigned code points; this excludes only C0/C1 controls — the actual goal for password-buffer sanitization.

## Test plan
- [ ] Password prompt accepts normal input, rejects control/escape sequences.
- [ ] `createServer()` imports on a no-ICU Node build (no parse-time throw).
