### PR TITLE
Use CID v1.0 `@context` in served did:nostr docs so `Multikey` is defined

### DIFF
--- a/src/idp/well-known-did-nostr.js
+++ b/src/idp/well-known-did-nostr.js
@@ -498,7 +498,7 @@ function buildDidDocument({ pubkey, webId }) {
   const multikey = `f` + `e701` + `02` + pubkey.toLowerCase();
   const vmId = `${did}#key1`;
   return {
-    '@context': ['https://w3id.org/did', 'https://w3id.org/nostr/context'],
+    '@context': ['https://www.w3.org/ns/cid/v1', 'https://w3id.org/nostr/context'],
     'id': did,
     'type': 'DIDNostr',
     'alsoKnownAs': [webId],

--- a/test/well-known-did-nostr.test.js
+++ b/test/well-known-did-nostr.test.js
@@ -129,7 +129,7 @@ describe('GET /.well-known/did/nostr/:pubkey (#407)', () => {
     assert.ok(r.headers.get('last-modified'));
 
     const doc = await r.json();
-    assert.deepStrictEqual(doc['@context'], ['https://w3id.org/did', 'https://w3id.org/nostr/context']);
+    assert.deepStrictEqual(doc['@context'], ['https://www.w3.org/ns/cid/v1', 'https://w3id.org/nostr/context']);
     assert.strictEqual(doc.id, `did:nostr:${alicePk}`);
     assert.strictEqual(doc.type, 'DIDNostr');
     assert.ok(Array.isArray(doc.alsoKnownAs));


### PR DESCRIPTION
Closes #568.

`src/idp/well-known-did-nostr.js` serves DID documents with `"type": "Multikey"` + `publicKeyMultibase`, but the `@context` (`https://w3id.org/did` + `nostr/context`) defines neither, and `https://w3id.org/did` returns `text/html` rather than a JSON-LD context.

```diff
-    '@context': ['https://w3id.org/did', 'https://w3id.org/nostr/context'],
+    '@context': ['https://www.w3.org/ns/cid/v1', 'https://w3id.org/nostr/context'],
```

`Multikey` / `publicKeyMultibase` are defined only in Controlled Identifiers v1.0 (`https://www.w3.org/ns/cid/v1`) — which jss already uses in `src/keys/provision.js:141`, so this also removes an internal inconsistency. Mirrors nostrcg/did-nostr#91. Safe: nothing asserts the literal `@context`; auth/resolution match on the verification method, not the context.