### PR TITLE
fix(cli): forward plugins and appPaths from config to createServer (#592)

### DIFF
--- a/bin/jss.js
+++ b/bin/jss.js
@@ -268,6 +268,11 @@ program
         mongoUrl: config.mongoUrl,
         mongoDatabase: config.mongoDatabase,
         mcp: config.mcp,
+        // Config-file-only keys (no CLI flags yet): omitting them here made
+        // the documented `-c config.json` route silently boot without the
+        // declared apps (#592).
+        appPaths: config.appPaths,
+        plugins: config.plugins,
       });
 
       await server.listen({ port: config.port, host: config.host });


### PR DESCRIPTION
Fixes #592.

## Problem

`loadConfig` merges `plugins` (#589) and `appPaths` (#582) from `config.json`, but the explicit allowlist `bin/jss.js` passes to `createServer(...)` omitted both — so the documented config-file route ("declare the apps in config and the server imports, mounts, and tears them down itself") silently booted a server with **no plugins and no error**. That's exactly the silent-missing-app failure mode `src/plugins.js` was designed to refuse, and it left the #206 loader programmatic-only: nothing driving JSS through the CLI (including servejss) could mount plugins.

## Fix

Forward both keys in the `createServer` call. `createServer` already defaults each when undefined (`Array.isArray` guards), so configs that don't set them are unaffected.

## Verified (A/B)

Config with `{"plugins": [{"module": "…/hello-plugin.mjs", "prefix": "/hello-app", "config": {"greeting": "hi"}}]}`:

- **with fix**: `jss start -c config.json` mounts the app; `GET /hello-app/hello` → `{"from":"plugin","config":{"greeting":"hi"}}`
- **without fix** (current main): same config boots cleanly, route → 404

Also confirmed a bad module path now fails the boot loudly through the CLI, as the loader intends.

Follow-ups from #592 (repeatable `--plugin` CLI flag; `pluginDataDir` override so servejss-served trees don't collect `.plugins/`) left for separate PRs.