### PR TITLE
feat(plugins): api.reservePath — claim protocol-pinned paths (#602)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -442,15 +442,16 @@ api.reservePath('/xrpc');            // fixed root — WAC-exempt subtree, all m
 api.reservePath('/:user/did.json');  // pinned document — exact shape, read-only
 ```
 
-Literal reservations behave like an entry prefix (the plugin owns the
-subtree). Parameterized reservations (`:name` matches one segment) exempt
-only the exact path shape and only safe methods by default
-(`GET`/`HEAD`/`OPTIONS`; override with `{ methods: [...] }`) — they exist
-for pinned documents inside the pod's WAC-governed namespace, where a
-subtree or write exemption would be a WAC bypass. Claims are cross-plugin:
-a second plugin reserving the same path fails the boot naming both
-claimants. Registering routes on the reserved paths remains the plugin's
-job via `api.fastify`.
+Both kinds are **read-only by default** (`GET`/`HEAD`/`OPTIONS`; widen with
+`{ methods: [...] }`) — a reserved path is WAC-exempt and the LDP write
+wildcards sit beneath it, so exempting a write method the plugin hasn't
+implemented would let that write fall through to storage unauthenticated.
+Literal reservations claim their whole subtree; parameterized reservations
+(`:name` matches one segment) match only the exact path shape, since they
+exist for pinned documents inside the pod's WAC-governed namespace. Claims
+are cross-plugin: a second plugin reserving the same path fails the boot
+naming both claimants. Registering routes on the reserved paths remains the
+plugin's job via `api.fastify`.
 
 To mount an **existing node-style app** — a `(req, res)` handler, a reverse
 proxy, or a framework adapter — use `api.mountApp(handler, { prefix })`:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -434,6 +434,24 @@ routed through the same upgrade path as the built-in realtime features, so
 plugins never attach their own `'upgrade'` listener. Return
 `{ deactivate }` to run teardown (state saves, timers) on server close.
 
+A plugin whose protocol **pins absolute paths** outside its prefix can
+claim them with `api.reservePath(path)`:
+
+```js
+api.reservePath('/xrpc');            // fixed root — WAC-exempt subtree, all methods
+api.reservePath('/:user/did.json');  // pinned document — exact shape, read-only
+```
+
+Literal reservations behave like an entry prefix (the plugin owns the
+subtree). Parameterized reservations (`:name` matches one segment) exempt
+only the exact path shape and only safe methods by default
+(`GET`/`HEAD`/`OPTIONS`; override with `{ methods: [...] }`) — they exist
+for pinned documents inside the pod's WAC-governed namespace, where a
+subtree or write exemption would be a WAC bypass. Claims are cross-plugin:
+a second plugin reserving the same path fails the boot naming both
+claimants. Registering routes on the reserved paths remains the plugin's
+job via `api.fastify`.
+
 To mount an **existing node-style app** — a `(req, res)` handler, a reverse
 proxy, or a framework adapter — use `api.mountApp(handler, { prefix })`:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -438,8 +438,8 @@ A plugin whose protocol **pins absolute paths** outside its prefix can
 claim them with `api.reservePath(path)`:
 
 ```js
-api.reservePath('/xrpc');            // fixed root — WAC-exempt subtree, all methods
-api.reservePath('/:user/did.json');  // pinned document — exact shape, read-only
+api.reservePath('/xrpc', { methods: ['GET', 'POST'] });  // fixed root — subtree, methods opted in
+api.reservePath('/:user/did.json');                      // pinned document — exact shape, read-only
 ```
 
 Both kinds are **read-only by default** (`GET`/`HEAD`/`OPTIONS`; widen with

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -94,6 +94,15 @@ export function compilePathPattern(p) {
   return new RegExp(`^${pattern}(?:\\?.*)?$`);
 }
 
+/**
+ * A literal reservation ('/xrpc') claims its whole subtree — the path
+ * itself, everything under it, and either plus a query string.
+ */
+export function compileSubtreePattern(p) {
+  const esc = p.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`^${esc}(?:/.*)?(?:\\?.*)?$`);
+}
+
 // Collision key: two reservations conflict when they exempt the same
 // URLs, so parameter NAMES don't matter — '/:user/did.json' and
 // '/:acct/did.json' are the same claim. Each segment is tagged by TYPE
@@ -240,20 +249,20 @@ export async function loadPlugins(fastify, entries, ctx) {
           throw new Error(`plugin ${id}: path '${key}' is already reserved by plugin '${holder}'`);
         }
         reservations.set(claim, id);
-        if (isParamPath(key)) {
-          // Parameterized reservations are method-gated, read-only by
-          // default: the URL shape lives inside a WAC-governed pod
-          // namespace, and exempting PUT/DELETE would hand the LDP
-          // fallthrough an unauthenticated write path.
-          const methods = new Set((opts.methods ?? ['GET', 'HEAD', 'OPTIONS'])
-            .map((m) => String(m).toUpperCase()));
-          ctx.appPathPatterns?.push({ re: compilePathPattern(key), methods });
-        } else if (!ctx.appPaths.includes(key)) {
-          // Literal reservations behave exactly like an entry prefix:
-          // the plugin owns the subtree, every method.
-          ctx.appPaths.push(key);
-        }
-        log.info(`plugin ${id} reserved ${key}`);
+        // Read-only by default for BOTH lanes: a reserved path is
+        // WAC-exempt, and the LDP write wildcards (PUT/POST/PATCH/DELETE
+        // '/*') sit underneath it. Exempting a write method the plugin
+        // has NOT implemented would let that write fall through to the
+        // LDP handlers as an unauthenticated storage write — the exact
+        // trap core installs 405 blocks for under /.well-known/*. Widen
+        // with { methods } when the protocol genuinely needs writes.
+        const methods = new Set((opts.methods ?? ['GET', 'HEAD', 'OPTIONS'])
+          .map((m) => String(m).toUpperCase()));
+        // Parameterized shapes match exactly (they live inside a
+        // WAC-governed pod namespace); literals claim their subtree.
+        const re = isParamPath(key) ? compilePathPattern(key) : compileSubtreePattern(key);
+        ctx.appPathPatterns?.push({ re, methods });
+        log.info(`plugin ${id} reserved ${key} [${[...methods].join(', ')}]`);
       },
       serverInfo() {
         const o = ctx.origin ?? {};

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -70,14 +70,31 @@ export function makePluginLog(base) {
  * documents inside otherwise WAC-governed namespaces (did:web), where
  * exempting a whole subtree would be a WAC bypass.
  */
+// Only a segment that is ENTIRELY ':name' is a parameter. '/:user.json'
+// is literal (its own segment mixes a param sigil with literal text) —
+// treating it as a wildcard would exempt a far broader set of URLs than
+// the ':name'-per-segment contract promises.
+const PARAM_SEGMENT = /^:[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function isParamPath(p) {
+  return p.split('/').some((seg) => PARAM_SEGMENT.test(seg));
+}
+
 export function compilePathPattern(p) {
   const pattern = p
     .split('/')
-    .map((seg) => (seg.startsWith(':') && seg.length > 1
+    .map((seg) => (PARAM_SEGMENT.test(seg)
       ? '[^/]+'
       : seg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
     .join('/');
   return new RegExp(`^${pattern}(?:\\?.*)?$`);
+}
+
+// Collision key: two reservations conflict when they exempt the same
+// URLs, so parameter NAMES don't matter — '/:user/did.json' and
+// '/:acct/did.json' are the same claim. Canonicalize param segments.
+export function reservationKey(p) {
+  return p.split('/').map((seg) => (PARAM_SEGMENT.test(seg) ? ':' : seg)).join('/');
 }
 
 /** Same normalization appPaths applies: no trailing slash, must be '/x…'. */
@@ -202,12 +219,16 @@ export async function loadPlugins(fastify, entries, ctx) {
         if (!key.startsWith('/') || key.length < 2) {
           throw new Error(`plugin ${id}: reservePath needs an absolute path, got ${JSON.stringify(p)}`);
         }
-        const holder = reservations.get(key);
+        // Track by the shape, not the raw string: '/:user/did.json' and
+        // '/:acct/did.json' exempt the same URLs, so they're the same
+        // claim and must collide loudly like two literal reservations.
+        const claim = reservationKey(key);
+        const holder = reservations.get(claim);
         if (holder && holder !== id) {
           throw new Error(`plugin ${id}: path '${key}' is already reserved by plugin '${holder}'`);
         }
-        reservations.set(key, id);
-        if (key.includes('/:')) {
+        reservations.set(claim, id);
+        if (isParamPath(key)) {
           // Parameterized reservations are method-gated, read-only by
           // default: the URL shape lives inside a WAC-governed pod
           // namespace, and exempting PUT/DELETE would hand the LDP

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -83,8 +83,12 @@ export function isParamPath(p) {
 export function compilePathPattern(p) {
   const pattern = p
     .split('/')
+    // Exclude '?' as well as '/': a param must be a single PATH segment,
+    // so it must not swallow the query delimiter — otherwise a query
+    // containing '/' (e.g. /alice?x=a/b) would fail to match a shape the
+    // path part satisfies, making matching depend on query contents.
     .map((seg) => (PARAM_SEGMENT.test(seg)
-      ? '[^/]+'
+      ? '[^/?]+'
       : seg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
     .join('/');
   return new RegExp(`^${pattern}(?:\\?.*)?$`);

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -223,12 +223,13 @@ export async function loadPlugins(fastify, entries, ctx) {
       // logic in server.js.
       // Reserve a path the protocol pins outside the plugin's prefix
       // (#602): fixed roots like /xrpc or /_matrix (literal — exempts the
-      // subtree, like a prefix), or parameterized documents like
-      // /:user/did.json (exact-shape match only; see compilePathPattern).
-      // The claim is deliberate and cross-plugin: a second plugin
-      // reserving the same path fails the boot naming both claimants,
-      // instead of one silently losing. Registering the routes is still
-      // the plugin's job via api.fastify.
+      // subtree), or parameterized documents like /:user/did.json
+      // (exact-shape match only; see compilePathPattern). Both are
+      // read-only by default and method-gated ({ methods } to widen) —
+      // see the exemption note below. The claim is deliberate and
+      // cross-plugin: a second plugin reserving the same path fails the
+      // boot naming both claimants, instead of one silently losing.
+      // Registering the routes is still the plugin's job via api.fastify.
       reservePath(p, opts = {}) {
         // Validate AFTER normalization: '//' or '/ ' normalize to '',
         // and an empty string in appPaths would match every URL in the

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -233,7 +233,10 @@ export async function loadPlugins(fastify, entries, ctx) {
         // claim and must collide loudly like two literal reservations.
         const claim = reservationKey(key);
         const holder = reservations.get(claim);
-        if (holder && holder !== id) {
+        if (holder === id) {
+          return; // idempotent re-claim — the matcher is already installed
+        }
+        if (holder) {
           throw new Error(`plugin ${id}: path '${key}' is already reserved by plugin '${holder}'`);
         }
         reservations.set(claim, id);

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -231,6 +231,13 @@ export async function loadPlugins(fastify, entries, ctx) {
       // boot naming both claimants, instead of one silently losing.
       // Registering the routes is still the plugin's job via api.fastify.
       reservePath(p, opts = {}) {
+        // Tolerate a null/garbage opts (treat as omitted), but a provided
+        // non-array `methods` is a caller mistake worth a targeted error
+        // rather than an opaque TypeError from .map deep in activate.
+        const options = opts && typeof opts === 'object' ? opts : {};
+        if (options.methods !== undefined && !Array.isArray(options.methods)) {
+          throw new Error(`plugin ${id}: reservePath { methods } must be an array, got ${JSON.stringify(options.methods)}`);
+        }
         // Validate AFTER normalization: '//' or '/ ' normalize to '',
         // and an empty string in appPaths would match every URL in the
         // WAC hook — a one-call total WAC bypass.
@@ -265,7 +272,7 @@ export async function loadPlugins(fastify, entries, ctx) {
         // LDP handlers as an unauthenticated storage write — the exact
         // trap core installs 405 blocks for under /.well-known/*. Widen
         // with { methods } when the protocol genuinely needs writes.
-        const methods = new Set((opts.methods ?? ['GET', 'HEAD', 'OPTIONS'])
+        const methods = new Set((options.methods ?? ['GET', 'HEAD', 'OPTIONS'])
           .map((m) => String(m).toUpperCase()));
         // Parameterized shapes match exactly (they live inside a
         // WAC-governed pod namespace); literals claim their subtree.

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -92,9 +92,14 @@ export function compilePathPattern(p) {
 
 // Collision key: two reservations conflict when they exempt the same
 // URLs, so parameter NAMES don't matter — '/:user/did.json' and
-// '/:acct/did.json' are the same claim. Canonicalize param segments.
+// '/:acct/did.json' are the same claim. Each segment is tagged by TYPE
+// (param vs literal) so a canonicalized param can't alias a literal
+// segment that happens to be the placeholder text (e.g. a literal '/:/…').
+// '\x00' never occurs in a real path, so it's a safe framing prefix.
 export function reservationKey(p) {
-  return p.split('/').map((seg) => (PARAM_SEGMENT.test(seg) ? ':' : seg)).join('/');
+  return p.split('/')
+    .map((seg) => (PARAM_SEGMENT.test(seg) ? '\x00P' : `\x00L${seg}`))
+    .join('/');
 }
 
 /** Same normalization appPaths applies: no trailing slash, must be '/x…'. */

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -195,10 +195,13 @@ export async function loadPlugins(fastify, entries, ctx) {
       // instead of one silently losing. Registering the routes is still
       // the plugin's job via api.fastify.
       reservePath(p, opts = {}) {
-        if (typeof p !== 'string' || !p.startsWith('/') || p.length < 2) {
+        // Validate AFTER normalization: '//' or '/ ' normalize to '',
+        // and an empty string in appPaths would match every URL in the
+        // WAC hook — a one-call total WAC bypass.
+        const key = typeof p === 'string' ? p.trim().replace(/\/+$/, '') : '';
+        if (!key.startsWith('/') || key.length < 2) {
           throw new Error(`plugin ${id}: reservePath needs an absolute path, got ${JSON.stringify(p)}`);
         }
-        const key = p.trim().replace(/\/+$/, '');
         const holder = reservations.get(key);
         if (holder && holder !== id) {
           throw new Error(`plugin ${id}: path '${key}' is already reserved by plugin '${holder}'`);

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -238,6 +238,14 @@ export async function loadPlugins(fastify, entries, ctx) {
         if (!key.startsWith('/') || key.length < 2) {
           throw new Error(`plugin ${id}: reservePath needs an absolute path, got ${JSON.stringify(p)}`);
         }
+        // A reservation is a pathname, not a URL: '?'/'#' don't belong.
+        // A query in the string would be escaped into the matcher (tying
+        // the exemption to that exact query), and fragments never reach
+        // request.url — both silently produce a reservation that matches
+        // nothing real.
+        if (key.includes('?') || key.includes('#')) {
+          throw new Error(`plugin ${id}: reservePath must be a pathname without '?' or '#', got ${JSON.stringify(p)}`);
+        }
         // Track by the shape, not the raw string: '/:user/did.json' and
         // '/:acct/did.json' exempt the same URLs, so they're the same
         // claim and must collide loudly like two literal reservations.

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -20,6 +20,7 @@
  *   api.auth.getAgent(req)   -> agent id string | null   (#584)
  *   api.storage.pluginDir()  -> private server-side data dir for this plugin
  *   api.serverInfo()         -> { baseUrl, protocol, host, port, listening } (#601)
+ *   api.reservePath(path)    claim + WAC-exempt a protocol-pinned path (#602)
  *   api.ws.route(path, (socket, request) => {})          (#588)
  *
  * The entry's `prefix` is added to appPaths automatically (#582), so the
@@ -59,6 +60,24 @@ export function makePluginLog(base) {
     if (typeof fn === 'function') fn.call(base, ...args);
   };
   return { log: call('info'), info: call('info'), warn: call('warn'), error: call('error'), debug: call('debug') };
+}
+
+/**
+ * Compile a parameterized reservation like '/:user/did.json' (#602) to a
+ * matcher. ':name' segments match one path segment; everything else is
+ * literal. Parameterized reservations match the exact path shape (plus an
+ * optional query string) — NOT a subtree — because they exist for pinned
+ * documents inside otherwise WAC-governed namespaces (did:web), where
+ * exempting a whole subtree would be a WAC bypass.
+ */
+export function compilePathPattern(p) {
+  const pattern = p
+    .split('/')
+    .map((seg) => (seg.startsWith(':') && seg.length > 1
+      ? '[^/]+'
+      : seg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+    .join('/');
+  return new RegExp(`^${pattern}(?:\\?.*)?$`);
 }
 
 /** Same normalization appPaths applies: no trailing slash, must be '/x…'. */
@@ -103,6 +122,11 @@ export function pluginId(spec) {
 export async function loadPlugins(fastify, entries, ctx) {
   const log = makePluginLog(ctx.log);
   const seenIds = new Set();
+  // reservePath claims (#602), shared across all entries of this load so
+  // two plugins reserving the same pinned path fail the boot with both
+  // names — loud beats the silent-loser outcome witnessed with webfinger
+  // vs remotestorage.
+  const reservations = new Map();
   for (const entry of entries) {
     const spec = typeof entry === 'string' ? { module: entry } : entry;
     if (!spec || typeof spec.module !== 'string' || !spec.module) {
@@ -162,6 +186,39 @@ export async function loadPlugins(fastify, entries, ctx) {
       // An explicit idpIssuer is the deployment's canonical public origin
       // and wins over the host:port derivation, mirroring the pod-seeding
       // logic in server.js.
+      // Reserve a path the protocol pins outside the plugin's prefix
+      // (#602): fixed roots like /xrpc or /_matrix (literal — exempts the
+      // subtree, like a prefix), or parameterized documents like
+      // /:user/did.json (exact-shape match only; see compilePathPattern).
+      // The claim is deliberate and cross-plugin: a second plugin
+      // reserving the same path fails the boot naming both claimants,
+      // instead of one silently losing. Registering the routes is still
+      // the plugin's job via api.fastify.
+      reservePath(p, opts = {}) {
+        if (typeof p !== 'string' || !p.startsWith('/') || p.length < 2) {
+          throw new Error(`plugin ${id}: reservePath needs an absolute path, got ${JSON.stringify(p)}`);
+        }
+        const key = p.trim().replace(/\/+$/, '');
+        const holder = reservations.get(key);
+        if (holder && holder !== id) {
+          throw new Error(`plugin ${id}: path '${key}' is already reserved by plugin '${holder}'`);
+        }
+        reservations.set(key, id);
+        if (key.includes('/:')) {
+          // Parameterized reservations are method-gated, read-only by
+          // default: the URL shape lives inside a WAC-governed pod
+          // namespace, and exempting PUT/DELETE would hand the LDP
+          // fallthrough an unauthenticated write path.
+          const methods = new Set((opts.methods ?? ['GET', 'HEAD', 'OPTIONS'])
+            .map((m) => String(m).toUpperCase()));
+          ctx.appPathPatterns?.push({ re: compilePathPattern(key), methods });
+        } else if (!ctx.appPaths.includes(key)) {
+          // Literal reservations behave exactly like an entry prefix:
+          // the plugin owns the subtree, every method.
+          ctx.appPaths.push(key);
+        }
+        log.info(`plugin ${id} reserved ${key}`);
+      },
       serverInfo() {
         const o = ctx.origin ?? {};
         const addr = fastify.server?.listening ? fastify.server.address() : null;

--- a/src/server.js
+++ b/src/server.js
@@ -764,7 +764,7 @@ export function createServer(options = {}) {
         (terminalEnabled && (request.url === '/.terminal' || request.url.startsWith('/.terminal?'))) ||
         (tunnelEnabled && (request.url === tunnelPath || request.url.startsWith(tunnelPath + '?') || request.url.startsWith('/tunnel/'))) ||
         appPaths.some(p => request.url === p || request.url.startsWith(p + '/') || request.url.startsWith(p + '?')) ||
-        appPathPatterns.some(m => m.re.test(request.url) && m.methods.has(request.method)) ||
+        appPathPatterns.some(m => m.methods.has(request.method) && m.re.test(request.url)) ||
         mashlibPaths.some(p => request.url === p || request.url.startsWith(p + '.'))) {
       return;
     }

--- a/src/server.js
+++ b/src/server.js
@@ -124,6 +124,10 @@ export function createServer(options = {}) {
   // appPaths. The WAC hook reads the array per request, so pushes made
   // during plugin activation are honored.
   const pluginEntries = Array.isArray(options.plugins) ? options.plugins : [];
+  // Parameterized reservations from api.reservePath (#602): compiled
+  // matchers for path shapes like /:user/did.json that literal appPaths
+  // prefixes cannot express. Same per-request read as appPaths.
+  const appPathPatterns = [];
   // ActivityPub federation is OFF by default
   const activitypubEnabled = options.activitypub ?? false;
   const apUsername = options.apUsername ?? 'me';
@@ -426,6 +430,7 @@ export function createServer(options = {}) {
       const { loadPlugins } = await import('./plugins.js');
       await loadPlugins(instance, pluginEntries, {
         appPaths,
+        appPathPatterns,
         root: options.root || process.env.DATA_ROOT || './data',
         log: fastify.log,
         // api.serverInfo inputs (#601). ?? keeps an explicit port 0 —
@@ -759,6 +764,7 @@ export function createServer(options = {}) {
         (terminalEnabled && (request.url === '/.terminal' || request.url.startsWith('/.terminal?'))) ||
         (tunnelEnabled && (request.url === tunnelPath || request.url.startsWith(tunnelPath + '?') || request.url.startsWith('/tunnel/'))) ||
         appPaths.some(p => request.url === p || request.url.startsWith(p + '/') || request.url.startsWith(p + '?')) ||
+        appPathPatterns.some(m => m.re.test(request.url) && m.methods.has(request.method)) ||
         mashlibPaths.some(p => request.url === p || request.url.startsWith(p + '.'))) {
       return;
     }

--- a/test/plugin-reservepath.test.js
+++ b/test/plugin-reservepath.test.js
@@ -133,6 +133,15 @@ describe('api.reservePath (#602)', () => {
     assert.deepStrictEqual(await res.json(), { id: 'did:web:alice' });
   });
 
+  it('a query string (even one containing /) does not affect shape matching', async () => {
+    await start(MAIN());
+    // The param class must not swallow '?': a '/' inside the query would
+    // otherwise break the match for a path shape that is satisfied.
+    const res = await fetch(`${baseUrl}/alice/did.json?redirect=/a/b`);
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(await res.json(), { id: 'did:web:alice' });
+  });
+
   it('parameterized reservations are read-only: writes to the shape stay WAC-guarded', async () => {
     await start(MAIN());
     // Without the method gate this PUT would skip WAC and fall through

--- a/test/plugin-reservepath.test.js
+++ b/test/plugin-reservepath.test.js
@@ -58,6 +58,21 @@ export async function activate(api) {
 }
 `;
 
+// A literal ':' segment ('/:/x') must NOT collide with the param shape
+// '/:user/x' — different claim types that only alias if the collision
+// key throws away the param-vs-literal distinction.
+const LITERAL_COLON_FIXTURE = `
+export async function activate(api) {
+  api.reservePath('/:user/x');    // param
+  api.fastify.get('/:user/x', async () => ({ param: true }));
+}
+`;
+const COLON_SEG_FIXTURE = `
+export async function activate(api) {
+  api.reservePath('/:/x');        // literal ':' segment
+}
+`;
+
 let server;
 let baseUrl;
 let originalDataRoot;
@@ -85,6 +100,8 @@ describe('api.reservePath (#602)', () => {
     await fs.writeFile(path.join(FIXTURE_DIR, 'rival.js'), RIVAL_FIXTURE);
     await fs.writeFile(path.join(FIXTURE_DIR, 'shape-rival.js'), SHAPE_RIVAL_FIXTURE);
     await fs.writeFile(path.join(FIXTURE_DIR, 'literalish.js'), LITERALISH_FIXTURE);
+    await fs.writeFile(path.join(FIXTURE_DIR, 'literal-colon.js'), LITERAL_COLON_FIXTURE);
+    await fs.writeFile(path.join(FIXTURE_DIR, 'colon-seg.js'), COLON_SEG_FIXTURE);
   });
   after(async () => {
     await fs.remove(FIXTURE_DIR);
@@ -169,6 +186,18 @@ describe('api.reservePath (#602)', () => {
     // the segment had been treated as a param).
     const sibling = await fetch(`${baseUrl}/alice.json`, { method: 'PUT', body: 'x' });
     assert.ok([401, 403].includes(sibling.status), `expected WAC rejection, got ${sibling.status}`);
+  });
+
+  it("a literal ':' segment does not alias a param shape (no false collision)", async () => {
+    await start([
+      { id: 'litcolon', module: path.join(FIXTURE_DIR, 'literal-colon.js'), prefix: '/lc' },
+      { id: 'colonseg', module: path.join(FIXTURE_DIR, 'colon-seg.js'), prefix: '/cs' },
+    ]);
+    // Booted cleanly — the two reservations are distinct claims. The
+    // param route still serves its shape.
+    const res = await fetch(`${baseUrl}/alice/x`);
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(await res.json(), { param: true });
   });
 
   it('two plugins claiming the same path fail the boot naming both', async () => {

--- a/test/plugin-reservepath.test.js
+++ b/test/plugin-reservepath.test.js
@@ -1,0 +1,117 @@
+/**
+ * api.reservePath (#602) — a plugin can claim protocol-pinned paths
+ * outside its prefix: fixed roots (/xrpc) as WAC-exempt subtrees, and
+ * parameterized documents (/:user/did.json) as exact-shape, read-only
+ * exemptions inside the pod's WAC-governed namespace. Claims are
+ * cross-plugin: a second claimant fails the boot naming both.
+ */
+
+import { describe, it, before, after, afterEach } from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+
+const TEST_DATA_DIR = './test-data-reservepath';
+const FIXTURE_DIR = path.join(os.tmpdir(), 'jss-reservepath-fixture');
+
+// An xrpc-style shim (fixed root) plus a did:web-style pinned document.
+const FIXTURE = `
+export async function activate(api) {
+  api.reservePath('/xrpc');
+  api.fastify.get('/xrpc/ping', async () => ({ pong: true }));
+
+  api.reservePath('/:user/did.json');
+  api.fastify.get('/:user/did.json', async (req) => ({ id: 'did:web:' + req.params.user }));
+}
+`;
+
+// A rival that claims the same fixed root — must fail the boot.
+const RIVAL_FIXTURE = `
+export async function activate(api) {
+  api.reservePath('/xrpc');
+}
+`;
+
+let server;
+let baseUrl;
+let originalDataRoot;
+
+async function start(plugins) {
+  await fs.emptyDir(TEST_DATA_DIR);
+  const { createServer } = await import('../src/server.js');
+  server = createServer({
+    logger: false,
+    forceCloseConnections: true,
+    root: TEST_DATA_DIR,
+    plugins,
+  });
+  await server.listen({ port: 0, host: '127.0.0.1' });
+  baseUrl = `http://127.0.0.1:${server.server.address().port}`;
+}
+
+const MAIN = () => [{ id: 'shim', module: path.join(FIXTURE_DIR, 'plugin.js'), prefix: '/shim' }];
+
+describe('api.reservePath (#602)', () => {
+  before(async () => {
+    originalDataRoot = process.env.DATA_ROOT;
+    await fs.emptyDir(FIXTURE_DIR);
+    await fs.writeFile(path.join(FIXTURE_DIR, 'plugin.js'), FIXTURE);
+    await fs.writeFile(path.join(FIXTURE_DIR, 'rival.js'), RIVAL_FIXTURE);
+  });
+  after(async () => {
+    await fs.remove(FIXTURE_DIR);
+    if (originalDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = originalDataRoot;
+  });
+  afterEach(async () => {
+    if (server) { await server.close(); server = null; }
+    await fs.remove(TEST_DATA_DIR);
+  });
+
+  it('a reserved fixed root serves unauthenticated', async () => {
+    await start(MAIN());
+    const res = await fetch(`${baseUrl}/xrpc/ping`);
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(await res.json(), { pong: true });
+  });
+
+  it('WAC still guards unreserved paths', async () => {
+    await start(MAIN());
+    const res = await fetch(`${baseUrl}/somepod/private/x`, { method: 'PUT', body: 'data' });
+    assert.ok([401, 403].includes(res.status), `expected WAC rejection, got ${res.status}`);
+  });
+
+  it('a parameterized reservation serves the pinned document shape', async () => {
+    await start(MAIN());
+    const res = await fetch(`${baseUrl}/alice/did.json`);
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(await res.json(), { id: 'did:web:alice' });
+  });
+
+  it('parameterized reservations are read-only: writes to the shape stay WAC-guarded', async () => {
+    await start(MAIN());
+    // Without the method gate this PUT would skip WAC and fall through
+    // to the LDP wildcard as an unauthenticated pod write.
+    const res = await fetch(`${baseUrl}/alice/did.json`, { method: 'PUT', body: '{}' });
+    assert.ok([401, 403].includes(res.status), `expected WAC rejection, got ${res.status}`);
+  });
+
+  it('two plugins claiming the same path fail the boot naming both', async () => {
+    await fs.emptyDir(TEST_DATA_DIR);
+    const { createServer } = await import('../src/server.js');
+    server = createServer({
+      logger: false,
+      forceCloseConnections: true,
+      root: TEST_DATA_DIR,
+      plugins: [
+        ...MAIN(),
+        { id: 'rival', module: path.join(FIXTURE_DIR, 'rival.js'), prefix: '/rival' },
+      ],
+    });
+    await assert.rejects(
+      server.listen({ port: 0, host: '127.0.0.1' }),
+      /rival: path '\/xrpc' is already reserved by plugin 'shim'/,
+    );
+  });
+});

--- a/test/plugin-reservepath.test.js
+++ b/test/plugin-reservepath.test.js
@@ -33,6 +33,14 @@ export async function activate(api) {
 }
 `;
 
+// '//' normalizes to '' — pushed to appPaths it would match every URL
+// and disable WAC wholesale. Must be rejected at activate.
+const SLASHES_FIXTURE = `
+export async function activate(api) {
+  api.reservePath('//');
+}
+`;
+
 let server;
 let baseUrl;
 let originalDataRoot;
@@ -95,6 +103,24 @@ describe('api.reservePath (#602)', () => {
     // to the LDP wildcard as an unauthenticated pod write.
     const res = await fetch(`${baseUrl}/alice/did.json`, { method: 'PUT', body: '{}' });
     assert.ok([401, 403].includes(res.status), `expected WAC rejection, got ${res.status}`);
+  });
+
+  it("reservePath('//') fails the boot instead of exempting every URL from WAC", async () => {
+    await fs.writeFile(path.join(FIXTURE_DIR, 'slashes.js'), SLASHES_FIXTURE);
+    await fs.emptyDir(TEST_DATA_DIR);
+    const { createServer } = await import('../src/server.js');
+    server = createServer({
+      logger: false,
+      forceCloseConnections: true,
+      root: TEST_DATA_DIR,
+      plugins: [
+        { id: 'slashes', module: path.join(FIXTURE_DIR, 'slashes.js'), prefix: '/slashes' },
+      ],
+    });
+    await assert.rejects(
+      server.listen({ port: 0, host: '127.0.0.1' }),
+      /reservePath needs an absolute path/,
+    );
   });
 
   it('two plugins claiming the same path fail the boot naming both', async () => {

--- a/test/plugin-reservepath.test.js
+++ b/test/plugin-reservepath.test.js
@@ -36,6 +36,14 @@ export async function activate(api) {
 }
 `;
 
+// A shim that legitimately needs writes widens the method set explicitly.
+const WRITE_SHIM_FIXTURE = `
+export async function activate(api) {
+  api.reservePath('/api', { methods: ['GET', 'POST'] });
+  api.fastify.post('/api/echo', async (req) => ({ ok: true }));
+}
+`;
+
 // '//' normalizes to '' — pushed to appPaths it would match every URL
 // and disable WAC wholesale. Must be rejected at activate.
 const SLASHES_FIXTURE = `
@@ -101,6 +109,7 @@ describe('api.reservePath (#602)', () => {
     await fs.emptyDir(FIXTURE_DIR);
     await fs.writeFile(path.join(FIXTURE_DIR, 'plugin.js'), FIXTURE);
     await fs.writeFile(path.join(FIXTURE_DIR, 'rival.js'), RIVAL_FIXTURE);
+    await fs.writeFile(path.join(FIXTURE_DIR, 'write-shim.js'), WRITE_SHIM_FIXTURE);
     await fs.writeFile(path.join(FIXTURE_DIR, 'shape-rival.js'), SHAPE_RIVAL_FIXTURE);
     await fs.writeFile(path.join(FIXTURE_DIR, 'literalish.js'), LITERALISH_FIXTURE);
     await fs.writeFile(path.join(FIXTURE_DIR, 'literal-colon.js'), LITERAL_COLON_FIXTURE);
@@ -121,6 +130,25 @@ describe('api.reservePath (#602)', () => {
     const res = await fetch(`${baseUrl}/xrpc/ping`);
     assert.strictEqual(res.status, 200);
     assert.deepStrictEqual(await res.json(), { pong: true });
+  });
+
+  it('a write under a read-only literal reservation stays WAC-guarded', async () => {
+    await start(MAIN());
+    // /xrpc is reserved read-only; the plugin only handles GET /xrpc/ping.
+    // Without the method gate this PUT would skip WAC and fall through to
+    // the LDP write wildcard as an unauthenticated storage write.
+    const res = await fetch(`${baseUrl}/xrpc/ping`, { method: 'PUT', body: 'x' });
+    assert.ok([401, 403].includes(res.status), `expected WAC rejection, got ${res.status}`);
+  });
+
+  it('a shim can widen its reservation to serve writes', async () => {
+    await start([{ id: 'writer', module: path.join(FIXTURE_DIR, 'write-shim.js'), prefix: '/w' }]);
+    // POST is in the widened set and handled → serves unauthenticated.
+    const ok = await fetch(`${baseUrl}/api/echo`, { method: 'POST', body: '{}' });
+    assert.strictEqual(ok.status, 200);
+    // PUT is NOT in the set → still WAC-guarded, no LDP fall-through.
+    const put = await fetch(`${baseUrl}/api/echo`, { method: 'PUT', body: '{}' });
+    assert.ok([401, 403].includes(put.status), `expected WAC rejection, got ${put.status}`);
   });
 
   it('WAC still guards unreserved paths', async () => {

--- a/test/plugin-reservepath.test.js
+++ b/test/plugin-reservepath.test.js
@@ -22,6 +22,9 @@ export async function activate(api) {
   api.fastify.get('/xrpc/ping', async () => ({ pong: true }));
 
   api.reservePath('/:user/did.json');
+  // A second identical claim by the same plugin is an idempotent no-op —
+  // no duplicate matcher, no self-collision error.
+  api.reservePath('/:user/did.json');
   api.fastify.get('/:user/did.json', async (req) => ({ id: 'did:web:' + req.params.user }));
 }
 `;

--- a/test/plugin-reservepath.test.js
+++ b/test/plugin-reservepath.test.js
@@ -52,6 +52,13 @@ export async function activate(api) {
 }
 `;
 
+// A reservation carrying a query is malformed — must be rejected.
+const QUERY_FIXTURE = `
+export async function activate(api) {
+  api.reservePath('/xrpc?x=1');
+}
+`;
+
 // Same shape as the main plugin's /:user/did.json, different param name —
 // exempts the same URLs, so it's the same claim and must collide.
 const SHAPE_RIVAL_FIXTURE = `
@@ -110,6 +117,7 @@ describe('api.reservePath (#602)', () => {
     await fs.writeFile(path.join(FIXTURE_DIR, 'plugin.js'), FIXTURE);
     await fs.writeFile(path.join(FIXTURE_DIR, 'rival.js'), RIVAL_FIXTURE);
     await fs.writeFile(path.join(FIXTURE_DIR, 'write-shim.js'), WRITE_SHIM_FIXTURE);
+    await fs.writeFile(path.join(FIXTURE_DIR, 'query.js'), QUERY_FIXTURE);
     await fs.writeFile(path.join(FIXTURE_DIR, 'shape-rival.js'), SHAPE_RIVAL_FIXTURE);
     await fs.writeFile(path.join(FIXTURE_DIR, 'literalish.js'), LITERALISH_FIXTURE);
     await fs.writeFile(path.join(FIXTURE_DIR, 'literal-colon.js'), LITERAL_COLON_FIXTURE);
@@ -238,6 +246,23 @@ describe('api.reservePath (#602)', () => {
     const res = await fetch(`${baseUrl}/alice/x`);
     assert.strictEqual(res.status, 200);
     assert.deepStrictEqual(await res.json(), { param: true });
+  });
+
+  it("reservePath with a query ('/xrpc?x=1') fails the boot as malformed", async () => {
+    await fs.emptyDir(TEST_DATA_DIR);
+    const { createServer } = await import('../src/server.js');
+    server = createServer({
+      logger: false,
+      forceCloseConnections: true,
+      root: TEST_DATA_DIR,
+      plugins: [
+        { id: 'q', module: path.join(FIXTURE_DIR, 'query.js'), prefix: '/q' },
+      ],
+    });
+    await assert.rejects(
+      server.listen({ port: 0, host: '127.0.0.1' }),
+      /must be a pathname without '\?' or '#'/,
+    );
   });
 
   it('two plugins claiming the same path fail the boot naming both', async () => {

--- a/test/plugin-reservepath.test.js
+++ b/test/plugin-reservepath.test.js
@@ -59,6 +59,20 @@ export async function activate(api) {
 }
 `;
 
+// A non-array { methods } is a caller mistake — targeted error, not a
+// TypeError. And null opts is tolerated as "omitted" (read-only default).
+const BAD_METHODS_FIXTURE = `
+export async function activate(api) {
+  api.reservePath('/x', { methods: 'GET' });
+}
+`;
+const NULL_OPTS_FIXTURE = `
+export async function activate(api) {
+  api.reservePath('/nullopts', null);
+  api.fastify.get('/nullopts/ping', async () => ({ ok: true }));
+}
+`;
+
 // Same shape as the main plugin's /:user/did.json, different param name —
 // exempts the same URLs, so it's the same claim and must collide.
 const SHAPE_RIVAL_FIXTURE = `
@@ -118,6 +132,8 @@ describe('api.reservePath (#602)', () => {
     await fs.writeFile(path.join(FIXTURE_DIR, 'rival.js'), RIVAL_FIXTURE);
     await fs.writeFile(path.join(FIXTURE_DIR, 'write-shim.js'), WRITE_SHIM_FIXTURE);
     await fs.writeFile(path.join(FIXTURE_DIR, 'query.js'), QUERY_FIXTURE);
+    await fs.writeFile(path.join(FIXTURE_DIR, 'bad-methods.js'), BAD_METHODS_FIXTURE);
+    await fs.writeFile(path.join(FIXTURE_DIR, 'null-opts.js'), NULL_OPTS_FIXTURE);
     await fs.writeFile(path.join(FIXTURE_DIR, 'shape-rival.js'), SHAPE_RIVAL_FIXTURE);
     await fs.writeFile(path.join(FIXTURE_DIR, 'literalish.js'), LITERALISH_FIXTURE);
     await fs.writeFile(path.join(FIXTURE_DIR, 'literal-colon.js'), LITERAL_COLON_FIXTURE);
@@ -263,6 +279,31 @@ describe('api.reservePath (#602)', () => {
       server.listen({ port: 0, host: '127.0.0.1' }),
       /must be a pathname without '\?' or '#'/,
     );
+  });
+
+  it('a non-array { methods } fails the boot with a targeted error', async () => {
+    await fs.emptyDir(TEST_DATA_DIR);
+    const { createServer } = await import('../src/server.js');
+    server = createServer({
+      logger: false,
+      forceCloseConnections: true,
+      root: TEST_DATA_DIR,
+      plugins: [
+        { id: 'bm', module: path.join(FIXTURE_DIR, 'bad-methods.js'), prefix: '/bm' },
+      ],
+    });
+    await assert.rejects(
+      server.listen({ port: 0, host: '127.0.0.1' }),
+      /reservePath \{ methods \} must be an array/,
+    );
+  });
+
+  it('null opts is tolerated as omitted (read-only default)', async () => {
+    await start([{ id: 'no', module: path.join(FIXTURE_DIR, 'null-opts.js'), prefix: '/no' }]);
+    const ok = await fetch(`${baseUrl}/nullopts/ping`);
+    assert.strictEqual(ok.status, 200);
+    const put = await fetch(`${baseUrl}/nullopts/ping`, { method: 'PUT', body: 'x' });
+    assert.ok([401, 403].includes(put.status), `expected WAC rejection, got ${put.status}`);
   });
 
   it('two plugins claiming the same path fail the boot naming both', async () => {

--- a/test/plugin-reservepath.test.js
+++ b/test/plugin-reservepath.test.js
@@ -41,6 +41,23 @@ export async function activate(api) {
 }
 `;
 
+// Same shape as the main plugin's /:user/did.json, different param name —
+// exempts the same URLs, so it's the same claim and must collide.
+const SHAPE_RIVAL_FIXTURE = `
+export async function activate(api) {
+  api.reservePath('/:acct/did.json');
+}
+`;
+
+// '/:user.json' is NOT a param segment (mixes sigil with literal text);
+// only the exact literal path is exempt, a sibling like /alice.json isn't.
+const LITERALISH_FIXTURE = `
+export async function activate(api) {
+  api.reservePath('/:user.json');
+  api.fastify.get('/:user.json', async () => ({ literal: true }));
+}
+`;
+
 let server;
 let baseUrl;
 let originalDataRoot;
@@ -66,6 +83,8 @@ describe('api.reservePath (#602)', () => {
     await fs.emptyDir(FIXTURE_DIR);
     await fs.writeFile(path.join(FIXTURE_DIR, 'plugin.js'), FIXTURE);
     await fs.writeFile(path.join(FIXTURE_DIR, 'rival.js'), RIVAL_FIXTURE);
+    await fs.writeFile(path.join(FIXTURE_DIR, 'shape-rival.js'), SHAPE_RIVAL_FIXTURE);
+    await fs.writeFile(path.join(FIXTURE_DIR, 'literalish.js'), LITERALISH_FIXTURE);
   });
   after(async () => {
     await fs.remove(FIXTURE_DIR);
@@ -121,6 +140,35 @@ describe('api.reservePath (#602)', () => {
       server.listen({ port: 0, host: '127.0.0.1' }),
       /reservePath needs an absolute path/,
     );
+  });
+
+  it('same shape with a different param name is the same claim and collides', async () => {
+    await fs.emptyDir(TEST_DATA_DIR);
+    const { createServer } = await import('../src/server.js');
+    server = createServer({
+      logger: false,
+      forceCloseConnections: true,
+      root: TEST_DATA_DIR,
+      plugins: [
+        ...MAIN(),
+        { id: 'shaperival', module: path.join(FIXTURE_DIR, 'shape-rival.js'), prefix: '/sr' },
+      ],
+    });
+    await assert.rejects(
+      server.listen({ port: 0, host: '127.0.0.1' }),
+      /already reserved by plugin 'shim'/,
+    );
+  });
+
+  it("'/:user.json' is literal, not a wildcard — a sibling stays WAC-guarded", async () => {
+    await start([{ id: 'lit', module: path.join(FIXTURE_DIR, 'literalish.js'), prefix: '/lit' }]);
+    // The exact reserved path serves...
+    const exact = await fetch(`${baseUrl}/:user.json`);
+    assert.strictEqual(exact.status, 200);
+    // ...but a real single-segment sibling is NOT exempted (would be, if
+    // the segment had been treated as a param).
+    const sibling = await fetch(`${baseUrl}/alice.json`, { method: 'PUT', body: 'x' });
+    assert.ok([401, 403].includes(sibling.status), `expected WAC rejection, got ${sibling.status}`);
   });
 
   it('two plugins claiming the same path fail the boot naming both', async () => {


### PR DESCRIPTION
Closes #602 (the reservation primitive; the shared-document/JRD registry half is split to #606). Second of the four seams from the [33-plugin exercise](https://github.com/JavaScriptSolidServer/plugins/blob/gh-pages/REPORT.md) — the most-hit one (7+ consumers).

## What

```js
export async function activate(api) {
  api.reservePath('/xrpc');            // bluesky shim: fixed root, WAC-exempt subtree
  api.fastify.get('/xrpc/ping', ...);

  api.reservePath('/:user/did.json');  // did:web: pinned document, exact shape, read-only
  api.fastify.get('/:user/did.json', ...);
}
```

## Design

- **Literal reservations** generalize `appPaths` from operator config to plugin declaration — the plugin owns the subtree, all methods, same semantics as its entry prefix.
- **Parameterized reservations** (`:name` = one path segment) compile to exact-shape matchers and are **method-gated, read-only by default** (`GET/HEAD/OPTIONS`, `{ methods }` to widen). This is the security-load-bearing part: the shapes live *inside* the pod's WAC-governed namespace, and without the gate a `PUT /alice/did.json` would skip WAC and fall through to the LDP wildcard as an **unauthenticated pod write**. A test pins this.
- **Claims are cross-plugin and loud**: a second plugin reserving the same path fails the boot naming both claimants — replacing the load-order lottery (boot error one way, silent link loss the other) witnessed with webfinger vs remotestorage.
- Route registration stays the plugin's job via `api.fastify`; reservePath only handles exemption + claim bookkeeping.

## Tests

5 in `test/plugin-reservepath.test.js`: fixed root serves unauthenticated, WAC intact elsewhere, pinned document serves, **write to the reserved shape stays WAC-guarded**, duplicate claim fails boot naming both. Full suite **1040/1040**. Documented in `docs/configuration.md` + loader header.