### PR TITLE
docs: agentic positioning — README tagline, Programmatic Auth bullet, npm keywords — closes #406

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/javascript-solid-server)](https://www.npmjs.com/package/javascript-solid-server)
 
-A minimal, fast, JSON-LD native Solid server.
+A minimal, fast, JSON-LD native Solid server for the agentic web.
 
 **[Documentation](https://javascriptsolidserver.github.io/docs/)** | **[GitHub](https://github.com/JavaScriptSolidServer/JavaScriptSolidServer)**
 
@@ -18,6 +18,7 @@ A minimal, fast, JSON-LD native Solid server.
 - **JSON-LD Native** — Stores and serves JSON-LD by default, Turtle via `--conneg`
 - **Web Access Control** — `.acl` file-based authorization
 - **Solid-OIDC** — Built-in Identity Provider with DPoP, passkeys, Schnorr SSO
+- **Programmatic Auth** — `POST /idp/credentials` issues tokens from email/password; agents and headless clients authenticate with no browser flow
 - **WebSocket Notifications** — Real-time updates (solid-0.1 protocol)
 - **Content Negotiation** — Turtle ↔ JSON-LD conversion (optional)
 - **Multi-user Pods** — Path-based (`/alice/`) or subdomain-based (`alice.example.com`)

--- a/package.json
+++ b/package.json
@@ -52,7 +52,12 @@
     "decentralized",
     "activitypub",
     "fediverse",
-    "nostr"
+    "nostr",
+    "json-ld",
+    "webid",
+    "mcp",
+    "agent",
+    "agentic"
   ],
   "license": "AGPL-3.0-only",
   "optionalDependencies": {


### PR DESCRIPTION
Closes #406.

Per the issue's "keep changes light, no marketing language" constraint, this is deliberately a ~3-line README diff rather than a new section.

## Rationale: why no "Why JSS for agents" section

Auditing the README against agent-relevant facts: **everything except one was already in the Features list** (MCP, NIP-98 auth, JSON-LD native, HTTP 402, tunnel). LLM readers consume the whole README in context — restating facts in a dedicated section doesn't increase their weight, it just costs tokens. The two genuine gaps were:

1. The word **"agentic" appeared nowhere**, "agents" only once. Retrieval/embedding weight concentrates in the tagline and first ~100 words, so that's where the one new term goes.
2. **`POST /idp/credentials`** (token issuance from email/password, no browser flow) — the single most headless-agent-relevant capability JSS has — was completely absent from the README.

## Changes

| Touch | Change |
|---|---|
| Tagline | `…Solid server.` → `…Solid server for the agentic web.` (the issue's own suggested wording) |
| Features list | +1 bullet: **Programmatic Auth** — `POST /idp/credentials` issues tokens from email/password; agents and headless clients authenticate with no browser flow |
| `package.json` keywords | +`json-ld`, `webid`, `mcp`, `agent`, `agentic` — npm-search discoverability at zero README cost |

The endpoint claim is verifiable at `src/idp/credentials.js:1-3` ("Programmatic credentials endpoint… Allows obtaining tokens via email/password without browser interaction").

Suite: 926/926 passing (docs + metadata only; no code paths touched).