### PR TITLE
fix(mcp): write_acl sets accessTo to the resource URL, not './' (fixes owner lockout #575)

### DIFF
--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -300,12 +300,21 @@ async function read_acl({ path }, ctx) {
   });
 }
 
-function buildAclDoc(structured) {
+function buildAclDoc(structured, targetUrl, isContainer) {
   const graph = structured.authorizations.map((auth, i) => {
     const node = {
       '@id': `#auth${i}`,
       '@type': 'acl:Authorization',
-      'acl:accessTo': { '@id': './' },
+      // Point accessTo at the explicit absolute resource URL, NOT './'. A
+      // relative './' resolves against the .acl document's own URL, which
+      // only lands on the right target for a *container* ACL
+      // (<container>/.acl -> the container). For a *resource* ACL
+      // (<resource>.acl) it resolves to the parent container, so
+      // checkAuthorizations() — which requires an exact accessTo match —
+      // finds nothing and leaves the resource with zero authorizations,
+      // locking out even the owner who just granted themselves Control
+      // (#575). parser.js already writes the explicit resourceUrl; match it.
+      'acl:accessTo': { '@id': targetUrl },
       'acl:mode': (auth.modes || []).map(m => ({ '@id': `acl:${m}` }))
     };
     if (auth.agents && auth.agents.length) {
@@ -316,8 +325,11 @@ function buildAclDoc(structured) {
         '@id': fullAgentClass(c)
       }));
     }
-    if (auth.isDefault) {
-      node['acl:default'] = { '@id': './' };
+    // acl:default only has meaning on a container ACL (it supplies the
+    // defaults inherited by contained resources). Emit it for containers
+    // only, pointing at the container itself.
+    if (auth.isDefault && isContainer) {
+      node['acl:default'] = { '@id': targetUrl };
     }
     return node;
   });
@@ -340,20 +352,33 @@ async function write_acl({ path, authorizations }, ctx) {
     return toolError(`access denied: control ${path}`);
   }
   const aclPath = aclUrlFor(path);
-  const doc = buildAclDoc({ authorizations });
+  const targetUrl = buildUrl(ctx, path);
+  const doc = buildAclDoc({ authorizations }, targetUrl, path.endsWith('/'));
   const serialized = serializeAcl(doc);
 
   // Safety: refuse to write an ACL that would lock the caller out of
-  // future Control. This is the most common write_acl footgun —
-  // typically caused by relative WebID paths in `agents` resolving
-  // against the .acl URL to a different absolute URI than the caller's
-  // actual WebID. Parse the proposed ACL with its real URL so relative
-  // agents resolve correctly, then check whether any authorization
-  // grants Control to the caller.
+  // future Control. Two footguns are covered:
+  //   1. relative WebID paths in `agents` resolving against the .acl URL
+  //      to a different absolute URI than the caller's actual WebID;
+  //   2. an authorization whose `accessTo` does not actually cover this
+  //      resource (e.g. #575), which the checker would skip entirely.
+  // Parse the proposed ACL with its real URL so relative refs resolve
+  // correctly, then require an authorization that both grants Control to
+  // the caller *and* applies to this target.
   const aclAbsUrl = buildUrl(ctx, aclPath);
   const proposed = await parseAcl(serialized, aclAbsUrl);
+  const normUrl = u => String(u).replace(/\/$/, '');
+  const appliesToTarget = auth => {
+    const t = normUrl(targetUrl);
+    return (auth.accessTo || []).some(a => normUrl(a) === t) ||
+      (auth.default || []).some(d => {
+        const p = normUrl(d);
+        return t === p || t.startsWith(p + '/');
+      });
+  };
   const callerHasControl = proposed.some(auth => {
     if (!(auth.modes || []).includes(AccessMode.CONTROL)) return false;
+    if (!appliesToTarget(auth)) return false;
     if (ctx.webId && (auth.agents || []).includes(ctx.webId)) return true;
     if ((auth.agentClasses || []).includes(FOAF_AGENT)) return true;
     if (ctx.webId && (auth.agentClasses || []).includes(ACL_AUTH_AGENT)) return true;

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -305,16 +305,16 @@ function buildAclDoc(structured, targetRef, isContainer) {
     const node = {
       '@id': `#auth${i}`,
       '@type': 'acl:Authorization',
-      // accessTo is a *relative* IRI resolved against the .acl document's
-      // own URL, so stored ACLs stay host-portable across origins (#428).
-      // The bare './' the old code always used only lands on the right
-      // target for a *container* ACL (<container>/.acl -> the container).
-      // For a *resource* ACL (<resource>.acl) './' resolves to the parent
-      // container, so checkAuthorizations() — which requires an exact
-      // accessTo match — finds nothing and leaves the resource with zero
-      // authorizations, locking out even the owner who just granted
-      // themselves Control (#575). targetRef is therefore './' for a
-      // container and './<basename>' for a resource.
+      // accessTo is a *relative* IRI; the parser resolves it against the
+      // ACL's base URL (parser.js getBaseUrl()), which is the parent
+      // container directory for BOTH container and resource ACLs. So './'
+      // resolves to that container — correct for a container ACL, but for a
+      // *resource* ACL it points at the parent container, not the resource,
+      // leaving checkAuthorizations() (which requires an exact accessTo
+      // match) with zero authorizations and locking out even the owner who
+      // just granted themselves Control (#575). targetRef is therefore './'
+      // for a container and './<basename>' for a resource. Relative IRIs
+      // keep stored ACLs host-portable across origins (#428).
       'acl:accessTo': { '@id': targetRef },
       'acl:mode': (auth.modes || []).map(m => ({ '@id': `acl:${m}` }))
     };
@@ -354,8 +354,9 @@ async function write_acl({ path, authorizations }, ctx) {
   const aclPath = aclUrlFor(path);
   const isContainer = path.endsWith('/');
   // Relative target IRI for the stored ACL (host-portable, #428): './' for
-  // a container, './<basename>' for a resource. Resolved against the .acl
-  // URL by the parser at check time.
+  // a container, './<basename>' for a resource. The parser resolves it
+  // against the ACL base URL (the parent container directory), so the
+  // basename lands on the resource.
   const targetRef = isContainer
     ? './'
     : './' + path.replace(/\/+$/, '').split('/').pop();

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -300,21 +300,22 @@ async function read_acl({ path }, ctx) {
   });
 }
 
-function buildAclDoc(structured, targetUrl, isContainer) {
+function buildAclDoc(structured, targetRef, isContainer) {
   const graph = structured.authorizations.map((auth, i) => {
     const node = {
       '@id': `#auth${i}`,
       '@type': 'acl:Authorization',
-      // Point accessTo at the explicit absolute resource URL, NOT './'. A
-      // relative './' resolves against the .acl document's own URL, which
-      // only lands on the right target for a *container* ACL
-      // (<container>/.acl -> the container). For a *resource* ACL
-      // (<resource>.acl) it resolves to the parent container, so
-      // checkAuthorizations() — which requires an exact accessTo match —
-      // finds nothing and leaves the resource with zero authorizations,
-      // locking out even the owner who just granted themselves Control
-      // (#575). parser.js already writes the explicit resourceUrl; match it.
-      'acl:accessTo': { '@id': targetUrl },
+      // accessTo is a *relative* IRI resolved against the .acl document's
+      // own URL, so stored ACLs stay host-portable across origins (#428).
+      // The bare './' the old code always used only lands on the right
+      // target for a *container* ACL (<container>/.acl -> the container).
+      // For a *resource* ACL (<resource>.acl) './' resolves to the parent
+      // container, so checkAuthorizations() — which requires an exact
+      // accessTo match — finds nothing and leaves the resource with zero
+      // authorizations, locking out even the owner who just granted
+      // themselves Control (#575). targetRef is therefore './' for a
+      // container and './<basename>' for a resource.
+      'acl:accessTo': { '@id': targetRef },
       'acl:mode': (auth.modes || []).map(m => ({ '@id': `acl:${m}` }))
     };
     if (auth.agents && auth.agents.length) {
@@ -326,10 +327,9 @@ function buildAclDoc(structured, targetUrl, isContainer) {
       }));
     }
     // acl:default only has meaning on a container ACL (it supplies the
-    // defaults inherited by contained resources). Emit it for containers
-    // only, pointing at the container itself.
+    // defaults inherited by contained resources), where targetRef is './'.
     if (auth.isDefault && isContainer) {
-      node['acl:default'] = { '@id': targetUrl };
+      node['acl:default'] = { '@id': targetRef };
     }
     return node;
   });
@@ -352,8 +352,15 @@ async function write_acl({ path, authorizations }, ctx) {
     return toolError(`access denied: control ${path}`);
   }
   const aclPath = aclUrlFor(path);
-  const targetUrl = buildUrl(ctx, path);
-  const doc = buildAclDoc({ authorizations }, targetUrl, path.endsWith('/'));
+  const isContainer = path.endsWith('/');
+  // Relative target IRI for the stored ACL (host-portable, #428): './' for
+  // a container, './<basename>' for a resource. Resolved against the .acl
+  // URL by the parser at check time.
+  const targetRef = isContainer
+    ? './'
+    : './' + path.replace(/\/+$/, '').split('/').pop();
+  const targetUrl = buildUrl(ctx, path); // absolute, for the lockout check below
+  const doc = buildAclDoc({ authorizations }, targetRef, isContainer);
   const serialized = serializeAcl(doc);
 
   // Safety: refuse to write an ACL that would lock the caller out of

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -376,6 +376,13 @@ async function write_acl({ path, authorizations }, ctx) {
   const aclAbsUrl = buildUrl(ctx, aclPath);
   const proposed = await parseAcl(serialized, aclAbsUrl);
   const normUrl = u => String(u).replace(/\/$/, '');
+  const grantsCallerControl = auth => {
+    if (!(auth.modes || []).includes(AccessMode.CONTROL)) return false;
+    if (ctx.webId && (auth.agents || []).includes(ctx.webId)) return true;
+    if ((auth.agentClasses || []).includes(FOAF_AGENT)) return true;
+    if (ctx.webId && (auth.agentClasses || []).includes(ACL_AUTH_AGENT)) return true;
+    return false;
+  };
   const appliesToTarget = auth => {
     const t = normUrl(targetUrl);
     return (auth.accessTo || []).some(a => normUrl(a) === t) ||
@@ -384,20 +391,24 @@ async function write_acl({ path, authorizations }, ctx) {
         return t === p || t.startsWith(p + '/');
       });
   };
-  const callerHasControl = proposed.some(auth => {
-    if (!(auth.modes || []).includes(AccessMode.CONTROL)) return false;
-    if (!appliesToTarget(auth)) return false;
-    if (ctx.webId && (auth.agents || []).includes(ctx.webId)) return true;
-    if ((auth.agentClasses || []).includes(FOAF_AGENT)) return true;
-    if (ctx.webId && (auth.agentClasses || []).includes(ACL_AUTH_AGENT)) return true;
-    return false;
-  });
-  if (!callerHasControl) {
+  // Distinguish the two failure modes so the caller can fix the right thing:
+  //   (a) no authorization grants Control to the caller at all, vs
+  //   (b) one does, but its accessTo/default does not cover this target.
+  const controlAuths = proposed.filter(grantsCallerControl);
+  if (controlAuths.length === 0) {
     return toolError(
       `write_acl refused: the proposed ACL would not grant Control to the caller (${ctx.webId || 'anonymous'}). ` +
       'This is typically caused by relative WebID paths in agents resolving against the .acl URL — use absolute WebIDs. ' +
       'If you really want to remove your own access (e.g. transferring ownership), do it in two steps: ' +
       'first grant Control to the new owner, then have the new owner write_acl without you.'
+    );
+  }
+  if (!controlAuths.some(appliesToTarget)) {
+    return toolError(
+      `write_acl refused: the proposed ACL grants Control to the caller (${ctx.webId || 'anonymous'}) ` +
+      `but none of those authorizations apply to ${path} — their accessTo/default targets a different ` +
+      'resource (commonly the parent container), so the resource would be left with no effective Control. ' +
+      'Ensure each authorization\'s accessTo covers this resource.'
     );
   }
 

--- a/test/mcp.test.js
+++ b/test/mcp.test.js
@@ -22,6 +22,7 @@ import {
 import { emitChange } from '../src/notifications/events.js';
 
 let token;
+let ownerWebId;
 
 async function rpc(body, opts = {}) {
   const headers = { 'Content-Type': 'application/json' };
@@ -39,8 +40,9 @@ async function rpc(body, opts = {}) {
 describe('MCP server (--mcp enabled)', () => {
   before(async () => {
     await startTestServer({ mcp: true });
-    await createTestPod('mcptest');
+    const pod = await createTestPod('mcptest');
     token = getPodToken('mcptest');
+    ownerWebId = pod.webId;
   });
 
   after(async () => {
@@ -320,6 +322,41 @@ describe('MCP server (--mcp enabled)', () => {
     });  // no token
     assert.ok(body.result.isError);
     assert.match(body.result.content[0].text, /control/i);
+  });
+
+  it('write_acl on a resource does not lock the owner out (#575)', async () => {
+    // Regression: write_acl on a non-container resource used to set
+    // accessTo='./', which resolves to the *parent container* rather than
+    // the resource, leaving the resource with zero matching authorizations
+    // and locking out even the owner who just granted themselves Control.
+    const resPath = '/mcptest/public/acl575.txt';
+    const cr = await rpc({
+      jsonrpc: '2.0', id: 220, method: 'tools/call',
+      params: { name: 'write_resource', arguments: { path: resPath, content: 'secret', contentType: 'text/plain' } }
+    }, { token });
+    assert.strictEqual(cr.body.result.isError, false, cr.body.result.content?.[0]?.text);
+
+    // Grant the owner Read/Write/Control on the resource itself.
+    const wr = await rpc({
+      jsonrpc: '2.0', id: 221, method: 'tools/call',
+      params: { name: 'write_acl', arguments: {
+        path: resPath,
+        authorizations: [{ agents: [ownerWebId], modes: ['Read', 'Write', 'Control'] }]
+      } }
+    }, { token });
+    assert.strictEqual(wr.body.result.isError, false, wr.body.result.content?.[0]?.text);
+
+    // read_acl requires Control on the resource. Before the fix the owner
+    // was locked out and this was denied; it must now succeed.
+    const rd = await rpc({
+      jsonrpc: '2.0', id: 222, method: 'tools/call',
+      params: { name: 'read_acl', arguments: { path: resPath } }
+    }, { token });
+    assert.strictEqual(rd.body.result.isError, false,
+      'owner locked out of resource ACL (#575): ' + rd.body.result.content?.[0]?.text);
+    const payload = JSON.parse(rd.body.result.content[0].text);
+    assert.ok(payload.authorizations.some(a => a.modes.includes('Control')),
+      'resource ACL should grant the owner Control');
   });
 
   // --- call_remote_pod (#495) ---


### PR DESCRIPTION
Closes #575. Thanks to @NilsBM for the precise report and root-cause.

## Bug

`write_acl` (MCP tool, #496) hardcoded `acl:accessTo: { '@id': './' }` in `buildAclDoc`. A relative `'./'` resolves against the **`.acl` document's own URL**:

- Container `/c/` -> ACL `/c/.acl` -> `'./'` = `/c/` ✅
- Resource `/c/r` -> ACL `/c/r.acl` -> `'./'` = `/c/` (parent) ❌ should be `/c/r`

`checkAuthorizations()` (`src/wac/checker.js`) requires an **exact** `accessTo` match against the target. For a resource ACL nothing matched, so the resource was left with **zero authorizations** — denying everyone, including the owner who just granted themselves Control.

The existing round-trip test only used a **container** path (`/mcptest/public/`), where `'./'` happens to be correct, so the resource case was never exercised. `parser.js` already writes the explicit `resourceUrl` in six places — only this MCP tool deviated.

## Fix

- **`buildAclDoc`** now takes the explicit absolute target URL (`buildUrl(ctx, path)`) for `accessTo`, matching `parser.js`. `acl:default` is emitted **only for containers** (it has no meaning on a resource ACL).
- **Hardened the lockout safety net**: a controlling authorization must now also *apply to the target* (its `accessTo`/`default` covers the resource), so a mismatched `accessTo` is refused with a clear error instead of silently locking the owner out.
- **Regression test**: a resource-level `write_acl` + `read_acl` round-trip that fails without the fix (verified) — closing the container-only coverage gap.

## Verification

- New test `write_acl on a resource does not lock the owner out (#575)` passes with the fix and **fails without it** (verified by reverting `accessTo` to `'./'`).
- Full suite green (`npm test`, exit 0).