### PR TITLE
fix(idp): passkey login degrades on WebView/insecure contexts instead of crashing — closes #556

### DIFF
--- a/src/idp/views.js
+++ b/src/idp/views.js
@@ -265,12 +265,26 @@ export function loginPage(uid, clientId, error = null, passkeyEnabled = true, sc
     var INTERACTION_UID = '${safeUid}';
 
     async function loginWithPasskey() {
+      // Passkeys require WebAuthn + a secure context. Stale Android
+      // System WebViews (common on de-Googled phones, #556) and plain
+      // http origins lack it. Detect up front and steer the user to the
+      // password form right below instead of failing deep in the
+      // ceremony with a cryptic error.
+      if (!window.isSecureContext || !window.PublicKeyCredential ||
+          !(navigator.credentials && navigator.credentials.get)) {
+        alert('Passkeys aren\\'t available in this browser. Please sign in with your username and password below.');
+        return;
+      }
       try {
-        // Get authentication options
+        // Get authentication options. No client-side correlation id is
+        // sent — the server mints the challengeKey (always-available
+        // Node crypto) and returns it; we echo options.challengeKey on
+        // verify. This deliberately avoids a browser crypto.randomUUID
+        // call that old WebViews lack (#556).
         const optionsRes = await fetch('/idp/passkey/login/options', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ visitorId: crypto.randomUUID() })
+          body: JSON.stringify({})
         });
         const options = await optionsRes.json();
         if (options.error) {
@@ -1032,6 +1046,15 @@ export function passkeyPromptPage(uid, accountId) {
     var PASSKEY_ICON = '${passkeyIconEscaped}';
 
     async function registerPasskey() {
+      // Same WebAuthn / secure-context gate as the login page (#556):
+      // on a stale WebView the create() ceremony would fail cryptically.
+      // Steer to "Skip for now" instead of disabling the button on a
+      // path that can't succeed.
+      if (!window.isSecureContext || !window.PublicKeyCredential ||
+          !(navigator.credentials && navigator.credentials.create)) {
+        alert('Passkeys aren\\'t available in this browser. Tap "Skip for now" to continue.');
+        return;
+      }
       const btn = document.getElementById('addBtn');
       btn.disabled = true;
       btn.textContent = 'Setting up...';

--- a/test/passkey-webauthn-degrade.test.js
+++ b/test/passkey-webauthn-degrade.test.js
@@ -1,0 +1,118 @@
+/**
+ * Passkey login degrades on WebView/insecure contexts (#556).
+ *
+ * Two problems on stale Android System WebViews (de-Googled phones):
+ *   1. The login page's inline JS called `crypto.randomUUID()` to make a
+ *      `visitorId` — missing on old WebViews (Chromium <92 / non-secure),
+ *      so "Sign in with Passkey" threw `crypto.randomUUID is not a
+ *      function`. Unlike jspod (#65), where the call lives inside the
+ *      imported solid-oidc library, JSS OWNS the call site: the server
+ *      already mints the challengeKey (Node crypto, always available)
+ *      and returns it, so the browser call was redundant. Removed.
+ *   2. Both passkey ceremonies (login get(), prompt create()) would
+ *      fail deep with a cryptic WebAuthn error on a WebView that can't
+ *      do WebAuthn at all. Now guarded with a secure-context /
+ *      PublicKeyCredential check that steers the user to the password
+ *      form (login) or "Skip for now" (prompt).
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { loginPage, passkeyPromptPage } from '../src/idp/views.js';
+import { createServer } from '../src/server.js';
+import { createServer as createNetServer } from 'net';
+import fs from 'fs-extra';
+
+const TEST_HOST = 'localhost';
+const DATA_DIR = './test-data-passkey-degrade';
+
+function getAvailablePort() {
+  return new Promise((resolve, reject) => {
+    const srv = createNetServer();
+    srv.on('error', reject);
+    srv.listen(0, TEST_HOST, () => {
+      const port = srv.address().port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+function inlineScripts(html) {
+  return [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+}
+
+describe('passkey WebAuthn degradation (#556)', () => {
+  describe('rendered pages', () => {
+    it('login page no longer emits a browser crypto.randomUUID() call', () => {
+      const html = loginPage('uid-1', 'client-1', null, true, true);
+      assert.ok(!/crypto\.randomUUID\(\)/.test(html),
+        'no crypto.randomUUID() call should survive in the served JS');
+      assert.ok(html.includes('JSON.stringify({})'),
+        'login options request sends an empty body (server mints challengeKey)');
+    });
+
+    it('login page guards on secure-context + WebAuthn before the ceremony', () => {
+      const html = loginPage('uid-1', 'client-1', null, true, true);
+      assert.ok(html.includes('isSecureContext') && html.includes('PublicKeyCredential'),
+        'WebAuthn availability is checked up front');
+    });
+
+    it('passkey prompt page guards registration the same way', () => {
+      const html = passkeyPromptPage('uid-1', 'acct-1');
+      assert.ok(html.includes('isSecureContext') && html.includes('PublicKeyCredential'),
+        'registration ceremony is guarded too');
+    });
+
+    it('every inline <script> in both pages is syntactically valid JS', () => {
+      for (const html of [loginPage('u', 'c', null, true, true), passkeyPromptPage('u', 'a')]) {
+        for (const src of inlineScripts(html)) {
+          assert.doesNotThrow(() => new Function(src),
+            'inline script must parse (escaping regression guard)');
+        }
+      }
+    });
+  });
+
+  describe('options endpoint mints the challengeKey server-side', () => {
+    let server;
+    let baseUrl;
+    let originalDataRoot;
+
+    before(async () => {
+      originalDataRoot = process.env.DATA_ROOT;
+      await fs.remove(DATA_DIR);
+      await fs.ensureDir(DATA_DIR);
+      const port = await getAvailablePort();
+      baseUrl = `http://${TEST_HOST}:${port}`;
+      server = createServer({
+        logger: false, root: DATA_DIR, idp: true,
+        idpIssuer: baseUrl, forceCloseConnections: true,
+      });
+      await server.listen({ port, host: TEST_HOST });
+    });
+
+    after(async () => {
+      if (server) await server.close();
+      if (originalDataRoot === undefined) delete process.env.DATA_ROOT;
+      else process.env.DATA_ROOT = originalDataRoot;
+      await fs.remove(DATA_DIR);
+    });
+
+    it('returns a challengeKey for an EMPTY options body (no client visitorId needed)', async () => {
+      // This is what the page now sends. The server falls back to its
+      // own crypto.randomUUID() (Node, always available) and returns the
+      // key the client echoes on verify — so dropping the browser call
+      // is functionally complete, not a regression.
+      const res = await fetch(`${baseUrl}/idp/passkey/login/options`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      assert.strictEqual(res.status, 200, 'anonymous options request must succeed');
+      const body = await res.json();
+      assert.ok(typeof body.challengeKey === 'string' && body.challengeKey.length > 0,
+        'server must return a challengeKey the client can echo on verify');
+      assert.ok(body.challenge, 'WebAuthn challenge present');
+    });
+  });
+});


### PR DESCRIPTION
Closes #556. Port-back from [jspod#65](https://github.com/JavaScriptSolidServer/jspod/issues/65), but JSS can fix it *better* than jspod could.

## The two problems on stale WebViews (de-Googled phones)

1. **`crypto.randomUUID` crash.** `loginPage`'s inline JS built a `visitorId` with `crypto.randomUUID()` — absent on Chromium <92 / non-secure contexts → `Sign in with Passkey` threw `crypto.randomUUID is not a function`.
2. **WebAuthn-unavailable crash.** Even past that, both ceremonies (`navigator.credentials.get`/`create`) fail with a cryptic error on a WebView that can't do WebAuthn.

## Why JSS's fix is cleaner than jspod's polyfill

jspod *had* to polyfill `randomUUID` because the call lives inside the `solid-oidc` library it imports. **JSS owns the call site.** And the call was redundant: `authenticationOptions` (`passkey.js:226`) already mints the `challengeKey` via Node's always-available `crypto.randomUUID()` and returns it (`:236`), and the client already echoes `options.challengeKey` on verify (`views.js:298`). So the browser call generated a value the server immediately overrode.

**Fix 1:** drop the client `crypto.randomUUID()`; send `{}`. Server mints the key, client echoes it — functionally identical, zero browser crypto.

**Fix 2:** an up-front `isSecureContext` + `PublicKeyCredential` + `credentials.get/create` guard on both `loginWithPasskey` and `registerPasskey` that steers the user to the password form (login) or "Skip for now" (prompt) — both already on the page. This addresses jspod#65's own caveat: the polyfill only fixes `randomUUID`, never the WebAuthn/secure-context gate, which is the real wall. We can't make passkeys *work* on those WebViews (nobody can), but the page now degrades cleanly to password/Schnorr login instead of erroring.

## Tests

`test/passkey-webauthn-degrade.test.js` (5 — the first direct passkey-endpoint coverage, noted missing when #78 closed):
- no `crypto.randomUUID()` call survives in the served JS; empty options body is sent
- both pages carry the secure-context/WebAuthn guard
- every inline `<script>` parses (apostrophe-escaping regression guard)
- **functional proof:** the options endpoint returns a usable `challengeKey` for an **empty** body — so dropping the client call is complete, not a regression

Full suite: **958/958**.

## Scope note

Server-side `crypto.randomUUID` in `keys.js`/`accounts.js`/`credentials.js`/`passkey.js` is Node (always available) — untouched. `views.js:273` was the only browser-side site.