### PR TITLE
fix(storage): list symlinked directories as containers (#531)

### DIFF
--- a/src/storage/filesystem.js
+++ b/src/storage/filesystem.js
@@ -181,6 +181,13 @@ export async function listContainer(urlPath) {
       };
       try {
         const stat = await fs.stat(path.join(filePath, entry.name));
+        // Dirent.isDirectory() uses lstat semantics, so it is false for
+        // *any* symlink — even one targeting a directory. Reclassify from
+        // the dereferenced stat so symlinked directories list as containers
+        // (trailing slash + ldp:BasicContainer), matching how they behave
+        // on a direct GET. A dangling symlink throws here and keeps the
+        // lstat-based isDirectory: false. (#531)
+        if (entry.isSymbolicLink()) result.isDirectory = stat.isDirectory();
         result.size = stat.size;
         result.modified = stat.mtime.toISOString();
       } catch { /* stat failed, skip metadata */ }

--- a/test/filesystem-symlink.test.js
+++ b/test/filesystem-symlink.test.js
@@ -1,0 +1,90 @@
+/**
+ * Regression tests for #531 — listContainer misclassified symlinked
+ * directories as plain resources.
+ *
+ * `fs.readdir(dir, { withFileTypes: true })` returns Dirents with lstat
+ * semantics, so `Dirent.isDirectory()` is false for ANY symlink — even one
+ * pointing at a directory. listContainer relied on that flag, so a symlinked
+ * sub-directory was listed without a trailing slash and typed ldp:Resource
+ * instead of ldp:BasicContainer, making it unbrowsable in container listings
+ * (while a direct GET, which dereferences, worked fine).
+ *
+ * The fix reclassifies symlink entries from the dereferenced fs.stat() that
+ * listContainer already performs for size/mtime.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import { listContainer } from '../src/storage/filesystem.js';
+
+let TEST_ROOT;
+let originalDataRoot;
+
+describe('listContainer — symlink classification (#531)', () => {
+  before(async () => {
+    originalDataRoot = process.env.DATA_ROOT;
+    TEST_ROOT = await fs.mkdtemp(path.join(os.tmpdir(), 'jss-symlink-'));
+    process.env.DATA_ROOT = TEST_ROOT;
+
+    // The container being listed.
+    const box = path.join(TEST_ROOT, 'box');
+    await fs.ensureDir(box);
+
+    // Real entries.
+    await fs.ensureDir(path.join(box, 'realdir'));
+    await fs.writeFile(path.join(box, 'realfile.txt'), 'hi');
+
+    // Symlink targets live outside the container (and outside DATA_ROOT) to
+    // mirror the real-world case of linking external content into a pod.
+    const targetDir = path.join(TEST_ROOT, 'external-dir');
+    const targetFile = path.join(TEST_ROOT, 'external-file.txt');
+    await fs.ensureDir(targetDir);
+    await fs.writeFile(targetFile, 'external');
+
+    await fs.symlink(targetDir, path.join(box, 'linkdir'));
+    await fs.symlink(targetFile, path.join(box, 'linkfile.txt'));
+    // Dangling symlink — target does not exist.
+    await fs.symlink(path.join(TEST_ROOT, 'nope'), path.join(box, 'broken'));
+  });
+
+  after(async () => {
+    if (originalDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = originalDataRoot;
+    await fs.remove(TEST_ROOT);
+  });
+
+  it('classifies a symlink-to-directory as a directory', async () => {
+    const entries = await listContainer('box');
+    const byName = Object.fromEntries(entries.map((e) => [e.name, e]));
+
+    assert.strictEqual(byName.linkdir.isDirectory, true,
+      'symlinked directory should be listed as a container');
+  });
+
+  it('keeps a symlink-to-file as a non-directory', async () => {
+    const entries = await listContainer('box');
+    const byName = Object.fromEntries(entries.map((e) => [e.name, e]));
+
+    assert.strictEqual(byName['linkfile.txt'].isDirectory, false,
+      'symlinked file should remain a resource');
+  });
+
+  it('does not regress real directories and files', async () => {
+    const entries = await listContainer('box');
+    const byName = Object.fromEntries(entries.map((e) => [e.name, e]));
+
+    assert.strictEqual(byName.realdir.isDirectory, true);
+    assert.strictEqual(byName['realfile.txt'].isDirectory, false);
+  });
+
+  it('treats a dangling symlink as a non-directory (stat throws)', async () => {
+    const entries = await listContainer('box');
+    const byName = Object.fromEntries(entries.map((e) => [e.name, e]));
+
+    assert.strictEqual(byName.broken.isDirectory, false,
+      'a dangling symlink keeps the lstat-based isDirectory: false');
+  });
+});


### PR DESCRIPTION
Fixes #531.

## Problem

`listContainer` (`src/storage/filesystem.js`) set each entry's `isDirectory` from `Dirent.isDirectory()`. With `readdir(dir, { withFileTypes: true })`, the Dirent reflects the symlink itself (lstat semantics), so `isDirectory()` is `false` for **any** symlink — including one pointing at a directory.

Consequence: a symlinked sub-directory was emitted without a trailing slash and typed `ldp:Resource` instead of `ldp:BasicContainer`, so it was unbrowsable from container listings — even though a direct `GET` (which dereferences the link via `fs.stat`) served it fine. Symlinked *files* were unaffected.

## Fix

Reclassify symlink entries from the dereferenced `fs.stat()` that `listContainer` already performs for `size`/`mtime` — no extra syscalls:

```js
if (entry.isSymbolicLink()) result.isDirectory = stat.isDirectory();
```

A dangling symlink throws inside that `stat` and keeps the lstat-based `isDirectory: false`, which is the correct outcome.

This is intentionally orthogonal to the broader symlink-containment caveat documented in `src/handlers/git.js` (the lexical path guard does not `realpath`); this PR only corrects listing classification and is safe regardless of how that hardening is eventually handled.

## Tests

Adds `test/filesystem-symlink.test.js` (node --test, temp `DATA_ROOT` pattern per `quota-race.test.js`):

- symlink → directory ⇒ `isDirectory: true`
- symlink → file ⇒ `isDirectory: false`
- real dir / real file unchanged (no regression)
- dangling symlink ⇒ `isDirectory: false`

The symlink-to-dir case **fails on the prior code and passes with the fix** (verified by stashing the change). `ldp`, `container`, `conneg`, and `server-root` suites pass (106/106, 0 fail).

## Repro (manual)

```bash
mkdir -p data/public/box /tmp/realdir && printf x > /tmp/realdir/a.txt
ln -s /tmp/realdir data/public/box/linkdir
curl -s -H 'Accept: application/ld+json' http://localhost:PORT/public/box/
# before: linkdir typed ldp:Resource, @id without trailing slash
# after:  linkdir/ typed ldp:BasicContainer
```

## AI-assistance disclosure

AI-assisted (drafted with Claude Code) with substantive human review by the maintainer — discovered while debugging a real pod whose `documents/` contained a symlinked folder that wouldn't browse. Prompts available on request.