### PR TITLE
mime: adopt mime-types db; serve mashlib shell for audio files (#533)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "javascript-solid-server",
-  "version": "0.0.191",
+  "version": "0.0.204",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "javascript-solid-server",
-      "version": "0.0.191",
+      "version": "0.0.204",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/middie": "^8.3.3",
@@ -21,6 +21,7 @@
         "fs-extra": "^11.2.0",
         "jose": "^6.1.3",
         "microfed": "^0.0.14",
+        "mime-types": "^2.1.35",
         "n3": "^1.26.0",
         "oidc-provider": "^9.6.0",
         "sql.js": "^1.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-solid-server",
-  "version": "0.0.203",
+  "version": "0.0.204",
   "description": "A minimal, fast Solid server",
   "main": "src/index.js",
   "type": "module",
@@ -36,6 +36,7 @@
     "fs-extra": "^11.2.0",
     "jose": "^6.1.3",
     "microfed": "^0.0.14",
+    "mime-types": "^2.1.35",
     "n3": "^1.26.0",
     "oidc-provider": "^9.6.0",
     "sql.js": "^1.13.0",

--- a/src/mashlib/index.js
+++ b/src/mashlib/index.js
@@ -356,8 +356,12 @@ export function shouldServeMashlib(request, mashlibEnabled, contentType) {
     }
   }
 
