### PR TITLE
did:nostr: align DID-document @context to cid/v1 per updated CG spec

### DIFF
--- a/src/idp/well-known-did-nostr.js
+++ b/src/idp/well-known-did-nostr.js
@@ -450,18 +450,24 @@ export async function resolveDidNostrLocally(pubkeyHex) {
 /**
  * Build a CID-shaped DID document for a Nostr pubkey + account pair.
  *
- * Uses the spec example's vocabulary (Multikey + publicKeyMultibase)
- * for max interop with our own resolver and the W3C VC track. The
- * Multikey value is computed deterministically from the pubkey via
- * the f-form recipe (multibase `f` + multicodec `e701` + parity byte
- * `02` + 32-byte xonly hex) — the same shape the doctor's B.2 emits.
+ * Uses the vocabulary of the updated did:nostr CG spec example
+ * (https://nostrcg.github.io/did-nostr/): Multikey + publicKeyMultibase,
+ * @context [https://www.w3.org/ns/cid/v1, https://w3id.org/nostr/context]
+ * (cid/v1 is the Controlled Identifiers v1.0 context that defines the
+ * Multikey term). The Multikey value is computed deterministically from
+ * the pubkey via the f-form recipe (multibase `f` + multicodec `e701` +
+ * parity byte `02` + 32-byte xonly hex) — the same shape the doctor's B.2
+ * emits. Verification-relationship refs are kept ABSOLUTE
+ * (`did:nostr:<hex>#key1`); the spec example shows the relative `#key1`
+ * form, but DID Core permits both and this indexer deliberately
+ * absolutizes auth refs (see the profile-absolutization path below).
  */
 function buildDidDocument({ pubkey, webId }) {
   const did = `did:nostr:${pubkey.toLowerCase()}`;
   const multikey = `f` + `e701` + `02` + pubkey.toLowerCase();
   const vmId = `${did}#key1`;
   return {
-    '@context': ['https://w3id.org/did', 'https://w3id.org/nostr/context'],
+    '@context': ['https://www.w3.org/ns/cid/v1', 'https://w3id.org/nostr/context'],
     'id': did,
     'type': 'DIDNostr',
     'alsoKnownAs': [webId],

--- a/test/well-known-did-nostr.test.js
+++ b/test/well-known-did-nostr.test.js
@@ -129,7 +129,7 @@ describe('GET /.well-known/did/nostr/:pubkey (#407)', () => {
     assert.ok(r.headers.get('last-modified'));
 
     const doc = await r.json();
-    assert.deepStrictEqual(doc['@context'], ['https://w3id.org/did', 'https://w3id.org/nostr/context']);
+    assert.deepStrictEqual(doc['@context'], ['https://www.w3.org/ns/cid/v1', 'https://w3id.org/nostr/context']);
     assert.strictEqual(doc.id, `did:nostr:${alicePk}`);
     assert.strictEqual(doc.type, 'DIDNostr');
     assert.ok(Array.isArray(doc.alsoKnownAs));


### PR DESCRIPTION
## Summary

Aligns `buildDidDocument`'s `@context[0]` to the **Controlled Identifiers v1.0** context (`https://www.w3.org/ns/cid/v1`), matching the current did:nostr Community Group spec example shapes (https://nostrcg.github.io/did-nostr/). The generic `w3id.org/did` context does not define the `Multikey` term used by the document; `cid/v1` is what the CG spec references.

## Change

- `src/idp/well-known-did-nostr.js`: `buildDidDocument` `@context` → `['https://www.w3.org/ns/cid/v1', 'https://w3id.org/nostr/context']`.

Absolute auth/assertion references are kept as-is (JSS's existing deliberate choice). This is a one-line context reconciliation to keep JSS byte-aligned with the emerging standard.

## Context

Part of a cross-ecosystem did:nostr convergence (JSS + a Rust port + agent tooling) tracking the CG spec. Filed as a first-class-collaborator alignment; happy to adjust to maintainer preference.

🤖 Generated by Claude Code
