### PR TITLE
fix(idp): login error survives the redirect — ride in lastSubmission — closes #514

### DIFF
--- a/src/idp/interactions.js
+++ b/src/idp/interactions.js
@@ -95,7 +95,7 @@ export async function handleInteractionGet(request, reply, provider) {
 
     // If we need login
     if (prompt.name === 'login') {
-      return reply.type('text/html').send(loginPage(uid, params.client_id, interaction.lastError));
+      return reply.type('text/html').send(loginPage(uid, params.client_id, interaction.lastSubmission?.lastError));
     }
 
     // If we need consent
@@ -173,9 +173,17 @@ export async function handleLogin(request, reply, provider) {
       return reply.code(404).type('text/html').send(errorPage('Session expired', 'Please try logging in again.'));
     }
 
-    // Validate input
+    // Validate input.
+    //
+    // The error must live inside `lastSubmission` — oidc-provider's
+    // Interaction.save() persists ONLY the fields in the model's
+    // IN_PAYLOAD list (lib/models/interaction.js), and `lastSubmission`
+    // is the designated slot for form re-render state. A bare
+    // `interaction.lastError = …` survives in memory but is silently
+    // DROPPED on save, so the redirected GET re-rendered the form with
+    // no error and users retried blind (#514).
     if (!identifier || !password) {
-      interaction.lastError = 'Username and password are required';
+      interaction.lastSubmission = { lastError: 'Username and password are required' };
       await interaction.save(interaction.exp - Math.floor(Date.now() / 1000));
       return reply.redirect(`/idp/interaction/${uid}`);
     }
@@ -183,7 +191,8 @@ export async function handleLogin(request, reply, provider) {
     // Authenticate
     const account = await authenticate(identifier, password);
     if (!account) {
-      interaction.lastError = 'Invalid username or password';
+      // See the IN_PAYLOAD note above — must ride in lastSubmission.
+      interaction.lastSubmission = { lastError: 'Invalid username or password' };
       await interaction.save(interaction.exp - Math.floor(Date.now() / 1000));
       return reply.redirect(`/idp/interaction/${uid}`);
     }
@@ -404,7 +413,7 @@ export async function handleSwitchAccount(request, reply, provider) {
     interaction.session = undefined;
     interaction.result = undefined;
     interaction.prompt = { name: 'login', reasons: ['no_session'], details: {} };
-    interaction.lastError = undefined;
+    interaction.lastSubmission = undefined;
     const ttl = Math.max(1, interaction.exp - Math.floor(Date.now() / 1000));
     await interaction.save(ttl);
 

--- a/test/idp-login-error.test.js
+++ b/test/idp-login-error.test.js
@@ -1,0 +1,142 @@
+/**
+ * Login-form error rendering (#514).
+ *
+ * Submitting the IdP sign-in form with bad credentials set
+ * `interaction.lastError` and redirected back to the form — but
+ * oidc-provider's Interaction.save() persists ONLY the fields in the
+ * model's IN_PAYLOAD list, and `lastError` isn't one of them. The
+ * property survived in memory, was silently dropped on save, and the
+ * redirected GET re-rendered a pristine form: no error banner, user
+ * retries blind (the "credibility cliff" in the issue).
+ *
+ * Fix: the message rides in `lastSubmission` — the IN_PAYLOAD slot
+ * oidc-provider designates for form re-render state.
+ *
+ * The test drives the real OIDC interaction flow over HTTP (register
+ * client → /idp/auth → interaction redirect → POST bad credentials →
+ * follow redirect) with manual cookie threading, and asserts the
+ * re-rendered form carries the error.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { createServer } from '../src/server.js';
+import { createServer as createNetServer } from 'net';
+import fs from 'fs-extra';
+
+const TEST_HOST = 'localhost';
+const DATA_DIR = './test-data-idp-login-error';
+
+function getAvailablePort() {
+  return new Promise((resolve, reject) => {
+    const srv = createNetServer();
+    srv.on('error', reject);
+    srv.listen(0, TEST_HOST, () => {
+      const port = srv.address().port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+// Collect cookies from a response and merge into a name→value jar.
+function absorbCookies(jar, res) {
+  for (const c of res.headers.getSetCookie?.() || []) {
+    const [pair] = c.split(';');
+    const eq = pair.indexOf('=');
+    if (eq > 0) jar.set(pair.slice(0, eq).trim(), pair.slice(eq + 1).trim());
+  }
+}
+function cookieHeader(jar) {
+  return [...jar.entries()].map(([k, v]) => `${k}=${v}`).join('; ');
+}
+
+describe('IdP login form error rendering (#514)', () => {
+  let server;
+  let baseUrl;
+  let originalDataRoot;
+
+  before(async () => {
+    originalDataRoot = process.env.DATA_ROOT;
+    await fs.remove(DATA_DIR);
+    await fs.ensureDir(DATA_DIR);
+
+    const port = await getAvailablePort();
+    baseUrl = `http://${TEST_HOST}:${port}`;
+
+    server = createServer({
+      logger: false,
+      root: DATA_DIR,
+      idp: true,
+      idpIssuer: baseUrl,
+      forceCloseConnections: true,
+    });
+    await server.listen({ port, host: TEST_HOST });
+
+    const res = await fetch(`${baseUrl}/.pods`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'alice', email: 'a@example.org', password: 'correct123' }),
+    });
+    assert.strictEqual(res.status, 201, 'prereq: pod creation');
+  });
+
+  after(async () => {
+    if (server) await server.close();
+    if (originalDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = originalDataRoot;
+    await fs.remove(DATA_DIR);
+  });
+
+  it('re-renders the form WITH the error after a failed login', async () => {
+    // 1. Dynamic client registration
+    const reg = await fetch(`${baseUrl}/idp/reg`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        redirect_uris: [`${baseUrl}/cb`],
+        token_endpoint_auth_method: 'none',
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+      }),
+    });
+    assert.strictEqual(reg.status, 201, 'client registration');
+    const { client_id: clientId } = await reg.json();
+
+    // 2. Start the auth flow → interaction redirect + session cookies
+    const jar = new Map();
+    const authUrl = `${baseUrl}/idp/auth?client_id=${encodeURIComponent(clientId)}` +
+      `&redirect_uri=${encodeURIComponent(`${baseUrl}/cb`)}` +
+      '&response_type=code&scope=openid+webid' +
+      '&code_challenge_method=S256&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&state=s1';
+    const auth = await fetch(authUrl, { redirect: 'manual' });
+    absorbCookies(jar, auth);
+    const interactionPath = auth.headers.get('location');
+    assert.ok(interactionPath?.includes('/idp/interaction/'),
+      `expected interaction redirect, got ${interactionPath}`);
+    const interactionUrl = interactionPath.startsWith('http')
+      ? interactionPath : `${baseUrl}${interactionPath}`;
+
+    // 3. Submit WRONG credentials
+    const post = await fetch(`${interactionUrl}/login`, {
+      method: 'POST',
+      redirect: 'manual',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Cookie: cookieHeader(jar),
+      },
+      body: 'username=alice&password=definitely-wrong',
+    });
+    absorbCookies(jar, post);
+    assert.ok([302, 303].includes(post.status),
+      `failed login must redirect back to the form, got ${post.status}`);
+
+    // 4. Follow the redirect — the re-rendered form must carry the error
+    const rerender = await fetch(interactionUrl, {
+      headers: { Cookie: cookieHeader(jar) },
+    });
+    assert.strictEqual(rerender.status, 200);
+    const html = await rerender.text();
+    assert.match(html, /<div class="error">Invalid username or password<\/div>/,
+      're-rendered form must show the auth error (#514: lastError was dropped by Interaction.save)');
+  });
+});

--- a/test/idp-login-error.test.js
+++ b/test/idp-login-error.test.js
@@ -38,9 +38,18 @@ function getAvailablePort() {
   });
 }
 
+// Headers.getSetCookie() landed in Node 18.15 / 19.7. The engines
+// field still declares >=18.0.0 (bump deferred — #541), so guard
+// explicitly rather than collecting zero cookies and failing at a
+// confusing distance. Skipping costs nothing on those runtimes: the
+// IdP itself cannot run on Node 18 at all (oidc-provider uses
+// Array#toReversed and crypto.hash — #523), so every IdP test is
+// already broken there.
+const HAS_GET_SET_COOKIE = typeof new Headers().getSetCookie === 'function';
+
 // Collect cookies from a response and merge into a name→value jar.
 function absorbCookies(jar, res) {
-  for (const c of res.headers.getSetCookie?.() || []) {
+  for (const c of res.headers.getSetCookie()) {
     const [pair] = c.split(';');
     const eq = pair.indexOf('=');
     if (eq > 0) jar.set(pair.slice(0, eq).trim(), pair.slice(eq + 1).trim());
@@ -87,7 +96,11 @@ describe('IdP login form error rendering (#514)', () => {
     await fs.remove(DATA_DIR);
   });
 
-  it('re-renders the form WITH the error after a failed login', async () => {
+  it('re-renders the form WITH the error after a failed login', async (t) => {
+    if (!HAS_GET_SET_COOKIE) {
+      t.skip('Headers.getSetCookie unavailable (Node <18.15) — IdP requires Node 20+ anyway, see #523/#541');
+      return;
+    }
     // 1. Dynamic client registration
     const reg = await fetch(`${baseUrl}/idp/reg`, {
       method: 'POST',


### PR DESCRIPTION
Closes #514.

## Bug — and why it was invisible in the source

Every piece of the error wiring looked correct: the failed-login path set `interaction.lastError` and saved (`interactions.js:178/186`), the GET re-render passed it to the view (`:98`), and `loginPage()` renders the error div (`views.js:448`). Yet the live repro confirmed the issue: wrong password → redirect → **pristine form, no error**.

**Root cause:** oidc-provider's `Interaction.save()` persists only the fields in the model's `IN_PAYLOAD` list (`node_modules/oidc-provider/lib/models/interaction.js:57`). `lastError` is a foreign property — it survived in memory, was **silently dropped on save**, and the redirected GET loaded a fresh instance without it.

## Fix

The message rides in **`lastSubmission`** — the `IN_PAYLOAD` slot oidc-provider designates for exactly this form re-render state:

| Site | Change |
|---|---|
| `interactions.js:178` (missing fields) | `interaction.lastSubmission = { lastError: … }` + the IN_PAYLOAD gotcha documented in a comment |
| `interactions.js:186` (bad credentials) | same, with a pointer to the note |
| `interactions.js:98` (GET re-render) | reads `interaction.lastSubmission?.lastError` |
| `interactions.js:407` (switch-account clear) | clears `lastSubmission` |

## Verification

- **Live before/after**: the issue's exact repro (single-user IdP, wrong password) — before: no error div in the re-rendered HTML; after: `<div class="error">Invalid username or password</div>` renders.
- **Regression test** (`test/idp-login-error.test.js`): drives the real OIDC interaction flow over HTTP — dynamic client registration → `/idp/auth` → interaction redirect → POST bad credentials → follow redirect — with manual cookie threading, asserting the error div appears. DATA_ROOT snapshot/restore per house pattern.
- Full suite: **948/948 passing**.

## On the issue's "sweep other pages" note

The register flow renders `registerPage(uid, error, …)` **directly in the same response** (no save/redirect cycle), so it doesn't have this bug — the persistence trap only fires when error state must survive a round-trip through `Interaction.save()`. The login form was the only such site (the `lastError` grep now returns zero hits).