### PR TITLE
Wire --body-limit into createServer; real CONTENT_LENGTH for chunked git pushes

### DIFF
--- a/bin/jss.js
+++ b/bin/jss.js
@@ -190,6 +190,10 @@ program
       const server = createServer({
         port: config.port,
         host: config.host,
+        // Wire the parsed --body-limit / JSS_BODY_LIMIT value through —
+        // omitting it here silently pinned every CLI-started server to
+        // the 10MB default and made the #474 knob dead wiring (#561).
+        bodyLimit: config.bodyLimit,
         logger: config.logger,
         conneg: config.conneg,
         notifications: config.notifications,

--- a/src/handlers/git.js
+++ b/src/handlers/git.js
@@ -279,7 +279,15 @@ export async function handleGit(request, reply) {
     CONTENT_TYPE: request.headers['content-type'] || '',
     QUERY_STRING: queryString,
     REMOTE_USER: request.webId || '',           // Pass authenticated user
-    CONTENT_LENGTH: request.headers['content-length'] || '0',
+    // Use the buffered body's real length, not the Content-Length header:
+    // git sends packs larger than http.postBuffer (1 MiB default) with
+    // Transfer-Encoding: chunked and NO Content-Length, so the header
+    // fallback told http-backend "0 bytes" and receive-pack died with
+    // "the remote end hung up unexpectedly" on any push > 1 MiB (#561).
+    // Fastify has already buffered the full body either way.
+    CONTENT_LENGTH: request.body?.length
+      ? String(request.body.length)
+      : (request.headers['content-length'] || '0'),
   };
 
   // For regular repositories, set GIT_DIR

--- a/test/body-limit-cli.test.js
+++ b/test/body-limit-cli.test.js
@@ -82,13 +82,19 @@ async function stopCli() {
   if (!child) return;
   const c = child;
   child = null;
-  if (c.exitCode === null && c.signalCode === null) {
-    const gone = new Promise(r => c.once('exit', r));
-    c.kill('SIGTERM');
-    await Promise.race([gone, new Promise(r => setTimeout(r, 3000))]);
-    if (c.exitCode === null && c.signalCode === null) c.kill('SIGKILL');
-    await gone;
-  }
+  // The exitCode check and the once('exit') attach below are in the
+  // same synchronous block — Node can't emit 'exit' between two
+  // synchronous statements, so the listener can't miss the event (if
+  // it already fired, exitCode is non-null and we return here).
+  if (c.exitCode !== null || c.signalCode !== null) return;
+  const gone = new Promise(r => c.once('exit', r));
+  c.kill('SIGTERM');
+  await Promise.race([gone, new Promise(r => setTimeout(r, 3000))]);
+  if (c.exitCode === null && c.signalCode === null) c.kill('SIGKILL');
+  // SIGKILL can't be caught, so 'exit' follows promptly. The cap is a
+  // belt-and-braces bound so the suite can never hang on a pathological
+  // unkillable child (e.g. stuck in uninterruptible I/O).
+  await Promise.race([gone, new Promise(r => setTimeout(r, 2000))]);
 }
 
 async function putTwoKiB(baseUrl) {

--- a/test/body-limit-cli.test.js
+++ b/test/body-limit-cli.test.js
@@ -1,0 +1,124 @@
+/**
+ * CLI wiring for --body-limit / JSS_BODY_LIMIT (#561).
+ *
+ * test/body-limit.test.js covers createServer({ bodyLimit }) — the
+ * programmatic path — but the CLI start command builds its createServer
+ * options object by hand, and originally omitted `bodyLimit`. Result:
+ * the #474 knob parsed fine and was then silently dropped, pinning every
+ * CLI-started server to the 10 MiB default. git pushes of packs over the
+ * default failed with 413 no matter what the operator passed (#561).
+ *
+ * These tests spawn `bin/jss.js start` as a real subprocess (same
+ * pattern as cli-flag-like-values.test.js) and assert the limit
+ * actually reaches Fastify:
+ *
+ *   - `--body-limit 1KB`  → a 2 KiB PUT is rejected with 413
+ *   - `--body-limit 5MB`  → the same PUT is NOT rejected with 413
+ *   - `JSS_BODY_LIMIT=1KB` (env, no flag) → 413, same as the flag
+ *
+ * The over-limit assertions are deliberately status-exact (413) while
+ * the under-limit assertion is only "not 413": body parsing runs before
+ * auth/WAC, so an under-limit request may still be refused later in the
+ * pipeline — that's fine, the wiring under test is the parser cap.
+ */
+
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import { createServer as createNetServer } from 'node:net';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import fs from 'fs-extra';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BIN = path.join(__dirname, '..', 'bin', 'jss.js');
+const TEST_DATA_DIR = './test-data-body-limit-cli';
+
+let child;
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const srv = createNetServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+async function startCli({ args = [], env = {} }) {
+  await fs.emptyDir(TEST_DATA_DIR);
+  const port = await freePort();
+  child = spawn(process.execPath, [
+    BIN, 'start',
+    '--port', String(port),
+    '--host', '127.0.0.1',
+    '--root', TEST_DATA_DIR,
+    ...args,
+  ], {
+    env: { ...process.env, ...env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  // Poll until the server answers (or the child dies / 15 s passes).
+  const deadline = Date.now() + 15_000;
+  let exited = false;
+  child.once('exit', () => { exited = true; });
+  while (Date.now() < deadline) {
+    if (exited) throw new Error('jss CLI exited before becoming ready');
+    try {
+      await fetch(baseUrl, { signal: AbortSignal.timeout(1000) });
+      return baseUrl;
+    } catch {
+      await new Promise(r => setTimeout(r, 250));
+    }
+  }
+  throw new Error('jss CLI did not become ready within 15s');
+}
+
+async function stopCli() {
+  if (!child) return;
+  const c = child;
+  child = null;
+  if (c.exitCode === null && c.signalCode === null) {
+    const gone = new Promise(r => c.once('exit', r));
+    c.kill('SIGTERM');
+    await Promise.race([gone, new Promise(r => setTimeout(r, 3000))]);
+    if (c.exitCode === null && c.signalCode === null) c.kill('SIGKILL');
+    await gone;
+  }
+}
+
+async function putTwoKiB(baseUrl) {
+  const res = await fetch(`${baseUrl}/body-limit-probe.bin`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/octet-stream' },
+    body: Buffer.alloc(2048, 0x61),
+    signal: AbortSignal.timeout(5000),
+  });
+  return res.status;
+}
+
+describe('bin/jss.js — --body-limit reaches Fastify (#561)', () => {
+  afterEach(async () => {
+    await stopCli();
+    await fs.remove(TEST_DATA_DIR);
+  });
+
+  it('--body-limit 1KB rejects a 2KiB PUT with 413', async () => {
+    const baseUrl = await startCli({ args: ['--body-limit', '1KB'] });
+    assert.strictEqual(await putTwoKiB(baseUrl), 413);
+  });
+
+  it('--body-limit 5MB does not 413 a 2KiB PUT', async () => {
+    const baseUrl = await startCli({ args: ['--body-limit', '5MB'] });
+    assert.notStrictEqual(await putTwoKiB(baseUrl), 413);
+  });
+
+  it('JSS_BODY_LIMIT=1KB (env, no flag) rejects a 2KiB PUT with 413', async () => {
+    const baseUrl = await startCli({ env: { JSS_BODY_LIMIT: '1KB' } });
+    assert.strictEqual(await putTwoKiB(baseUrl), 413);
+  });
+});


### PR DESCRIPTION
Fixes #561. Related: #559 (default bundle vs limit), #560 (auto-init leftover), #474 (the knob this revives).

Two halves of one user-facing bug — **a `git push` with a pack over 10MB could not succeed no matter what the operator configured**:

## 1. `--body-limit` / `JSS_BODY_LIMIT` were dead wiring on the CLI path

`bin/jss.js start` parses them into `config.bodyLimit`, but the hand-written options object passed to `createServer()` omitted `bodyLimit` — so `src/server.js` always fell back to the 10MiB default. Only programmatic `createServer({ bodyLimit })` ever worked (which is why `test/body-limit.test.js` passed all along). One line: pass `bodyLimit: config.bodyLimit`.

## 2. Chunked git pushes told the CGI "0 bytes"

git sends any pack larger than `http.postBuffer` (1MiB default) with `Transfer-Encoding: chunked` and **no Content-Length header**. `src/handlers/git.js` set the CGI env from that header (`CONTENT_LENGTH: ... || '0'`), so `git http-backend` read zero bytes from a fully-buffered 13.6MB body and receive-pack died with "the remote end hung up unexpectedly". Fixed by using the buffered body's real length (`request.body.length`).

Without fix 2, fix 1 just moves the failure from `413` to a hang-up — both are needed before raising the limit helps anyone.

## Tests

`test/body-limit-cli.test.js` spawns the real CLI (same pattern as `cli-flag-like-values.test.js`) and asserts the limit reaches Fastify:
- `--body-limit 1KB` → 2KiB PUT gets 413
- `--body-limit 5MB` → same PUT does not get 413
- `JSS_BODY_LIMIT=1KB` env, no flag → 413

Verified the tests catch the bug: 2 of 3 fail with fix 1 reverted.

## End-to-end

`jss start --git --body-limit 200MB` + `jss install solid-chat/app=chat JavaScriptSolidServer/git` — the two apps that have never been installable over HTTP — now completes **2/2 with extracted working trees serving 200** (previously: 413s, then with fix 1 alone: hang-up + an empty auto-init repo, the #560 artifact).

Full suite: **961 pass, 0 fail** (was 958 before the 3 new tests).

`GIT_TRACE_CURL` evidence and the full diagnosis trail are in #561.