-  // Only serve mashlib for RDF content types
-  const rdfTypes = [
+  // Serve the mashlib shell only for content types that have a pane to
+  // render them. RDF + markdown + playlists, plus any single audio type
+  // (the audio pane). Do NOT add video/image types here until panes exist
+  // for them — wrapping them would show "No data found" instead of the
+  // browser's native inline render. See #533.
+  const viewableTypes = [
     'text/turtle',
     'application/ld+json',
     'application/json',
@@ -365,13 +369,15 @@ export function shouldServeMashlib(request, mashlibEnabled, contentType) {
     'application/n-triples',
     'application/rdf+xml',
     'text/markdown',
-    'audio/mpegurl',
-    'application/vnd.apple.mpegurl',
-    'audio/x-scpls'
+    'application/vnd.apple.mpegurl'
   ];
 
   const baseType = contentType.split(';')[0].trim().toLowerCase();
-  return rdfTypes.includes(baseType);
+  // Any audio/* type (mpeg, ogg, wave, x-flac, mpegurl playlists, ...) has a
+  // pane (audio or playlist), so match the whole family rather than enumerate
+  // the exact spellings the mime-types db happens to use.
+  if (baseType.startsWith('audio/')) return true;
+  return viewableTypes.includes(baseType);
 }
 
 /**

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -1,4 +1,5 @@
 import path from 'path';
+import * as mime from 'mime-types';
 
 // Base directory for storing all pods
 // Use a getter function to read env var at runtime (not import time)
@@ -218,28 +219,19 @@ function getPodNameFromPath(urlPath) {
  */
 export function getContentType(filePath) {
   const ext = path.extname(filePath).toLowerCase();
-  const types = {
+
+  // Solid-specific overrides — types the `mime-types` db doesn't know, or
+  // where Solid semantics differ. Checked before falling back to mime-types
+  // (which covers the long tail: audio/video/fonts/archives/office/etc.).
+  const overrides = {
     '.jsonld': 'application/ld+json',
-    '.json': 'application/json',
-    '.html': 'text/html',
-    '.txt': 'text/plain',
-    '.css': 'text/css',
-    '.js': 'application/javascript',
-    '.png': 'image/png',
-    '.jpg': 'image/jpeg',
-    '.jpeg': 'image/jpeg',
-    '.gif': 'image/gif',
-    '.svg': 'image/svg+xml',
-    '.pdf': 'application/pdf',
     '.ttl': 'text/turtle',
     '.n3': 'text/n3',
     '.nt': 'application/n-triples',
     '.rdf': 'application/rdf+xml',
     '.nq': 'application/n-quads',
     '.trig': 'application/trig',
-    '.md': 'text/markdown',
     '.m3u': 'audio/mpegurl',
-    '.m3u8': 'application/vnd.apple.mpegurl',
     '.pls': 'audio/x-scpls',
     // Solid ACL/meta as extensions (e.g. publicTypeIndex.jsonld.acl)
     '.acl': 'application/ld+json',
@@ -255,7 +247,10 @@ export function getContentType(filePath) {
   const base = path.basename(filePath);
   if (base === '.acl' || base === '.meta') return 'application/ld+json';
 
-  return types[ext] || 'application/octet-stream';
+  // Overrides first, then the comprehensive mime-types database (as CSS and
+  // NSS do), then octet-stream. This is what makes audio/video/etc. resolve
+  // to a real type instead of forcing a download. See #533.
+  return overrides[ext] || mime.lookup(filePath) || 'application/octet-stream';
 }
 
 /**

--- a/test/url.test.js
+++ b/test/url.test.js
@@ -94,7 +94,28 @@ describe('getContentType', () => {
       assert.strictEqual(getContentType('/x/card.ttl'), 'text/turtle');
     });
     it('falls back to application/octet-stream for unknown extensions', () => {
-      assert.strictEqual(getContentType('/x/file.xyz'), 'application/octet-stream');
+      // .zzz is not in the mime-types db (unlike .xyz → chemical/x-xyz)
+      assert.strictEqual(getContentType('/x/file.zzz'), 'application/octet-stream');
+    });
+  });
+
+  describe('media types via mime-types db (#533)', () => {
+    it('maps .mp3 → audio/mpeg (was octet-stream → forced download)', () => {
+      assert.strictEqual(getContentType('/music/song.mp3'), 'audio/mpeg');
+    });
+    it('maps common audio extensions to audio/*', () => {
+      for (const f of ['a.ogg', 'a.wav', 'a.m4a', 'a.flac', 'a.opus', 'a.aac']) {
+        assert.ok(getContentType(f).startsWith('audio/'), f + ' should be audio/*, got ' + getContentType(f));
+      }
+    });
+    it('maps video and other common types', () => {
+      assert.strictEqual(getContentType('v.mp4'), 'video/mp4');
+      assert.strictEqual(getContentType('d.pdf'), 'application/pdf');
+    });
+    it('keeps Solid overrides ahead of the mime-types db', () => {
+      assert.strictEqual(getContentType('card.ttl'), 'text/turtle');
+      assert.strictEqual(getContentType('x.jsonld'), 'application/ld+json');
+      assert.strictEqual(getContentType('p.m3u'), 'audio/mpegurl');
     });
   });
 


### PR DESCRIPTION
Fixes #533.

## Problem

Navigating to an `.mp3` (and most non-RDF, non-image files) downloaded the file instead of opening the data browser. Two causes:

1. `getContentType()` (`src/utils/url.js`) used a small hand-maintained extension table, so `.mp3` and friends fell through to `application/octet-stream` → browser downloads.
2. `shouldServeMashlib()` (`src/mashlib/index.js`) only wrapped an allowlist that had playlist types but not single-audio types, so even a correctly-typed `.mp3` was served raw on browser navigation.

## Changes

- **`src/utils/url.js`** — keep Solid-specific overrides (`.ttl`, `.jsonld`, `.acl`, `.meta`, `.m3u`, `.pls`, ...) but fall back to the `mime-types` database before `application/octet-stream`, the same approach as CSS (`ExtensionBasedMapper.ts`) and NSS (`lib/handlers/get.mjs`). All 12 previously-hardcoded types (`.json`, `.html`, `.css`, `.js`, `.png`, `.m3u8`, ...) resolve identically — verified — so no behavior change for existing types; the long tail (audio/video/fonts/office/archives) now gets a real content type.
- **`src/mashlib/index.js`** — `shouldServeMashlib` wraps any `audio/*` type (matched by prefix, robust to the mime db's spellings such as `audio/wave` and `audio/x-flac`) in addition to RDF/markdown/playlists. Video and image types are deliberately **not** wrapped: no pane exists for them, so the browser's native inline render beats a "No data found" shell. Mime correctness is safe for all types; shell-wrapping tracks pane availability.
- **`mime-types`** promoted from transitive to a direct dependency (`^2.1.35`).
- **`test/url.test.js`** — the old "unknown extension" test used `.xyz`, which `mime-types` knows (`chemical/x-xyz`); switched to `.zzz`. Added coverage for the audio/video mappings and override precedence.

## Verification

- `node --test test/*.test.js` → 84 pass, 0 fail.
- Hand-patched a live deployment (melvin.me) with the same two changes: after restart, browser navigation to an `.mp3` returns the `text/html` mashlib shell, the mashlib XHR for bytes returns `206 audio/mpeg`, and the audio pane renders a player. Direct `.mp4`/`.png` navigation still renders natively (not wrapped).

Companion audio pane: `panes/audio-pane.js` in the data browser repos.