### PR TITLE
fix(tunnel): accept ?token= query param on /.tunnel for browser WS auth

### DIFF
--- a/src/tunnel/index.js
+++ b/src/tunnel/index.js
@@ -57,6 +57,14 @@ export async function tunnelPlugin(fastify, options = {}) {
   fastify.get(wsPath, { websocket: true }, async (connection, request) => {
     const socket = connection.socket;
 
+    // Browser WebSockets can't set an Authorization header, so accept the
+    // bearer token as a ?token= query param too — mirrors the /.webrtc
+    // endpoint. Lets browser-based tunnel clients authenticate. (#528)
+    const queryToken = request.query?.token;
+    if (queryToken && !request.headers.authorization) {
+      request.headers.authorization = `Bearer ${queryToken}`;
+    }
+
     // Authenticate
     const { webId } = await getWebIdFromRequestAsync(request);
     if (!webId) {


### PR DESCRIPTION
Closes #528.

Browser `WebSocket`s can't set an `Authorization` header, so a browser-based tunnel client currently can't authenticate to `/.tunnel` (it gets `Authentication required` and the socket closes). Only Node clients work today.

This mirrors what `/.webrtc` already does: if a `?token=` query param is present and there's no `Authorization` header, inject it as a `Bearer` token before the WebID check.

```js
const queryToken = request.query?.token;
if (queryToken && !request.headers.authorization) {
  request.headers.authorization = `Bearer ${queryToken}`;
}
```

### Test
1. Get a WebID-bound JWT (`POST /.pods`).
2. Browser: `new WebSocket("wss://<host>/.tunnel?token=<jwt>")`, send `{type:"register", name:"demo"}`.
3. Expect `{type:"registered", url:"/tunnel/demo/"}`; `https://<host>/tunnel/demo/` proxies to the client.

### Notes
- Header-based auth is unchanged; this is purely additive.
- Same trade-off `/.webrtc` already accepts (token in the WS upgrade URL; WebID-bound / short-lived).
- Related: #527 (tunnel client mode) — resolves its "relay auth for the client" open question for browser clients.